### PR TITLE
chore: Run pipeline on merge to main, allow individual jobs to run via manual trigger

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,12 @@ on:
         default: 3.13
         required: true
         type: number
+  workflow_dispatch:
+    inputs:
+      python_runner_version:
+        default: 3.13
+        required: true
+        type: number
 
 jobs:
   run-linter:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - "**"
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,12 @@ on:
         default: 3.13
         required: true
         type: number
+  workflow_dispatch:
+    inputs:
+      python_runner_version:
+        default: 3.13
+        required: true
+        type: number
 
 defaults:
   run:


### PR DESCRIPTION
# 🔀 PULL REQUEST


## 💡 Summary

This is just a small update to the GitHub Actions to give us a little more flexibility:

- `pipeline.yml` will automatically run when we merge to `main`
- `lint.yml` and `tests.yml` will be able to run on-demand and independently of the pipeline 