### PR TITLE
fix: add the icd-9 url back to the list of expected values

### DIFF
--- a/api/refiner/app/utils.py
+++ b/api/refiner/app/utils.py
@@ -43,10 +43,11 @@ def create_clinical_services_dict(
     """
     Transform the original Trigger Code Reference API response to have keys as systems
     and values as lists of codes, while ensuring the systems are recognized and using their
-    shorthand names so that we can both dynamicall construct XPaths and post-filter matches
+    shorthand names so that we can both dynamically construct XPaths and post-filter matches
     to system name varients.
     """
     system_dict = {
+        "http://hl7.org/fhir/sid/icd-9-cm": "icd9",
         "http://hl7.org/fhir/sid/icd-10-cm": "icd10",
         "http://snomed.info/sct": "snomed",
         "http://loinc.org": "loinc",


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

<!--
What changes are being proposed?
-->
The icd-9 url at some point was removed from the list of expected systems, which was causing an error since those codes were still in the sqlite db. For now, this will keep things working as expected as we think about what the core needs are of a TCR explicitly as it relates to refiner and begin the work of folding the two services into one.

## 🔗 Related Issue

<!--
add the issue number in both places:
Fixes #14 
- #14 
-->

Fixes #14 
- #14 

## ✅ Acceptance Criteria

<!--
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
-->

## 🧪 How to test

<!--
1. Install dependencies: `npm install`
2. Run tests: `npm test`
3. Start application: `npm start` 
4. Navigate to http://localhost:3000
5. Enter sample data in the user profile form and verify validation works

or

1. Activate virtual environment: `source venv/bin/activate`
2. Install requirements: `pip install -r requirements.txt`
3. Run tests: `pytest tests/`
4. Verify the API endpoint at `/api/v1/data` returns properly formatted JSON
-->

1. build clean images using `docker compose build --no-cache` at the project root
2. start the services with `docker compose up -d`
3. using the API or rest tool of your choice and a test eICR for the body, `POST` this url: `http://localhost:8080/ecr?conditions_to_include=240589008`
4. if there are any observations connected to this it should be preserved.

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
