### PR TITLE
feat: Add end-to-end demo UI flow

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.5.2",
+        "react-xml-viewer": "^2.0.5",
         "tailwindcss": "^4.1.4"
       },
       "devDependencies": {
@@ -4069,6 +4070,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -5370,7 +5389,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -6083,6 +6101,24 @@
         }
       }
     },
+    "node_modules/react-xml-viewer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-xml-viewer/-/react-xml-viewer-2.0.5.tgz",
+      "integrity": "sha512-UAleJsWwr0bc/vTCA1EbZqhXURmnB5UkEUagocUxqU7TCaLECz1lyRXBsWz73fugSLEFVW12QAFzbyyC4VpFig==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^4.5.0",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.4",
+        "react-dom": ">= 16.8.4"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6649,6 +6685,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,7 @@
         "@eslint/js": "^9.21.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@typescript-eslint/parser": "^8.30.1",
@@ -1935,6 +1936,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.4",
-        "@tanstack/react-query": "^5.74.3",
         "classnames": "^2.5.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1844,32 +1843,6 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6"
-      }
-    },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.74.9",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.74.9.tgz",
-      "integrity": "sha512-qmjXpWyigDw4SfqdSBy24FzRvpBPXlaSbl92N77lcrL+yvVQLQkf0T6bQNbTxl9IEB/SvVFhhVZoIlQvFnNuuw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.74.11",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.74.11.tgz",
-      "integrity": "sha512-FFhn9ZiYRUOsxLAWZYxVfQTpVE7UWRaAeHJIWVDHKlmZZGc16rMHW9KrFZ8peC4hA71QUf/shJD8dPSMqDnRmA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.74.9"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
     "@eslint/js": "^9.21.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@typescript-eslint/parser": "^8.30.1",

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.5.2",
+    "react-xml-viewer": "^2.0.5",
     "tailwindcss": "^4.1.4"
   },
   "devDependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.4",
-    "@tanstack/react-query": "^5.74.3",
     "classnames": "^2.5.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -1,16 +1,11 @@
 import { render, screen } from '@testing-library/react';
-
 import App from './App';
 import { BrowserRouter } from 'react-router';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-const queryClient = new QueryClient();
 const renderApp = () => {
   return render(
     <BrowserRouter>
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
+      <App />
     </BrowserRouter>
   );
 };

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,16 +3,11 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
 import { BrowserRouter } from 'react-router';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-
-const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
+      <App />
     </BrowserRouter>
   </StrictMode>
 );

--- a/client/src/pages/Demo/Error.tsx
+++ b/client/src/pages/Demo/Error.tsx
@@ -1,0 +1,28 @@
+import ErrorSvg from '../../assets/red-x.svg';
+import { Button } from '../../components/Button';
+import { Container, Content } from './Layout';
+
+export function Error() {
+  return (
+    <Container color="red">
+      <Content className="gap-10">
+        <div className="flex flex-col items-center">
+          <img
+            className="p-8"
+            src={ErrorSvg}
+            alt="Red X indicating an error occured during upload."
+          />
+          <div className="flex flex-col items-center gap-6">
+            <p className="text-xl font-bold text-black">
+              The file could not be read.
+            </p>
+            <p className="leading-snug">
+              Please double check the format and size. It must be less than 1GB.
+            </p>
+          </div>
+        </div>
+        <Button color="black">Try again</Button>
+      </Content>
+    </Container>
+  );
+}

--- a/client/src/pages/Demo/Error.tsx
+++ b/client/src/pages/Demo/Error.tsx
@@ -2,7 +2,11 @@ import ErrorSvg from '../../assets/red-x.svg';
 import { Button } from '../../components/Button';
 import { Container, Content } from './Layout';
 
