### PR TITLE
chore: build Docker image and push to ghcr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Docker build
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Test Docker build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-ghcr.yml
+++ b/.github/workflows/docker-build-ghcr.yml
@@ -3,7 +3,7 @@ name: Build and push Refiner image to GHCR
 on:
   push:
     branches:
-      - "**"
+      - main
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker-build-ghcr.yml
+++ b/.github/workflows/docker-build-ghcr.yml
@@ -3,7 +3,7 @@ name: Build and push Refiner image to GHCR
 on:
   push:
     branches:
-      - main
+      - "**"
 
   workflow_dispatch:
     inputs:
@@ -64,7 +64,7 @@ jobs:
           fi
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/docker-build-ghcr.yml
+++ b/.github/workflows/docker-build-ghcr.yml
@@ -4,17 +4,16 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "Dockerfile"
-      - "**/*.py"
-      - ".github/workflows/docker-ghcr.yml"
 
   workflow_dispatch:
     inputs:
       ref:
-        description: "Git ref (branch or tag) to build"
+        description: "Git ref (branch or tag) to build from"
         required: false
         default: main
+      version_tag:
+        description: "Optional Docker tag to use instead of branch name (`1.2.3`)"
+        required: false
 
 jobs:
   build-and-push:
@@ -38,18 +37,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sanitize branch name for tagging
+      - name: Determine Docker tags
         id: vars
         run: |
-          BRANCH_NAME="${{ github.event.inputs.ref || github.ref_name }}"
-          SAFE_TAG=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-          echo "safe_branch=$SAFE_TAG" >> $GITHUB_OUTPUT
+          # Get the branch/ref and version tag
+          REF_NAME="${{ github.event.inputs.ref || github.ref_name }}"
+          VERSION_TAG="${{ github.event.inputs.version_tag }}"
+
+          # Sanitize ref so it's a valid image tag
+          if [ -z "$VERSION_TAG" ]; then
+            TAG=$(echo "$REF_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+          else
+            TAG="$VERSION_TAG"
+          fi
+
+          # If building `main`, include a `latest` tag
+          if [ "$REF_NAME" = "main" ]; then
+            echo "tags=ghcr.io/${{ github.repository_owner }}/dibbs-ecr-refiner:$TAG,ghcr.io/${{ github.repository_owner }}/dibbs-ecr-refiner:latest" >> $GITHUB_OUTPUT
+          else
+            echo "tags=ghcr.io/${{ github.repository_owner }}/dibbs-ecr-refiner:$TAG" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: false
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/dibbs-ecr-refiner:latest
-            ghcr.io/${{ github.repository_owner }}/dibbs-ecr-refiner:${{ steps.vars.outputs.safe_branch }}
+          push: true
+          tags: ${{ steps.vars.outputs.tags }}

--- a/.github/workflows/docker-build-ghcr.yml
+++ b/.github/workflows/docker-build-ghcr.yml
@@ -37,6 +37,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Make repo owner lowercase
+        id: repo
+        run: |
+          echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
       - name: Determine Docker tags
         id: vars
         run: |
@@ -53,9 +58,9 @@ jobs:
 
           # If building `main`, include a `latest` tag
           if [ "$REF_NAME" = "main" ]; then
-            echo "tags=ghcr.io/${{ github.repository_owner }}/dibbs-ecr-refiner:$TAG,ghcr.io/${{ github.repository_owner }}/dibbs-ecr-refiner:latest" >> $GITHUB_OUTPUT
+            echo "tags=ghcr.io/${{ steps.repo.outputs.owner }}/dibbs-ecr-refiner:$TAG,ghcr.io/${{ steps.repo.outputs.owner }}/dibbs-ecr-refiner:latest" >> $GITHUB_OUTPUT
           else
-            echo "tags=ghcr.io/${{ github.repository_owner }}/dibbs-ecr-refiner:$TAG" >> $GITHUB_OUTPUT
+            echo "tags=ghcr.io/${{ steps.repo.outputs.owner }}/dibbs-ecr-refiner:$TAG" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push Docker image

--- a/.github/workflows/docker-build-ghcr.yml
+++ b/.github/workflows/docker-build-ghcr.yml
@@ -3,7 +3,7 @@ name: Build and push Refiner image to GHCR
 on:
   push:
     branches:
-      - main
+      - "**" # change this back to `main`
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker-build-ghcr.yml
+++ b/.github/workflows/docker-build-ghcr.yml
@@ -3,7 +3,7 @@ name: Build and push Refiner image to GHCR
 on:
   push:
     branches:
-      - "**" # change this back to `main`
+      - main
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker-build-ghcr.yml
+++ b/.github/workflows/docker-build-ghcr.yml
@@ -1,0 +1,55 @@
+name: Build and push Refiner image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "Dockerfile"
+      - "**/*.py"
+      - ".github/workflows/docker-ghcr.yml"
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch or tag) to build"
+        required: false
+        default: main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sanitize branch name for tagging
+        id: vars
+        run: |
+          BRANCH_NAME="${{ github.event.inputs.ref || github.ref_name }}"
+          SAFE_TAG=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+          echo "safe_branch=$SAFE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/dibbs-ecr-refiner:latest
+            ghcr.io/${{ github.repository_owner }}/dibbs-ecr-refiner:${{ steps.vars.outputs.safe_branch }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -25,3 +25,5 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       python_runner_version: 3.13
+  run-build:
+    uses: ./.github/workflows/build.yml


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds two GitHub Actions:

1. `docker-build-ghcr.yml` - Upon merge to `main`, builds a container image tagged `main` and `latest`, and pushes it to the refiner's GitHub Container Registry. This job can also be triggered manually to run on any branch. You can also provide a version number if you want to do that. If you don't use a version number, the image tag will be a sanitized version of your branch's name.
2. `build.yml` - This job will run as part of `pipeline.yml` and will build, but not push, the Docker image. This is primarily just a check to make sure the code in the feature branch is buildable without issues.

## 🔗 Related Issue

Fixes #26

## ✅ Acceptance Criteria

- [ ] GitHub Action created to build and push Docker image to container registry
- [ ] Uploads of the new image are available in the container registry after the job runs
- [ ] Should build and push automatically on merge to `main`

## 🧪 How to test

1. See a successful pipeline run [here](https://github.com/CDCgov/dibbs-ecr-refiner/actions/runs/15074417789)
2. See a successful build and push [here](https://github.com/CDCgov/dibbs-ecr-refiner/actions/runs/15070907506)

## ℹ️ Additional Information

When this PR is merged we should see both `main` and `latest` in ghcr.
