### PR TITLE
[feat] add method to parse RR and extract reportable condition snomed code

### DIFF
--- a/refiner/app/main.py
+++ b/refiner/app/main.py
@@ -2,15 +2,7 @@ import os
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import (
-    APIRouter,
-    File,
-    Query,
-    Request,
-    Response,
-    UploadFile,
-    status,
-)
+from fastapi import APIRouter, File, Query, Request, Response, UploadFile, status
 from fastapi.openapi.utils import get_openapi
 from fastapi.staticfiles import StaticFiles
 
@@ -18,7 +10,7 @@ from app.base_service import BaseService
 from app.db import get_value_sets_for_condition
 from app.models import RefineECRResponse
 from app.refine import refine, validate_message, validate_sections_to_include
-from app.rr_parser import parse_xml, get_reportable_conditions
+from app.rr_parser import get_reportable_conditions, parse_xml
 from app.utils import create_clinical_services_dict, read_json_from_assets, read_zip
 
 from .routes import demo

--- a/refiner/app/rr_parser.py
+++ b/refiner/app/rr_parser.py
@@ -1,0 +1,77 @@
+import xml.etree.ElementTree as ET
+from fastapi import Response, status
+from typing import Union
+
+NAMESPACES = {
+    'cda': 'urn:hl7-org:v3',
+    'sdtc': 'urn:hl7-org:sdtc',
+    'voc': 'http://www.lantanagroup.com/voc'
+}
+
+def parse_xml(rr_xml: str) -> Union[ET.Element, Response]:
+    """
+    Parses a raw RR XML string and returns the root Element.
+
+    Args:
+        rr_xml (str): The raw XML string.
+
+    Returns:
+        ElementTree.Element if successful, or FastAPI Response on error.
+    """
+    try:
+        rr_root = ET.fromstring(rr_xml)
+        return rr_root
+    except ET.ParseError as e:
+        return Response(
+            content=f"Failed to parse RR XML: {str(e)}",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+# def get_reportable_conditions(root):
+#     """
+#     Returns a comma-separated list of all SNOMED CT codes found
+#     in the Report Summary section (code 55112-7), or None if none.
+#     """
+#     try:
+#         ns = {
+#             'cda': 'urn:hl7-org:v3',
+#             'xsi': 'http://www.w3.org/2001/XMLSchema-instance'
+#         }
+#         codes = []
+#         for section in root.findall(".//cda:section", namespaces=ns):
+#             c = section.find("cda:code", namespaces=ns)
+#             if c is not None and c.attrib.get("code") == "55112-7":
+#                 for ve in section.findall(
+#                     ".//cda:value[@codeSystem='2.16.840.1.113883.6.96']",
+#                     namespaces=ns
+#                 ):
+#                     code = ve.attrib.get('code')
+#                     if code:
+#                         codes.append(code)
+#         return ",".join(codes) if codes else None
+#
+#     except Exception as e:
+#         print(f"Error retrieving SNOMED codes: {e}")
+#         return None
+
+def get_reportable_conditions(root) -> str | None:
+    """
+    Scan the Report Summary section for SNOMED CT codes and return
+    them as a comma-separated string, or None if none found.
+    """
+    ns = {
+        'cda': 'urn:hl7-org:v3',
+        'xsi': 'http://www.w3.org/2001/XMLSchema-instance'
+    }
+    codes = []
+    for section in root.findall(".//cda:section", namespaces=ns):
+        if (c := section.find("cda:code", namespaces=ns)) is not None \
+           and c.attrib.get("code") == "55112-7":
+            for ve in section.findall(
+                ".//cda:value[@codeSystem='2.16.840.1.113883.6.96']",
+                namespaces=ns
+            ):
+                code = ve.attrib.get('code')
+                if code:
+                    codes.append(code)
+    return ",".join(codes) if codes else None

--- a/refiner/app/rr_parser.py
+++ b/refiner/app/rr_parser.py
@@ -1,14 +1,15 @@
 import xml.etree.ElementTree as ET
+
 from fastapi import Response, status
-from typing import Union
 
 NAMESPACES = {
-    'cda': 'urn:hl7-org:v3',
-    'sdtc': 'urn:hl7-org:sdtc',
-    'voc': 'http://www.lantanagroup.com/voc'
+    "cda": "urn:hl7-org:v3",
+    "sdtc": "urn:hl7-org:sdtc",
+    "voc": "http://www.lantanagroup.com/voc",
 }
 
-def parse_xml(rr_xml: str) -> Union[ET.Element, Response]:
+
+def parse_xml(rr_xml: str) -> ET.Element | Response:
     """
     Parses a raw RR XML string and returns the root Element.
 
@@ -27,51 +28,22 @@ def parse_xml(rr_xml: str) -> Union[ET.Element, Response]:
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 
-# def get_reportable_conditions(root):
-#     """
-#     Returns a comma-separated list of all SNOMED CT codes found
-#     in the Report Summary section (code 55112-7), or None if none.
-#     """
-#     try:
-#         ns = {
-#             'cda': 'urn:hl7-org:v3',
-#             'xsi': 'http://www.w3.org/2001/XMLSchema-instance'
-#         }
-#         codes = []
-#         for section in root.findall(".//cda:section", namespaces=ns):
-#             c = section.find("cda:code", namespaces=ns)
-#             if c is not None and c.attrib.get("code") == "55112-7":
-#                 for ve in section.findall(
-#                     ".//cda:value[@codeSystem='2.16.840.1.113883.6.96']",
-#                     namespaces=ns
-#                 ):
-#                     code = ve.attrib.get('code')
-#                     if code:
-#                         codes.append(code)
-#         return ",".join(codes) if codes else None
-#
-#     except Exception as e:
-#         print(f"Error retrieving SNOMED codes: {e}")
-#         return None
 
 def get_reportable_conditions(root) -> str | None:
     """
     Scan the Report Summary section for SNOMED CT codes and return
     them as a comma-separated string, or None if none found.
     """
-    ns = {
-        'cda': 'urn:hl7-org:v3',
-        'xsi': 'http://www.w3.org/2001/XMLSchema-instance'
-    }
+    ns = {"cda": "urn:hl7-org:v3", "xsi": "http://www.w3.org/2001/XMLSchema-instance"}
     codes = []
     for section in root.findall(".//cda:section", namespaces=ns):
-        if (c := section.find("cda:code", namespaces=ns)) is not None \
-           and c.attrib.get("code") == "55112-7":
+        if (c := section.find("cda:code", namespaces=ns)) is not None and c.attrib.get(
+            "code"
+        ) == "55112-7":
             for ve in section.findall(
-                ".//cda:value[@codeSystem='2.16.840.1.113883.6.96']",
-                namespaces=ns
+                ".//cda:value[@codeSystem='2.16.840.1.113883.6.96']", namespaces=ns
             ):
-                code = ve.attrib.get('code')
+                code = ve.attrib.get("code")
                 if code:
                     codes.append(code)
     return ",".join(codes) if codes else None


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary
- Update /zip-upload endpoint to parse RR
- Once RR is parsed, it will extract the reportable snomed codes 
- If conditions_to_include is not passed in from caller, it will set it as the reportable snomed code found in the RR 

## 🔗 Related Issue

Fixes #29 
- #29 

## ✅ Acceptance Criteria

-  Refiner code has been modified to read the RR XML
-  Code has been written to find reportable conditions
 - All reportable conditions and any other required information is stored (in an in-memory data structure like a dictionary, not a database) for usage

## 🧪 How to test

Using postman, hit http://localhost:8080/zip-upload with body containing file that is set to a zip file containing and RR and eICR. I used the MonMothma files for this. Ensure a refined ecr is returned from the refiner

## ℹ️ Additional Information

- Started to play around with checking for multiple snomed codes in the RR and checking the RRSV1 to see if displayName="Reportable" but was having some issues. Mainly having no RR to refer to that has multiple reportable conditions and RRSV1 values of Reportable and Not Reportable. So this will require some further digging although I assume Robert has some ideas