### PR TITLE
chore: pipeline should run checks when PR is in merge queue

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
+    types:
+      - checks_requested
   push:
     branches:
       - main


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates `pipeline.yml` to be triggered when a PR enters the merge queue. It seems this [`merge_group` block is necessary to include](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#status-checks-with-github-actions-and-a-merge-queue) or the jobs will not be kicked off.

Here are the repository settings I've updated as a part of this work:
<img width="853" alt="image" src="https://github.com/user-attachments/assets/4a4aa22f-70d5-4c46-a4f6-62564850bad9" />

## 🔗 Related Issue

Fixes #6 

## ✅ Acceptance Criteria

- [ ] PR successfully runs checks when entering merge queue and merge succeeds

## 🧪 How to test

We should be able to try merging this PR. If the jobs aren't kicked off, we can back it out of the queue. Maybe we can also test it with `act`?