### PR TITLE
chore: fix CODEOWNERS file syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-@lina-roth @jakewheeler @robertmitchellv 
+# These owners will be the default owners for everything in the repo.
+* @lina-roth @jakewheeler @robertmitchellv


### PR DESCRIPTION
This should solve the issue with folks not getting auto-assigned for PR reviews.