### PR TITLE
feat: download refined demo eCR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ coverage.xml
 
 # Static files
 dist
+refined-ecr

--- a/client/src/pages/Demo/Success.tsx
+++ b/client/src/pages/Demo/Success.tsx
@@ -57,7 +57,6 @@ export function Success({
               ))}
             </div>
             <div className="flex flex-col items-center">
-              {/* TODO: make this button work */}
               <Button
                 onClick={async () => await downloadFile(downloadToken)}
                 color="black"

--- a/client/src/pages/Demo/index.test.tsx
+++ b/client/src/pages/Demo/index.test.tsx
@@ -12,6 +12,7 @@ const mockUploadResponse: DemoUploadResponse = {
   unrefined_eicr: '<data>tons of data here</data>',
   refined_eicr: '<data>less data</data>',
   stats: ['eCR reduced by 59%'],
+  refined_download_token: 'test-token',
 };
 
 vi.mock(import('../../services/demo.ts'), async (importOriginal) => {

--- a/client/src/pages/Demo/index.tsx
+++ b/client/src/pages/Demo/index.tsx
@@ -46,6 +46,7 @@ export default function Demo() {
             unrefinedEicr={uploadResponse.unrefined_eicr}
             refinedEicr={uploadResponse.refined_eicr}
             stats={uploadResponse.stats}
+            downloadToken={uploadResponse.refined_download_token}
           />
         )}
         {view === 'error' && <Error onClick={reset} />}

--- a/client/src/services/demo.ts
+++ b/client/src/services/demo.ts
@@ -10,6 +10,7 @@ export interface DemoUploadResponse {
   unrefined_eicr: string;
   refined_eicr: string;
   stats: string[];
+  refined_download_token: string;
 }
 
 export async function uploadDemoFile(): Promise<DemoUploadResponse> {

--- a/refiner/app/api/v1/demo.py
+++ b/refiner/app/api/v1/demo.py
@@ -131,7 +131,7 @@ def _update_file_store(filename: str, path: Path, token: str) -> None:
     }
 
 
-def get_zip_creator() -> Callable[[str, str, Path], tuple[str, Path, str]]:
+def _get_zip_creator() -> Callable[[str, str, Path], tuple[str, Path, str]]:
     """
     Dependency injected function responsible for passing the function that'll write the ouput zip file to the handler.
     """
@@ -149,7 +149,7 @@ def _get_refined_ecr_output_dir() -> Path:
 async def demo_upload(
     demo_zip_path: Path = Depends(_get_demo_zip_path),
     create_output_zip: Callable[[str, str, Path], tuple[str, Path, str]] = Depends(
-        get_zip_creator
+        _get_zip_creator
     ),
     refined_zip_output_dir: Path = Depends(_get_refined_ecr_output_dir),
 ) -> JSONResponse:

--- a/refiner/app/api/v1/demo.py
+++ b/refiner/app/api/v1/demo.py
@@ -1,5 +1,10 @@
+import asyncio
 import io
+import os
+import time
+import uuid
 from pathlib import Path
+from zipfile import ZipFile
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
 from fastapi.encoders import jsonable_encoder
@@ -8,8 +13,42 @@ from fastapi.responses import FileResponse, JSONResponse
 from ...core.exceptions import XMLValidationError
 from ...services import file_io, refine
 
+# Keep track of files available for download / what needs to be cleaned up
+FILE_NAME_SUFFIX = "refined_ecr.zip"
+file_store: dict[str, dict] = {}
+
 # create a router instance for this file
 router = APIRouter(prefix="/demo")
+
+
+async def run_expired_file_cleanup_task() -> None:
+    """
+    Runs the task to delete files in the `refined-ecr` directory every 5 minutes.
+
+    This function will run periodically within its own thread upon application startup.
+    """
+    seconds = 300  # 5 minutes
+    while True:
+        await asyncio.to_thread(_cleanup_expired_files)
+        await asyncio.sleep(seconds)
+
+
+def _cleanup_expired_files() -> None:
+    """
+    Attempts to clean up files that exist beyond their time-to-live value (2 minutes) according to their `timestamp`.
+    """
+    file_ttl = 120
+    now = time.time()
+
+    to_delete = [
+        key for key, meta in file_store.items() if now - meta["timestamp"] > file_ttl
+    ]
+    for key in to_delete:
+        try:
+            os.remove(file_store[key]["path"])
+        except FileNotFoundError:
+            pass
+        del file_store[key]
 
 
 def _get_demo_zip_path() -> Path:
@@ -18,6 +57,14 @@ def _get_demo_zip_path() -> Path:
     """
 
     return file_io.get_asset_path("demo", "monmothma.zip")
+
+
+def _get_processed_ecr_directory() -> Path:
+    REFINED_ECR_DIR = "refined-ecr"
+    if not os.path.exists(REFINED_ECR_DIR):
+        os.mkdir(REFINED_ECR_DIR)
+
+    return REFINED_ECR_DIR
 
 
 def _get_file_size_difference_percentage(
@@ -63,6 +110,22 @@ async def demo_upload(file_path: Path = Depends(_get_demo_zip_path)) -> JSONResp
         rr_results = refine.process_rr(xml_files)
         refined_eicr = refine.refine_eicr(xml_files)
 
+        token = str(uuid.uuid4())
+        filename = f"{token}_{FILE_NAME_SUFFIX}"
+
+        output_dir = _get_processed_ecr_directory()
+        output_file_path = Path(output_dir, filename)
+
+        with ZipFile(output_file_path, "w") as zf:
+            zf.writestr("CDA_eICR.xml", refined_eicr)
+            zf.writestr("CDA_RR.xml", xml_files.rr)
+
+        file_store[token] = {
+            "path": output_file_path,
+            "timestamp": time.time(),
+            "filename": filename,
+        }
+
         return JSONResponse(
             content=jsonable_encoder(
                 {
@@ -77,6 +140,7 @@ async def demo_upload(file_path: Path = Depends(_get_demo_zip_path)) -> JSONResp
                         }%",
                         "Found X observations relevant to the condition(s)",
                     ],
+                    "refined_download_token": token,
                 }
             )
         )
@@ -87,10 +151,27 @@ async def demo_upload(file_path: Path = Depends(_get_demo_zip_path)) -> JSONResp
         )
 
 
+@router.get("/download/{token}")
+async def download_refined_ecr(token: str) -> FileResponse:
+    """
+    Download a refined eCR zip file given a token.
+    """
+
+    if token not in file_store:
+        raise HTTPException(status_code=404, detail="File not found or expired")
+
+    file_path = file_store[token]["path"]
+    print(file_path)
+    filename = file_store[token]["filename"]
+    return FileResponse(
+        file_path, media_type="application/octet-stream", filename=filename
+    )
+
+
 @router.get("/download")
 async def demo_download(file_path: Path = Depends(_get_demo_zip_path)) -> FileResponse:
     """
-    Allows the user to download the sample eCR zip file.
+    Download the unrefined sample eCR zip file.
     """
 
     # Grab demo zip and send it along to the client

--- a/refiner/app/core/app/base.py
+++ b/refiner/app/core/app/base.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import Literal
 
 from fastapi import FastAPI, Request, Response
+from fastapi.applications import AppType
+from starlette.types import Lifespan
 
 from ..config import DIBBS_CONTACT, LICENSES
 from ..models.api import StatusResponse
@@ -29,6 +31,7 @@ class BaseService:
         service_name: str,
         service_path: str,
         description_path: str,
+        lifespan: Lifespan[AppType],
         include_health_check_endpoint: bool = True,
         license_info: Literal["CreativeCommonsZero", "MIT"] = "CreativeCommonsZero",
         openapi_url: str = "/openapi.json",
@@ -40,6 +43,7 @@ class BaseService:
             service_name: Name of the service.
             service_path: Path used to access the service from a gateway.
             description_path: Path to markdown file containing service description.
+            lifespan: A Starlette `Lifespan` object
             include_health_check_endpoint: Whether to add standard DIBBs health
                 check endpoint. Defaults to True.
             license_info: License to use for the service. Options:
@@ -60,6 +64,7 @@ class BaseService:
             license_info=LICENSES[license_info],
             description=description,
             openapi_url=openapi_url,
+            lifespan=lifespan,
         )
 
     def add_path_rewrite_middleware(self) -> None:

--- a/refiner/tests/routes/test_demo.py
+++ b/refiner/tests/routes/test_demo.py
@@ -106,7 +106,7 @@ def test_demo_upload_success(test_assets_path: pathlib.Path) -> None:
     from app.api.v1.demo import (
         _get_demo_zip_path,
         _get_refined_ecr_output_dir,
-        get_zip_creator,
+        _get_zip_creator,
     )
 
     def mock_path_dep():
@@ -121,7 +121,7 @@ def test_demo_upload_success(test_assets_path: pathlib.Path) -> None:
     # Use the actual function reference, not a string
     app.dependency_overrides[_get_refined_ecr_output_dir] = mock_output_dir
     app.dependency_overrides[_get_demo_zip_path] = mock_path_dep
-    app.dependency_overrides[get_zip_creator] = mock_zip_creator
+    app.dependency_overrides[_get_zip_creator] = mock_zip_creator
 
     response = client.get(f"{api_route_base}/upload")
     assert response.status_code == 200

--- a/refiner/tests/routes/test_demo.py
+++ b/refiner/tests/routes/test_demo.py
@@ -1,16 +1,84 @@
+import asyncio
+import os
 import pathlib
+import time
 from typing import Any
 
 import pytest
 from fastapi import Response
 from fastapi.testclient import TestClient
 
-from app.api.v1.demo import _get_file_size_difference_percentage
+from app.api.v1.demo import (
+    _cleanup_expired_files,
+    _create_refined_ecr_zip,
+    _get_file_size_difference_percentage,
+    _get_processed_ecr_directory,
+    _update_file_store,
+    file_store,
+)
 from app.main import app
 
 client = TestClient(app)
 
 api_route_base = "/api/v1/demo"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_files(tmp_path):
+    async def _run_cleanup_once():
+        await asyncio.to_thread(_cleanup_expired_files)
+
+    old_file = tmp_path / "should_be_deleted.txt"
+    old_file.write_text("outdated")
+    file_store.clear()
+
+    file_store["delete"] = {
+        "path": str(old_file),
+        "timestamp": time.time() - 180,  # expired
+    }
+
+    await _run_cleanup_once()
+
+    assert "delete" not in file_store
+    assert not old_file.exists()
+
+
+def test_create_refined_ecr_zip(tmp_path):
+    file_name, file_path, token = _create_refined_ecr_zip(
+        "<eICR>", "<RR>", output_dir=tmp_path
+    )
+    assert file_name == f"{token}_refined_ecr.zip"
+    assert pathlib.Path(file_path).exists()
+    os.remove(file_path)
+
+
+def test_get_processed_ecr_directory(tmp_path):
+    result = _get_processed_ecr_directory(tmp_path / "refined-ecr")
+
+    assert result.exists()
+    assert result.name == "refined-ecr"
+    assert result.parent == tmp_path
+
+
+def test_update_file_store():
+    # Setup for testing
+    file_store.clear()
+    filename = "report.zip"
+    path = pathlib.Path("tmp") / filename
+    token = "example-token"
+
+    before = time.time()
+    _update_file_store(filename, path, token)
+    after = time.time()
+
+    entry = file_store[token]
+
+    # Check expected attributes in the dict
+    assert entry["filename"] == filename
+    assert entry["path"] == path
+
+    # Ensure timestamp is in the middle
+    assert before <= entry["timestamp"] <= after
 
 
 @pytest.mark.parametrize(
@@ -37,13 +105,17 @@ def test_demo_upload_success(test_assets_path: pathlib.Path) -> None:
     Test successful demo file upload and processing
     """
 
-    from app.api.v1.demo import _get_demo_zip_path
+    from app.api.v1.demo import _get_demo_zip_path, get_zip_creator
 
     def mock_path_dep() -> pathlib.Path:
         return test_assets_path / "demo" / "monmothma.zip"
 
+    def mock_zip_creator():
+        return lambda refined, unrefined, path: ("fake", pathlib.Path("fake"), "fake")
+
     # Use the actual function reference, not a string
     app.dependency_overrides[_get_demo_zip_path] = mock_path_dep
+    app.dependency_overrides[get_zip_creator] = mock_zip_creator
 
     response = client.get(f"{api_route_base}/upload")
     assert response.status_code == 200


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds the ability to allow users to download their refined eCR at the end of the demo flow. The API's `/demo/upload` will now do the following:

1. Refine the eCR located on the server (`monmothma.zip`)
2. Generate a unique token
3. Create and store a refined zip file at (`/refined-ecr/{token}`
4. Store the token and information about the saved file (used for handling file retrieval and expiration)
5. Provide the token as part of the API's response (`refined_download_token`)

These files are stored on the application server itself and must be cleaned up. This will be handled by `run_expired_file_cleanup_task()`, which runs as an async task. This is configured on startup by utilizing FastAPI's `lifespan`.

## 🔗 Related Issue

Fixes #41 

## ✅ Acceptance Criteria

- [x] Button to download refined eCRs
- [x] Downloads refined eCR zip file of eICR/RR pair(s)

## 🧪 How to test

### Expected case

Navigate through the demo flow until you get to the success page. On the success page you'll see the `Download refined eCR` button. Click it and it should download the zip file in your browser, which will be called `ecr_download.zip`.

![Kapture 2025-05-15 at 15 38 01](https://github.com/user-attachments/assets/132df2ad-fe66-49ac-95cf-51e744100abf)

### Error case

Here's an example of a case where the file does not exist on the server (likely due to being cleaned up):
You can test this yourself by running through the demo flow until the success page and then either:

1. Wait a few minutes for your file to expire and then click the link
2. Delete the `refined-ecr` directory and then click the link

![Kapture 2025-05-15 at 15 39 21](https://github.com/user-attachments/assets/eb94b495-85b4-490c-b5bb-8f17432d42cc)

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