-export function Error() {
+interface ErrorProps {
+  onClick: () => void;
+}
+
+export function Error({ onClick }: ErrorProps) {
   return (
     <Container color="red">
       <Content className="gap-10">
@@ -21,7 +25,9 @@ export function Error() {
             </p>
           </div>
         </div>
-        <Button color="black">Try again</Button>
+        <Button color="black" onClick={onClick}>
+          Try again
+        </Button>
       </Content>
     </Container>
   );

--- a/client/src/pages/Demo/Layout.tsx
+++ b/client/src/pages/Demo/Layout.tsx
@@ -1,0 +1,36 @@
+import classNames from 'classnames';
+
+interface ContainerProps {
+  color: 'blue' | 'red' | 'green';
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Container({ color, children, className }: ContainerProps) {
+  const defaultStyles =
+    'items-center gap-6 rounded-lg border-1 border-dashed px-20 py-8';
+  return (
+    <div
+      className={classNames(defaultStyles, className, {
+        'border-blue-300 bg-blue-100': color === 'blue',
+        'border-red-300 bg-rose-600/10': color === 'red',
+        'border-green-500 bg-green-500/10': color === 'green',
+      })}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface ContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Content({ children, className }: ContentProps) {
+  return (
+    <div className={classNames('flex flex-col items-center', className)}>
+      {children}
+    </div>
+  );
+}

--- a/client/src/pages/Demo/ReportableConditions.tsx
+++ b/client/src/pages/Demo/ReportableConditions.tsx
@@ -1,0 +1,46 @@
+import { Container, Content } from './Layout';
+import InformationSvg from '../../assets/information.svg';
+import { Button } from '../../components/Button';
+
+interface ReportableConditionsProps {
+  conditions: string[];
+  onClick: () => void;
+}
+export function ReportableConditions({
+  conditions,
+  onClick,
+}: ReportableConditionsProps) {
+  return (
+    <Container color="blue">
+      <Content className="flex flex-col">
+        <img className="p-3" src={InformationSvg} alt="Information icon" />
+        <div className="flex flex-col items-center gap-10">
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col items-center gap-3">
+              <p className="text-center text-xl font-bold text-black">
+                We found the following reportable condition(s):
+              </p>
+              {conditions.length > 0 ? (
+                <ul className="list-disc text-xl font-bold text-black">
+                  {conditions.map((condition) => (
+                    <li key={condition}>{condition}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+            <div className="flex flex-col items-center gap-2">
+              <p>Would you like to refine the eCR?</p>
+              <p>
+                Taking this action will retain information relevant only to the
+                conditions listed.
+              </p>
+            </div>
+          </div>
+          <div>
+            <Button onClick={onClick}>Refine eCR</Button>
+          </div>
+        </div>
+      </Content>
+    </Container>
+  );
+}

--- a/client/src/pages/Demo/RunTest.tsx
+++ b/client/src/pages/Demo/RunTest.tsx
@@ -1,0 +1,29 @@
+import { Button } from '../../components/Button';
+import { Container, Content } from './Layout';
+import UploadSvg from '../../assets/upload.svg';
+
+interface RunTestProps {
+  onClick: () => void;
+}
+export function RunTest({ onClick }: RunTestProps) {
+  return (
+    <Container color="blue">
+      <Content className="flex gap-3">
+        <img src={UploadSvg} alt="" className="p-3" />
+        <div className="flex flex-col items-center gap-6">
+          <p className="text-base font-normal text-black">
+            We will upload a test file for you to view the refinement results
+          </p>
+          <Button onClick={onClick}>Run test</Button>
+          <a
+            className="justify-start text-base font-bold text-blue-300 hover:underline"
+            href="/api/demo/download"
+            download
+          >
+            Download test file
+          </a>
+        </div>
+      </Content>
+    </Container>
+  );
+}

--- a/client/src/pages/Demo/Success.tsx
+++ b/client/src/pages/Demo/Success.tsx
@@ -16,6 +16,7 @@ export function Success({ unrefinedEicr, refinedEicr }: EicrComparisonProps) {
               <div className="rounded-lg bg-white p-4">
                 <div className="flex gap-2">
                   <GreenCheck />
+                  {/* TODO: provide calculated stats when available */}
                   <p className="leading-snug font-bold">
                     eCR file size reduced by 14%
                   </p>
@@ -29,6 +30,7 @@ export function Success({ unrefinedEicr, refinedEicr }: EicrComparisonProps) {
               </div>
             </div>
             <div>
+              {/* TODO: make this button work */}
               <Button color="black">Download refined eCR</Button>
             </div>
           </div>

--- a/client/src/pages/Demo/Success.tsx
+++ b/client/src/pages/Demo/Success.tsx
@@ -4,6 +4,12 @@ import { Container, Content } from './Layout';
 import XMLViewer from 'react-xml-viewer';
 
 export function Success({ unrefinedEicr, refinedEicr }: EicrComparisonProps) {
+  // TODO: This will come from the API
+  const successItems = [
+    'eCR file size reduced by 14%',
+    'Found 32 observations relevant to the condition(s)',
+  ];
+
   return (
     <>
       <Container color="green" className="w-full !p-8">
@@ -13,21 +19,9 @@ export function Success({ unrefinedEicr, refinedEicr }: EicrComparisonProps) {
           </h1>
           <div className="flex min-w-full flex-col items-center justify-between gap-4 sm:flex-row">
             <div className="flex flex-col gap-4 sm:flex-row">
-              <div className="rounded-lg bg-white p-4">
-                <div className="flex gap-2">
-                  <GreenCheck />
-                  {/* TODO: provide calculated stats when available */}
-                  <p className="leading-snug font-bold">
-                    eCR file size reduced by 14%
-                  </p>
-                </div>
-              </div>
-              <div className="flex items-center gap-2 rounded-lg bg-white p-4">
-                <GreenCheck />
-                <p className="flex flex-col items-center gap-2 leading-snug font-bold">
-                  Found 32 observations relevant to the condition(s)
-                </p>
-              </div>
+              {successItems.map((item) => (
+                <SuccessItem>{item}</SuccessItem>
+              ))}
             </div>
             <div>
               {/* TODO: make this button work */}
@@ -38,6 +32,21 @@ export function Success({ unrefinedEicr, refinedEicr }: EicrComparisonProps) {
       </Container>
       <EicrComparison unrefinedEicr={unrefinedEicr} refinedEicr={refinedEicr} />
     </>
+  );
+}
+
+interface SuccessItemProps {
+  children: React.ReactNode;
+}
+
+function SuccessItem({ children }: SuccessItemProps) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg bg-white p-4">
+      <GreenCheck />
+      <p className="flex flex-col items-center gap-2 leading-snug font-bold">
+        {children}
+      </p>
+    </div>
   );
 }
 

--- a/client/src/pages/Demo/Success.tsx
+++ b/client/src/pages/Demo/Success.tsx
@@ -17,7 +17,7 @@ export function Success({ unrefinedEicr, refinedEicr }: EicrComparisonProps) {
           <h1 className="text-xl font-bold text-black">
             eCR successfully refined!
           </h1>
-          <div className="flex min-w-full flex-col items-center justify-between gap-4 sm:flex-row">
+          <div className="flex min-h-full min-w-full flex-col items-center justify-between gap-4 sm:flex-row">
             <div className="flex flex-col gap-4 sm:flex-row">
               {successItems.map((item) => (
                 <SuccessItem>{item}</SuccessItem>
@@ -81,7 +81,9 @@ function EicrText({ title, xml }: EicrTextProps) {
   return (
     <div className="flex w-1/2 flex-col gap-2">
       <h2 className="text-3xl font-bold">{title}</h2>
-      <div className="p-10">
+      {/* There's not an easy way to apply classes directly to XMLViewer 
+      so we're using Tailwind to target the child XMLViewer div instead */}
+      <div className="p-10 [&>div]:h-170 [&>div]:w-full [&>div]:overflow-auto">
         <XMLViewer xml={xml} collapsible theme={{ commentColor: 'black' }} />
       </div>
     </div>

--- a/client/src/pages/Demo/Success.tsx
+++ b/client/src/pages/Demo/Success.tsx
@@ -70,7 +70,7 @@ function EicrText({ title, xml }: EicrTextProps) {
   return (
     <div className="flex w-1/2 flex-col gap-2">
       <h2 className="text-3xl font-bold">{title}</h2>
-      <div className="p-4">
+      <div className="p-10">
         <XMLViewer xml={xml} collapsible theme={{ commentColor: 'black' }} />
       </div>
     </div>

--- a/client/src/pages/Demo/Success.tsx
+++ b/client/src/pages/Demo/Success.tsx
@@ -1,15 +1,16 @@
 import SuccessSvg from '../../assets/green-check.svg';
 import { Button } from '../../components/Button';
 import { Container, Content } from './Layout';
+import XMLViewer from 'react-xml-viewer';
 
 export function Success({ unrefinedEicr, refinedEicr }: EicrComparisonProps) {
   return (
     <>
       <Container color="green" className="w-full !p-8">
         <Content className="flex flex-col items-start gap-4">
-          <p className="text-xl font-bold text-black">
+          <h1 className="text-xl font-bold text-black">
             eCR successfully refined!
-          </p>
+          </h1>
           <div className="flex min-w-full flex-col items-center justify-between gap-4 sm:flex-row">
             <div className="flex flex-col gap-4 sm:flex-row">
               <div className="rounded-lg bg-white p-4">
@@ -54,6 +55,7 @@ export function EicrComparison({
   return (
     <div className="flex w-full justify-between gap-10">
       <EicrText title="Unrefined eICR" xml={unrefinedEicr} />
+      <div className="border-1 border-gray-300"></div>
       <EicrText title="Refined eICR" xml={refinedEicr} />
     </div>
   );
@@ -68,7 +70,9 @@ function EicrText({ title, xml }: EicrTextProps) {
   return (
     <div className="flex w-1/2 flex-col gap-2">
       <h2 className="text-3xl font-bold">{title}</h2>
-      <p className="bg-gray-200 px-10 py-7">{xml}</p>
+      <div className="p-4">
+        <XMLViewer xml={xml} collapsible theme={{ commentColor: 'black' }} />
+      </div>
     </div>
   );
 }

--- a/client/src/pages/Demo/Success.tsx
+++ b/client/src/pages/Demo/Success.tsx
@@ -1,0 +1,74 @@
+import SuccessSvg from '../../assets/green-check.svg';
+import { Button } from '../../components/Button';
+import { Container, Content } from './Layout';
+
+export function Success({ unrefinedEicr, refinedEicr }: EicrComparisonProps) {
+  return (
+    <>
+      <Container color="green" className="w-full !p-8">
+        <Content className="flex flex-col items-start gap-4">
+          <p className="text-xl font-bold text-black">
+            eCR successfully refined!
+          </p>
+          <div className="flex min-w-full flex-col items-center justify-between gap-4 sm:flex-row">
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <div className="rounded-lg bg-white p-4">
+                <div className="flex gap-2">
+                  <GreenCheck />
+                  <p className="leading-snug font-bold">
+                    eCR file size reduced by 14%
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 rounded-lg bg-white p-4">
+                <GreenCheck />
+                <p className="flex flex-col items-center gap-2 leading-snug font-bold">
+                  Found 32 observations relevant to the condition(s)
+                </p>
+              </div>
+            </div>
+            <div>
+              <Button color="black">Download refined eCR</Button>
+            </div>
+          </div>
+        </Content>
+      </Container>
+      <EicrComparison unrefinedEicr={unrefinedEicr} refinedEicr={refinedEicr} />
+    </>
+  );
+}
+
+function GreenCheck() {
+  return <img className="h-6 w-6" src={SuccessSvg} alt="" />;
+}
+
+interface EicrComparisonProps {
+  unrefinedEicr: string;
+  refinedEicr: string;
+}
+
+export function EicrComparison({
+  unrefinedEicr,
+  refinedEicr,
+}: EicrComparisonProps) {
+  return (
+    <div className="flex w-full justify-between gap-10">
+      <EicrText title="Unrefined eICR" xml={unrefinedEicr} />
+      <EicrText title="Refined eICR" xml={refinedEicr} />
+    </div>
+  );
+}
+
+interface EicrTextProps {
+  title: string;
+  xml: string;
+}
+
+function EicrText({ title, xml }: EicrTextProps) {
+  return (
+    <div className="flex w-1/2 flex-col gap-2">
+      <h2 className="text-3xl font-bold">{title}</h2>
+      <p className="bg-gray-200 px-10 py-7">{xml}</p>
+    </div>
+  );
+}

--- a/client/src/pages/Demo/Success.tsx
+++ b/client/src/pages/Demo/Success.tsx
@@ -20,7 +20,7 @@ export function Success({ unrefinedEicr, refinedEicr }: EicrComparisonProps) {
           <div className="flex min-h-full min-w-full flex-col items-center justify-between gap-4 sm:flex-row">
             <div className="flex flex-col gap-4 sm:flex-row">
               {successItems.map((item) => (
-                <SuccessItem>{item}</SuccessItem>
+                <SuccessItem key={item}>{item}</SuccessItem>
               ))}
             </div>
             <div>

--- a/client/src/pages/Demo/index.test.tsx
+++ b/client/src/pages/Demo/index.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  ApiUploadError,
+  DemoUploadResponse,
+  uploadDemoFile,
+} from '../../services/demo';
+import Demo from '.';
+import { BrowserRouter } from 'react-router';
+
+const mockUploadResponse: DemoUploadResponse = {
+  unrefined_eicr: '<data>tons of data here</data>',
+  refined_eicr: '<data>less data</data>',
+};
+
+vi.mock(import('../../services/demo.ts'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    uploadDemoFile: vi.fn(),
+  };
+});
+
+const renderDemoView = () =>
+  render(
+    <BrowserRouter>
+      <Demo />
+    </BrowserRouter>
+  );
+
+describe('Demo', () => {
+  it('should navigate through the various views in the expected order', async () => {
+    const user = userEvent.setup();
+    renderDemoView();
+
+    // check that we start on the "run test" page
+    const runTestPageText =
+      'We will upload a test file for you to view the refinement results';
+    expect(screen.getByText(runTestPageText)).toBeInTheDocument();
+
+    // navigate to reportable conditions
+    vi.mocked(uploadDemoFile).mockResolvedValue(mockUploadResponse);
+    await user.click(screen.getByText('Run test'));
+    expect(uploadDemoFile).toHaveBeenCalledOnce();
+
+    // check reportable conditions view
+    expect(
+      screen.getByText('We found the following reportable condition(s):')
+    ).toBeInTheDocument();
+    await user.click(screen.getByText('Refine eCR', { selector: 'button' }));
+
+    // check success page
+    expect(screen.getByText('eCR successfully refined!')).toBeInTheDocument();
+    expect(screen.getByText('tons of data here')).toBeInTheDocument();
+    expect(screen.getByText('less data')).toBeInTheDocument();
+  });
+
+  it('should navigate to the error view when the upload request fails', async () => {
+    const user = userEvent.setup();
+    renderDemoView();
+
+    // throw an api error when attempting to run the test
+    vi.mocked(uploadDemoFile).mockRejectedValue(
+      new ApiUploadError('API call failed')
+    );
+    await user.click(screen.getByText('Run test'));
+
+    // check that we made it to the error view
+    expect(screen.getByText('The file could not be read.')).toBeInTheDocument();
+
+    // return to the start to try again
+    await user.click(screen.getByText('Try again'));
+    expect(
+      screen.getByText('Run test', { selector: 'button' })
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/Demo/index.tsx
+++ b/client/src/pages/Demo/index.tsx
@@ -33,6 +33,12 @@ export default function Demo() {
     }
   }
 
+  function reset() {
+    setView('run-test');
+    setUploadResponse(null);
+    setUploadError(null);
+  }
+
   return (
     <main className="flex min-w-screen flex-col gap-20 px-20 py-10">
       <LandingPageLink />
@@ -50,7 +56,7 @@ export default function Demo() {
             refinedEicr={uploadResponse.refined_eicr}
           />
         )}
-        {uploadError && <Error />}
+        {uploadError && <Error onClick={reset} />}
       </div>
     </main>
   );

--- a/client/src/pages/Demo/index.tsx
+++ b/client/src/pages/Demo/index.tsx
@@ -35,6 +35,7 @@ export default function Demo() {
       <div className="flex flex-col items-center justify-center gap-6">
         {view === 'run-test' && <RunTest onClick={runTest} />}
         {view === 'reportable-conditions' && uploadResponse && (
+          // TODO: provide list of reportable conditions from backend
           <ReportableConditions
             conditions={['Chlamydia trachomatis infection']}
             onClick={() => setView('success')}

--- a/client/src/pages/Demo/index.tsx
+++ b/client/src/pages/Demo/index.tsx
@@ -1,204 +1,47 @@
-import UploadSvg from '../../assets/upload.svg';
-import ErrorSvg from '../../assets/red-x.svg';
-import SuccessSvg from '../../assets/green-check.svg';
-import InformationSvg from '../../assets/information.svg';
 import { LandingPageLink } from '../../components/LandingPageLink';
-import { Button } from '../../components/Button';
-import classNames from 'classnames';
+import { Success } from './Success';
+import { ReportableConditions } from './ReportableConditions';
+import { Error } from './Error';
+import { RunTest } from './RunTest';
+import { useDemoUpload } from '../../services/demo';
+import { useEffect, useState } from 'react';
 
 export default function Demo() {
+  const [isComplete, setIsComplete] = useState(false);
+  const {
+    data,
+    resetData,
+    refetch: runTest,
+    isError,
+    isSuccess,
+  } = useDemoUpload();
+
+  useEffect(() => {
+    async function reset() {
+      await resetData();
+    }
+    reset();
+  }, []);
+
   return (
     <main className="flex min-w-screen flex-col gap-20 px-20 py-10">
       <LandingPageLink />
       <div className="flex flex-col items-center justify-center gap-6">
-        <UploadError />
-        <UploadSuccess />
-        <ReportableConditions />
-        <RunTest />
-        <EicrComparison
-          unrefinedEicr="<data>unrefined eICR data</data>"
-          refinedEicr="<data>refined eICR data</data>"
-        />
+        {!data && <RunTest onClick={runTest} />}
+        {data && isSuccess && !isComplete && (
+          <ReportableConditions
+            conditions={['Chlamydia trachomatis infection']}
+            onClick={() => setIsComplete(true)}
+          />
+        )}
+        {isComplete && (
+          <Success
+            unrefinedEicr="<data>unrefined</data>"
+            refinedEicr="<data>refined</data>"
+          />
+        )}
+        {isError && <Error />}
       </div>
     </main>
-  );
-}
-
-function RunTest() {
-  return (
-    <Container color="blue">
-      <Content className="flex gap-3">
-        <img src={UploadSvg} alt="" className="p-3" />
-        <div className="flex flex-col items-center gap-6">
-          <p className="text-base font-normal text-black">
-            We will upload a test file for you to view the refinement results
-          </p>
-          <Button>Run test</Button>
-          <a
-            className="justify-start text-base font-bold text-blue-300 hover:underline"
-            href="/api/demo/download"
-            download
-          >
-            Download test file
-          </a>
-        </div>
-      </Content>
-    </Container>
-  );
-}
-
-function UploadError() {
-  return (
-    <Container color="red">
-      <Content className="gap-10">
-        <div className="flex flex-col items-center">
-          <img
-            className="p-8"
-            src={ErrorSvg}
-            alt="Red X indicating an error occured during upload."
-          />
-          <div className="flex flex-col items-center gap-6">
-            <p className="text-xl font-bold text-black">
-              The file could not be read.
-            </p>
-            <p className="leading-snug">
-              Please double check the format and size. It must be less than 1GB.
-            </p>
-          </div>
-        </div>
-        <Button color="black">Try again</Button>
-      </Content>
-    </Container>
-  );
-}
-
-function UploadSuccess() {
-  return (
-    <Container color="green" className="w-full !p-8">
-      <Content className="flex flex-col items-start gap-4">
-        <p className="text-xl font-bold text-black">
-          eCR successfully refined!
-        </p>
-        <div className="flex min-w-full flex-col items-center justify-between gap-4 sm:flex-row">
-          <div className="flex flex-col gap-4 sm:flex-row">
-            <div className="rounded-lg bg-white p-4">
-              <div className="flex gap-2">
-                <GreenCheck />
-                <p className="leading-snug font-bold">
-                  eCR file size reduced by 14%
-                </p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2 rounded-lg bg-white p-4">
-              <GreenCheck />
-              <p className="flex flex-col items-center gap-2 leading-snug font-bold">
-                Found 32 observations relevant to the condition(s)
-              </p>
-            </div>
-          </div>
-          <div>
-            <Button color="black">Download refined eCR</Button>
-          </div>
-        </div>
-      </Content>
-    </Container>
-  );
-}
-
-function GreenCheck() {
-  return <img className="h-6 w-6" src={SuccessSvg} alt="" />;
-}
-
-function ReportableConditions() {
-  return (
-    <Container color="blue">
-      <Content className="flex flex-col">
-        <img className="p-3" src={InformationSvg} alt="Information icon" />
-        <div className="flex flex-col items-center gap-10">
-          <div className="flex flex-col gap-6">
-            <div className="flex flex-col items-center gap-3">
-              <p className="text-center text-xl font-bold text-black">
-                We found the following reportable condition(s):
-              </p>
-              <ul className="list-disc text-xl font-bold text-black">
-                <li>Chlamydia trachomatis infection</li>
-              </ul>
-            </div>
-            <div className="flex flex-col items-center gap-2">
-              <p>Would you like to refine the eCR?</p>
-              <p>
-                Taking this action will retain information relevant only to the
-                conditions listed.
-              </p>
-            </div>
-          </div>
-          <div>
-            <Button>Refine eCR</Button>
-          </div>
-        </div>
-      </Content>
-    </Container>
-  );
-}
-
-interface EicrComparisonProps {
-  unrefinedEicr: string;
-  refinedEicr: string;
-}
-
-function EicrComparison({ unrefinedEicr, refinedEicr }: EicrComparisonProps) {
-  return (
-    <div className="flex w-full justify-between gap-10">
-      <EicrText title="Unrefined eICR" xml={unrefinedEicr} />
-      <EicrText title="Refined eICR" xml={refinedEicr} />
-    </div>
-  );
-}
-
-interface EicrTextProps {
-  title: string;
-  xml: string;
-}
-
-function EicrText({ title, xml }: EicrTextProps) {
-  return (
-    <div className="flex w-1/2 flex-col gap-2">
-      <h2 className="text-3xl font-bold">{title}</h2>
-      <p className="bg-gray-200 px-10 py-7">{xml}</p>
-    </div>
-  );
-}
-
-interface ContainerProps {
-  color: 'blue' | 'red' | 'green';
-  children: React.ReactNode;
-  className?: string;
-}
-function Container({ color, children, className }: ContainerProps) {
-  const defaultStyles =
-    'items-center gap-6 rounded-lg border-1 border-dashed px-20 py-8';
-  return (
-    <div
-      className={classNames(defaultStyles, className, {
-        'border-blue-300 bg-blue-100': color === 'blue',
-        'border-red-300 bg-rose-600/10': color === 'red',
-        'border-green-500 bg-green-500/10': color === 'green',
-      })}
-    >
-      {children}
-    </div>
-  );
-}
-
-interface ContentProps {
-  children: React.ReactNode;
-  className?: string;
-}
-
-function Content({ children, className }: ContentProps) {
-  return (
-    <div className={classNames('flex flex-col items-center', className)}>
-      {children}
-    </div>
   );
 }

--- a/client/src/pages/Demo/index.tsx
+++ b/client/src/pages/Demo/index.tsx
@@ -4,11 +4,7 @@ import { ReportableConditions } from './ReportableConditions';
 import { Error } from './Error';
 import { RunTest } from './RunTest';
 import { useState } from 'react';
-import {
-  ApiUploadError,
-  DemoUploadResponse,
-  uploadDemoFile,
-} from '../../services/demo';
+import { DemoUploadResponse, uploadDemoFile } from '../../services/demo';
 
 type View = 'run-test' | 'reportable-conditions' | 'success' | 'error';
 
@@ -16,27 +12,21 @@ export default function Demo() {
   const [view, setView] = useState<View>('run-test');
   const [uploadResponse, setUploadResponse] =
     useState<DemoUploadResponse | null>(null);
-  const [uploadError, setUploadError] = useState<Error | null>(null);
 
   async function runTest() {
     try {
       const resp = await uploadDemoFile();
       setUploadResponse(resp);
-      setUploadError(null);
       setView('reportable-conditions');
-    } catch (e: unknown) {
+    } catch {
       setUploadResponse(null);
       setView('error');
-      if (e instanceof ApiUploadError) {
-        setUploadError(e);
-      }
     }
   }
 
   function reset() {
     setView('run-test');
     setUploadResponse(null);
-    setUploadError(null);
   }
 
   return (
@@ -44,19 +34,19 @@ export default function Demo() {
       <LandingPageLink />
       <div className="flex flex-col items-center justify-center gap-6">
         {view === 'run-test' && <RunTest onClick={runTest} />}
-        {uploadResponse && view === 'reportable-conditions' && (
+        {view === 'reportable-conditions' && uploadResponse && (
           <ReportableConditions
             conditions={['Chlamydia trachomatis infection']}
             onClick={() => setView('success')}
           />
         )}
-        {uploadResponse && view === 'success' && (
+        {view === 'success' && uploadResponse && (
           <Success
             unrefinedEicr={uploadResponse.unrefined_eicr}
             refinedEicr={uploadResponse.refined_eicr}
           />
         )}
-        {uploadError && <Error onClick={reset} />}
+        {view === 'error' && <Error onClick={reset} />}
       </div>
     </main>
   );

--- a/client/src/services/demo.ts
+++ b/client/src/services/demo.ts
@@ -2,6 +2,9 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 async function upload(): Promise<string> {
   const resp = await fetch('/api/demo/upload');
+  if (!resp.ok) {
+    throw new Error('Unable to perform demo upload.');
+  }
   return resp.text();
 }
 
@@ -19,7 +22,7 @@ export function useDemoUpload() {
       queryKey: [uploadKey],
       queryFn: upload,
       enabled: false,
-      initialData: '',
+      initialData: null,
     }),
     resetData,
   };

--- a/client/src/services/demo.ts
+++ b/client/src/services/demo.ts
@@ -1,29 +1,20 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-
-async function upload(): Promise<string> {
-  const resp = await fetch('/api/demo/upload');
-  if (!resp.ok) {
-    throw new Error('Unable to perform demo upload.');
+export class ApiUploadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ApiUploadError';
+    Object.setPrototypeOf(this, ApiUploadError.prototype);
   }
-  return resp.text();
 }
 
-const uploadKey = 'upload';
+export interface DemoUploadResponse {
+  unrefined_eicr: string;
+  refined_eicr: string;
+}
 
-export function useDemoUpload() {
-  const queryClient = useQueryClient();
-
-  async function resetData() {
-    await queryClient.resetQueries({ queryKey: [uploadKey], exact: true });
+export async function uploadDemoFile(): Promise<DemoUploadResponse> {
+  const resp = await fetch('/api/demo/upload');
+  if (!resp.ok) {
+    throw new ApiUploadError('Unable to perform demo upload.');
   }
-
-  return {
-    ...useQuery({
-      queryKey: [uploadKey],
-      queryFn: upload,
-      enabled: false,
-      initialData: null,
-    }),
-    resetData,
-  };
+  return resp.json();
 }

--- a/refiner/app/routes/demo.py
+++ b/refiner/app/routes/demo.py
@@ -1,8 +1,9 @@
 import io
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException, Response, UploadFile, status
-from fastapi.responses import FileResponse
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import FileResponse, JSONResponse
 
 from app.refine import refine, validate_message
 from app.utils import read_zip
@@ -42,7 +43,11 @@ async def demo_upload(file_path: Path = Depends(_get_demo_zip_path)):
     eicr_xml, _rr_xml = await read_zip(upload_file)
     validated_message, _error_message = validate_message(eicr_xml)
     refined_data = refine(validated_message, None, None)
-    return Response(content=refined_data, media_type="application/xml")
+    return JSONResponse(
+        content=jsonable_encoder(
+            {"unrefined_eicr": eicr_xml, "refined_eicr": refined_data}
+        )
+    )
 
 
 @router.get("/download")


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds the end-to-end demo flow based on the [designs](https://www.figma.com/design/QK7dVoNaG6qIF52r1imkwY/eCR-Refiner?node-id=221-156&p=f&m=dev). This flow functions very similarly to the way [Query Connector handles its query page](https://github.com/CDCgov/dibbs-query-connector/blob/main/src/app/(pages)/query/page.tsx#L82).

## 🔗 Related Issue

Fixes #55, #61, #68

## ✅ Acceptance Criteria

- [ ] Happy and error paths working as expected
- [ ] Success page displays unrefined vs. refined comparison
  - [ ] Unrefined vs. refined comparison data is coming from the API
  - [ ] react-xml-viewer is used to display the XML comparison on the success page

## 🧪 How to test

### Happy path

1. Navigate to [http://localhost:8081/demo](http://localhost:8081/demo)
2. Click `Run test`
3. Click `Refine eCR`
4. You should see the success page which will display the unrefined vs. refined comparison XML view

### Error path

1. In `/routes/demo.py`, add `raise HTTPException` on line 46 and make sure your server reloads
2. Click `Run test` in the UI
3. You should see the error screen. Click `Try again`, which will take you back to the `Run test` screen