### PR TITLE
chore: update "how to test" with better defaults

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,7 +49,7 @@ Unit tests
 
 or
 
-Testing the dev environment:
+Testing the application:
 
 1. Run `docker compose up`
 2. Check that both services are up and running with `docker ps`


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

<!--
What changes are being proposed?
-->

Updating this PR template so that the commented out **How to test** section contains two common examples of how we might want to test the application. This will make it easier to continue to have better instructions without having to type them over and over. That way _how to test_ doesn't end up looking like _run docker, check application_
