### PR TITLE
chore: Set up ruff linter locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 🚧 The DIBBs eCR Refiner is under construction 🚧
 
+## Running the linter
+
+The linter can be run two different ways: either manually via the `ruff` command or automatically when you go to create a new commit, which is powered by `pre-commit`.
+
+### Manually
+
+1. Activate the `refiner` virtual environment (steps listed [here](./api/refiner/README.md#running-from-python-source-code))
+2. Install dev dependencies with `pip install -r dev-requirements.txt`
+3. Run any `ruff` command you'd like (see [here](https://docs.astral.sh/ruff/linter/))
+
+### Pre-commit
+
+1. Install [pre-commit](https://pre-commit.com/)
+2. Run `pre-commit install`
+3. Run `pre-commit run --all-files` to check that the tool is working properly
+
+The `pre-commit` hook will automatically fix any linter issues and will also format the code.
+
 ## Running the eCR Refiner with Docker
 
 The project can be run from the top-level directory with `docker compose up`.

--- a/api/refiner/dev-requirements.txt
+++ b/api/refiner/dev-requirements.txt
@@ -2,3 +2,4 @@ httpx
 pytest
 pytest-asyncio
 testcontainers[compose]>=3.7.1
+ruff==0.11.2

--- a/api/trigger-code-reference/dev-requirements.txt
+++ b/api/trigger-code-reference/dev-requirements.txt
@@ -6,3 +6,4 @@ testcontainers[compose]
 tqdm
 fhir.resources
 sqlmodel
+ruff==0.11.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.ruff]
+exclude = [".git", ".pytest_cache", "__pycache__", "docs", "examples/"]
+line-length = 88
+indent-width = 4
+show-fixes = true
+target-version = "py313"
+
+[tool.ruff.lint]
+select = [
+  "F",    # Pyflakes
+  "E4",   # Pydocstyle errors
+  "E7",
+  "E9",
+  "W",    # Pydocstyle warnings
+  "D102", # Pydocstyle undocumented-public-method
+  "D103", # Pydocstyle undocumented-public-function
+  "D104", # Pydocstyle undocumented-public-package
+  "D105", # Pydocstyle undocumented-magic-method
+  "D106", # Pydocstyle undocumented-public-nested-class
+  "I",    # isort
+  "UP",   # pyupgrade
+]
+
+[tool.ruff.lint.per-file-ignores]
+"**/tests/*" = ["D", "S"]
+"**/__init__.py" = ["D"]


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

This PR adds the `ruff` linter to the project and provides some basic configuration.

## 🔗 Related Issue

<!--
add the issue number in both places:
Fixes #3
- #3
-->

Fixes #
- #7 

## ✅ Acceptance Criteria

<!--
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
-->

- [x] ruff has been locally installed as a dev dependency and can be run on-demand
- [x] ruff has been set up with a basic configuration
- [x] ruff will automatically run when a dev makes a commit* (as long as `pre-commit` was installed and the `install` command was run in the project)
- [x] docs have been updated

## 🧪 How to test

Please refer to the [`Running the linter` section](https://github.com/CDCgov/dibbs-ecr-refiner/pull/9/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5) in the updated README for setup & testing instructions. Feel free to let me know if these can be improved!

## ℹ️ Additional Information

Maybe not the biggest issue since I imagine we'll often be using `ruff` via the `pre-commit` git hook, it would be a lot nicer if we didn't have to install `ruff` in both the `refiner` and the `trigger-code-reference`. However, these are currently two independent projects 😕

Is there a better way to go about this with how things are currently set up?