### PR TITLE
chore: docker compose hot reloads on file changes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,12 @@
 services:
   message-refiner-service:
     platform: linux/amd64
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
     build:
       context: ./api/refiner
+    working_dir: /app
+    volumes:
+      - ./api/refiner:/app
     depends_on:
       - trigger-code-reference-service
     ports:
@@ -13,8 +17,12 @@ services:
       - TRIGGER_CODE_REFERENCE_URL=http://trigger-code-reference-service:8080
   trigger-code-reference-service:
     platform: linux/amd64
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
     build:
       context: ./api/trigger-code-reference
+    working_dir: /app
+    volumes:
+      - ./api/trigger-code-reference:/app
     ports:
       - "8081:8080"
     logging:


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR:

1. Makes it so that editing files in `/api/refiner` and `/api/trigger-code-reference` will cause the respective service to reload
2. Makes it so that new files can be added or removed locally and the changes will be reflected in the running container(s)

## 🔗 Related Issue

Fixes #10 

## ✅ Acceptance Criteria

- [x] When an application file is modified locally, the container will update its files and the FastAPI server will reload
- [x] Restarting containers and/or rebuilding images is not needed to see code changes reflected

## 🧪 How to test

A quick way to understand how this works:

1. From the project root, run `docker compose up`
4. In `api/refiner/app/main.py` try changing the `health_check()`'s return to `{"status": "TEST"}`
5. Save the file and you should see logs that let you know the server has reloaded
6. Hit the API's health check endpoint (`/`) and you should see your modified response

## ℹ️ Additional Information

What has been done so far seems to do everything I'd want it to with the way the repo is currently structured. Is there anything else that'd be helpful to change right now?