### PR TITLE
docs: Update `refiner-config.json` with `"value_code"` for RR information

### DIFF
--- a/refiner/assets/refiner_config.json
+++ b/refiner/assets/refiner_config.json
@@ -60,7 +60,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.22.1:2015-08-01": {
     "type": "section",
-    "display_name": "Encounters",
+    "display_name": "Encounters Section",
     "spec": "eICR",
     "version": ["1.1", "3.1"],
     "required": true,
@@ -77,7 +77,7 @@
   },
   "1.3.6.1.4.1.19376.1.5.3.1.3.4": {
     "type": "section",
-    "display_name": "History of Present Illness",
+    "display_name": "History of Present Illness Section",
     "spec": "eICR",
     "version": ["1.1", "3.1"],
     "required": true,
@@ -88,7 +88,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.2.1:2015-08-01": {
     "type": "section",
-    "display_name": "Immunizations",
+    "display_name": "Immunizations Section",
     "spec": "eICR",
     "version": ["1.1", "3.1"],
     "required": false,
@@ -105,7 +105,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.38:2014-06-09": {
     "type": "section",
-    "display_name": "Medications Administered",
+    "display_name": "Medications Administered Section",
     "spec": "eICR",
     "version": ["1.1", "3.1"],
     "required": true,
@@ -119,7 +119,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.10:2014-06-09": {
     "type": "section",
-    "display_name": "Plan of Treatment",
+    "display_name": "Plan of Treatment Section",
     "spec": "eICR",
     "version": ["1.1", "3.1"],
     "required": true,
@@ -139,7 +139,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.5.1:2015-08-01": {
     "type": "section",
-    "display_name": "Problems",
+    "display_name": "Problem Section",
     "spec": "eICR",
     "version": ["1.1", "3.1"],
     "required": true,
@@ -153,7 +153,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.12": {
     "type": "section",
-    "display_name": "Reason for Visit",
+    "display_name": "Reason for Visit Section",
     "spec": "eICR",
     "version": ["1.1", "3.1"],
     "required": true,
@@ -164,7 +164,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.3.1:2015-08-01": {
     "type": "section",
-    "display_name": "Results",
+    "display_name": "Results Section",
     "spec": "eICR",
     "version": ["1.1", "3.1"],
     "required": true,
@@ -181,7 +181,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.17:2015-08-01": {
     "type": "section",
-    "display_name": "Social History",
+    "display_name": "Social History Section",
     "spec": "eICR",
     "version": ["1.1", "3.1"],
     "required": true,
@@ -203,7 +203,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.44:2015-08-01": {
     "type": "section",
-    "display_name": "Admission Medications",
+    "display_name": "Admission Medications Section",
     "spec": "eICR",
     "version": ["3.1"],
     "required": false,
@@ -239,7 +239,7 @@
   },
   "2.16.840.1.113883.10.20.15.2.2.4:2021-01-01": {
     "type": "section",
-    "display_name": "Emergency Outbreak Information",
+    "display_name": "Emergency Outbreak Information Section",
     "spec": "eICR",
     "version": ["3.1"],
     "required": false,
@@ -250,7 +250,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.1.1:2014-06-09": {
     "type": "section",
-    "display_name": "Medications",
+    "display_name": "Medications Section",
     "spec": "eICR",
     "version": ["3.1"],
     "required": false,
@@ -275,7 +275,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.80:2018-04-01": {
     "type": "section",
-    "display_name": "Pregnancy",
+    "display_name": "Pregnancy Section",
     "spec": "eICR",
     "version": ["3.1"],
     "required": false,
@@ -286,7 +286,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.7.1:2014-06-09": {
     "type": "section",
-    "display_name": "Procedures",
+    "display_name": "Procedures Section",
     "spec": "eICR",
     "version": ["3.1"],
     "required": false,
@@ -305,7 +305,7 @@
   },
   "2.16.840.1.113883.10.20.15.2.2.5:2021-01-01": {
     "type": "section",
-    "display_name": "Reportability Response Information",
+    "display_name": "Reportability Response Information Section",
     "spec": "eICR",
     "version": ["3.1"],
     "required": false,
@@ -316,7 +316,7 @@
   },
   "1.3.6.1.4.1.19376.1.5.3.1.3.18": {
     "type": "section",
-    "display_name": "Review of Systems",
+    "display_name": "Review of Systems Section",
     "spec": "eICR",
     "version": ["3.1"],
     "required": false,
@@ -327,7 +327,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.17:2020-09-01": {
     "type": "section",
-    "display_name": "Occupational Data for Health Template Requirements",
+    "display_name": "Occupational Data for Health Template Requirements Section",
     "spec": "eICR",
     "version": ["3.1"],
     "required": false,
@@ -338,7 +338,7 @@
   },
   "2.16.840.1.113883.10.20.22.2.4.1:2015-08-01": {
     "type": "section",
-    "display_name": "Vital Signs",
+    "display_name": "Vital Signs Section",
     "spec": "eICR",
     "version": ["3.1"],
     "required": false,
@@ -349,7 +349,7 @@
   },
   "2.16.840.1.113883.10.20.15.2.3.5:2016-12-01": {
     "type": "observation",
-    "display_name": "Initial Case Report Manual Initiation Reason",
+    "display_name": "Initial Case Report Manual Initiation Reason Observation",
     "spec": "eICR",
     "version": ["1.1"],
     "required": false,
@@ -569,7 +569,7 @@
   },
   "2.16.840.1.113883.10.20.15.2.2.3:2017-04-01": {
     "type": "section",
-    "display_name": "Electronic Initial Case Report",
+    "display_name": "Electronic Initial Case Report Section",
     "spec": "RR",
     "version": ["1.1"],
     "required": true,
@@ -586,7 +586,7 @@
   },
   "2.16.840.1.113883.10.20.15.2.2.1:2017-04-01": {
     "type": "section",
-    "display_name": "Reportability Response Subject",
+    "display_name": "Reportability Response Subject Section",
     "spec": "RR",
     "version": ["1.1"],
     "required": false,
@@ -599,7 +599,7 @@
   },
   "2.16.840.1.113883.10.20.15.2.2.2:2017-04-01": {
     "type": "section",
-    "display_name": "Reportability Response Summary",
+    "display_name": "Reportability Response Summary Section",
     "spec": "RR",
     "version": ["1.1"],
     "required": false,
@@ -616,7 +616,7 @@
   },
   "2.16.840.1.113883.10.20.15.2.3.34:2017-04-01": {
     "type": "organizer",
-    "display_name": "Reportability Response Coded Information",
+    "display_name": "Reportability Response Coded Information Organizer",
     "spec": "RR",
     "version": ["1.1"],
     "required": true,

--- a/refiner/assets/refiner_config.json
+++ b/refiner/assets/refiner_config.json
@@ -7,6 +7,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "55751-2",
+    "value_code": null,
     "contains": {
       "1.1": [
         "2.16.840.1.113883.10.20.22.2.22.1:2015-08-01",
@@ -29,6 +30,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "55751-2",
+    "value_code": null,
     "contains": {
       "3.1": [
         "1.3.6.1.4.1.19376.1.5.3.1.3.18",
@@ -64,6 +66,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "46240-8",
+    "value_code": null,
     "contains": {
       "1.1": [
         "2.16.840.1.113883.10.20.15.2.3.5:2016-12-01",
@@ -80,6 +83,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "10164-2",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.22.2.2.1:2015-08-01": {
@@ -90,6 +94,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "11369-6",
+    "value_code": null,
     "contains": {
       "1.1": null,
       "3.1": [
@@ -106,6 +111,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "29549-3",
+    "value_code": null,
     "contains": {
       "1.1": null,
       "3.1": ["2.16.840.1.113883.10.20.15.2.3.36:2019-04-01"]
@@ -119,6 +125,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "18776-5",
+    "value_code": null,
     "contains": {
       "1.1": ["2.16.840.1.113883.10.20.15.2.3.4:2016-12-01"],
       "3.1": [
@@ -138,6 +145,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "11450-4",
+    "value_code": null,
     "contains": {
       "1.1": null,
       "3.1": ["2.16.840.1.113883.10.20.15.2.3.3:2021-01-01"]
@@ -151,6 +159,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "29299-5",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.22.2.3.1:2015-08-01": {
@@ -161,6 +170,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "30954-2",
+    "value_code": null,
     "contains": {
       "1.1": ["2.16.840.1.113883.10.20.15.2.3.2:2016-12-01"],
       "3.1": [
@@ -177,6 +187,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "29762-2",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.22.2.43:2015-08-01": {
@@ -187,6 +198,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "46241-6",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.22.2.44:2015-08-01": {
@@ -197,6 +209,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "42346-7",
+    "value_code": null,
     "contains": {
       "1.1": null,
       "3.1": ["2.16.840.1.113883.10.20.15.2.3.36:2019-04-01"]
@@ -210,6 +223,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "10154-3",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.22.2.24:2015-08-01": {
@@ -220,6 +234,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "11535-2",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.2.4:2021-01-01": {
@@ -230,6 +245,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "83910-0",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.22.2.1.1:2014-06-09": {
@@ -240,6 +256,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "10160-0",
+    "value_code": null,
     "contains": {
       "1.1": null,
       "3.1": ["2.16.840.1.113883.10.20.15.2.3.36:2019-04-01"]
@@ -253,6 +270,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "11348-0",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.22.2.80:2018-04-01": {
@@ -263,6 +281,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "90767-5",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.22.2.7.1:2014-06-09": {
@@ -273,6 +292,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "47519-4",
+    "value_code": null,
     "contains": {
       "1.1": null,
       "3.1": [
@@ -291,6 +311,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "88085-6",
+    "value_code": null,
     "contains": null
   },
   "1.3.6.1.4.1.19376.1.5.3.1.3.18": {
@@ -301,6 +322,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "10187-3",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.22.2.17:2020-09-01": {
@@ -311,6 +333,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "29762-2",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.22.2.4.1:2015-08-01": {
@@ -321,6 +344,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "8716-3",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.5:2016-12-01": {
@@ -341,6 +365,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.3:2016-12-01": {
@@ -351,6 +376,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.3:2021-01-01": {
@@ -361,6 +387,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.4:2016-12-01": {
@@ -371,6 +398,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.4:2019-04-01": {
@@ -381,6 +409,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.2:2016-12-01": {
@@ -391,6 +420,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.2:2019-04-01": {
@@ -401,6 +431,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": {
       "1.1": null,
       "3.1": ["2.16.840.1.113883.10.20.22.4.419:2018-09-01"]
@@ -414,6 +445,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.36:2019-04-01": {
@@ -424,6 +456,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.41:2021-01-01": {
@@ -434,6 +467,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.43:2021-01-01": {
@@ -444,6 +478,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.42:2021-01-01": {
@@ -454,6 +489,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.45:2021-01-01": {
@@ -464,6 +500,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.46:2021-01-01": {
@@ -474,6 +511,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.44:2021-01-01": {
@@ -484,6 +522,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.35:2022-05-01": {
@@ -494,6 +533,7 @@
     "required": false,
     "code_type": "flexible",
     "code": null,
+    "value_code": null,
     "contains": {
       "1.1": null,
       "3.1": ["2.16.840.1.113883.10.20.15.2.3.2:2019-04-01"]
@@ -507,6 +547,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "92236-9",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.1.2:2017-04-01": {
@@ -517,7 +558,14 @@
     "required": true,
     "code_type": "atomic",
     "code": "88085-6",
-    "contains": null
+    "value_code": null,
+    "contains": {
+      "1.1": [
+        "2.16.840.1.113883.10.20.15.2.2.1:2017-04-01",
+        "2.16.840.1.113883.10.20.15.2.2.2:2017-04-01",
+        "2.16.840.1.113883.10.20.15.2.2.3:2017-04-01"
+      ]
+    }
   },
   "2.16.840.1.113883.10.20.15.2.2.3:2017-04-01": {
     "type": "section",
@@ -527,6 +575,7 @@
     "required": true,
     "code_type": "atomic",
     "code": "88082-3",
+    "value_code": null,
     "contains": {
       "1.1": [
         "2.16.840.1.113883.10.20.15.2.3.9:2017-04-01:2017-04-01",
@@ -543,6 +592,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "88084-9",
+    "value_code": null,
     "contains": {
       "1.1": ["2.16.840.1.113883.10.20.15.2.3.7:2017-04-01"]
     }
@@ -555,11 +605,41 @@
     "required": false,
     "code_type": "atomic",
     "code": "55112-7",
+    "value_code": null,
     "contains": {
       "1.1": [
         "2.16.840.1.113883.10.20.15.2.3.34:2017-04-01",
         "2.16.840.1.113883.10.20.15.2.3.8:2017-04-01",
         "2.16.840.1.113883.10.20.15.2.3.30:2017-04-01"
+      ]
+    }
+  },
+  "2.16.840.1.113883.10.20.15.2.3.34:2017-04-01": {
+    "type": "organizer",
+    "display_name": "Reportability Response Coded Information",
+    "spec": "RR",
+    "version": ["1.1"],
+    "required": true,
+    "code_type": "atomic",
+    "code": "RR11",
+    "value_code": null,
+    "contains": {
+      "1.1": ["2.16.840.1.113883.10.20.15.2.3.12:2017-04-01"]
+    }
+  },
+  "2.16.840.1.113883.10.20.15.2.3.12:2017-04-01": {
+    "type": "observation",
+    "display_name": "Relevant Reportable Condition Observation",
+    "spec": "RR",
+    "version": ["1.1"],
+    "required": true,
+    "code_type": "atomic",
+    "code": "64572001",
+    "value_code": null,
+    "contains": {
+      "1.1": [
+        "2.16.840.1.113883.10.20.15.2.3.13:2017-04-01",
+        "2.16.840.1.113883.10.20.15.2.3.20:2017-04-01"
       ]
     }
   },
@@ -571,6 +651,12 @@
     "required": true,
     "code_type": "atomic",
     "code": "RR1",
+    "value_code": {
+      "RRVS1": "Reportable",
+      "RRVS2": "May be reportable",
+      "RRVS3": "Not reportable",
+      "RRVS4": "No rule met"
+    },
     "contains": {
       "1.1": [
         "2.16.840.1.113883.10.20.15.2.3.26:2017-04-01",
@@ -586,6 +672,16 @@
     "required": false,
     "code_type": "atomic",
     "code": "RR2",
+    "value_code": {
+      "RRVS23": "eICR was not processed due to an error of: fatal problem with the eICR that was received",
+      "RRVS24": "eICR was not processed due to an error of: an ongoing server problem",
+      "RRVS25": "eICR was not processed due to an error of: significant content or format issues",
+      "RRVS26": "eICR was processed with the warning of: invalid eICR identifier",
+      "RRVS27": "eICR was processed with the warning of: required data not found",
+      "RRVS28": "eICR was processed with the warning of: content or format issues",
+      "RRVS30": "eICR was processed with the warning of: RCTC code deprecated by coding system",
+      "RRVS29": "eICR was processed with the warning of: outdated RCTC version"
+    },
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.27:2017-04-01": {
@@ -596,6 +692,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "RR3",
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.29:2017-04-01": {
@@ -611,6 +708,7 @@
       "RRVS22": "eICR was not processed - error",
       "RRVS21": "eICR was processed - with a severe warning"
     },
+    "value_code": null,
     "contains": {
       "1.1": [
         "2.16.840.1.113883.10.20.15.2.3.21:2017-04-01",
@@ -626,6 +724,16 @@
     "required": false,
     "code_type": "atomic",
     "code": "RR6",
+    "value_code": {
+      "RRVS23": "eICR was not processed due to an error of: fatal problem with the eICR that was received",
+      "RRVS24": "eICR was not processed due to an error of: an ongoing server problem",
+      "RRVS25": "eICR was not processed due to an error of: significant content or format issues",
+      "RRVS26": "eICR was processed with the warning of: invalid eICR identifier",
+      "RRVS27": "eICR was processed with the warning of: required data not found",
+      "RRVS28": "eICR was processed with the warning of: content or format issues",
+      "RRVS30": "eICR was processed with the warning of: RCTC code deprecated by coding system",
+      "RRVS29": "eICR was processed with the warning of: outdated RCTC version"
+    },
     "contains": {
       "1.1": ["2.16.840.1.113883.10.20.15.2.3.32:2017-04-01"]
     }
@@ -642,6 +750,7 @@
       "RRVS32": "Inactive RCTC code detail",
       "RRVS33": "Expected RCTC Version Detail"
     },
+    "value_code": null,
     "contains": null
   },
   "2.16.840.1.113883.10.20.15.2.3.33:2017-04-01": {
@@ -652,6 +761,7 @@
     "required": false,
     "code_type": "atomic",
     "code": "RR10",
+    "value_code": null,
     "contains": null
   }
 }


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

<!--
What changes are being proposed?
-->

There are patterns in the RR that differ slightly from the eICR in connection to coded elements that have associated values that needed to be represented by the `refiner_config.json` file.

For example, in the RR where we would look for the `RR1` code, it will also have a `<value>` tag that will describe the reportability status with codes like:

- `RRVS2`: May be reporable
- `RRVS3`: Not reportable
- `RRVS1`: Reportable
- `RRVS4`: No rule met

These have been filled out. Additionally the `"contains"` list for some of the RR entries have better linking for representing how these templates are connected.

## 🔗 Related Issue

<!--
add the issue number in both places:
Fixes #3
- #3
-->

Fixes #57
- #57 

## ✅ Acceptance Criteria

<!--
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
-->

## 🧪 How to test

<!--
1. Install dependencies: `npm install`
2. Run tests: `npm test`
3. Start application: `npm start` 
4. Navigate to http://localhost:3000
5. Enter sample data in the user profile form and verify validation works

or

1. Activate virtual environment: `source venv/bin/activate`
2. Install requirements: `pip install -r requirements.txt`
3. Run tests: `pytest tests/`
4. Verify the API endpoint at `/api/v1/data` returns properly formatted JSON
-->

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
