### PR TITLE
chore: Remove placeholder observation calculation text from demo success page

### DIFF
--- a/refiner/app/api/v1/demo.py
+++ b/refiner/app/api/v1/demo.py
@@ -201,7 +201,6 @@ async def demo_upload(
                                 xml_files.eicr, refined_eicr
                             )
                         }%",
-                        "Found X observations relevant to the condition(s)",
                     ],
                     "refined_download_token": token,
                 }


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR removes the `Found X observations relevant to the condition(s)` from the demo success page.

## 🔗 Related Issue

Fixes #107 

## ✅ Acceptance Criteria


## 🧪 How to test

1. Go through the demo flow until you make it to the success page
2. Ensure you no longer see any text related to calculating observations

It should look like this:
<img width="1489" alt="image" src="https://github.com/user-attachments/assets/06867255-06c7-40f1-9321-392fb10c752e" />