### PR TITLE
<feat> add splitting eicrs based on reportable conditions 

### DIFF
--- a/client/src/pages/Demo/index.tsx
+++ b/client/src/pages/Demo/index.tsx
@@ -11,7 +11,7 @@ type View = 'run-test' | 'reportable-conditions' | 'success' | 'error';
 export default function Demo() {
   const [view, setView] = useState<View>('run-test');
   const [uploadResponse, setUploadResponse] =
-    useState<DemoUploadResponse | null>(null);
+      useState<DemoUploadResponse | null>(null);
 
   async function runTest() {
     try {
@@ -29,29 +29,31 @@ export default function Demo() {
     setUploadResponse(null);
   }
 
+  console.log(uploadResponse?.refined_outputs[0])
+
   return (
-    <main className="flex min-w-screen flex-col gap-20 px-20 py-10">
-      <LandingPageLink />
-      <div className="flex flex-col items-center justify-center gap-6">
-        {view === 'run-test' && <RunTest onClick={runTest} />}
-        {view === 'reportable-conditions' && uploadResponse && (
-          <ReportableConditions
-            conditions={uploadResponse.reportable_conditions.map(
-              (condition) => condition.displayName
-            )}
-            onClick={() => setView('success')}
-          />
-        )}
-        {view === 'success' && uploadResponse && (
-          <Success
-            unrefinedEicr={uploadResponse.unrefined_eicr}
-            refinedEicr={uploadResponse.refined_eicr}
-            stats={uploadResponse.stats}
-            downloadToken={uploadResponse.refined_download_token}
-          />
-        )}
-        {view === 'error' && <Error onClick={reset} />}
-      </div>
-    </main>
+      <main className="flex min-w-screen flex-col gap-20 px-20 py-10">
+        <LandingPageLink/>
+        <div className="flex flex-col items-center justify-center gap-6">
+          {view === 'run-test' && <RunTest onClick={runTest}/>}
+          {view === 'reportable-conditions' && uploadResponse && (
+              <ReportableConditions
+                  conditions={uploadResponse.reportable_conditions.map(
+                      (condition) => condition.displayName
+                  )}
+                  onClick={() => setView('success')}
+              />
+          )}
+          {view === 'success' && uploadResponse && uploadResponse.refined_outputs.length > 0 && (
+              <Success
+                  unrefinedEicr={uploadResponse.unrefined_eicr}
+                  refinedEicr={uploadResponse.refined_outputs[0].refined_eicr}
+                  stats={uploadResponse.refined_outputs[0].stats}
+                  downloadToken={uploadResponse.refined_outputs[0].refined_download_token}
+              />
+          )}
+          {view === 'error' && <Error onClick={reset}/>}
+        </div>
+      </main>
   );
 }

--- a/client/src/services/demo.ts
+++ b/client/src/services/demo.ts
@@ -6,12 +6,18 @@ export class ApiUploadError extends Error {
   }
 }
 
+export interface RefinedOutput {
+  refined_eicr: string;
+  reportable_condition: Condition;
+  refined_download_token: string;
+  output_file_name: string;
+  stats: string[];
+}
+
 export interface DemoUploadResponse {
   unrefined_eicr: string;
-  refined_eicr: string;
-  stats: string[];
-  refined_download_token: string;
   reportable_conditions: Condition[];
+  refined_outputs: RefinedOutput[];
 }
 
 type Condition = {

--- a/refiner/app/services/refine.py
+++ b/refiner/app/services/refine.py
@@ -1,7 +1,9 @@
 import logging
 
+from copy import deepcopy
 from lxml import etree
 from lxml.etree import _Element
+from typing import Any
 
 from ..core.exceptions import (
     ConditionCodeError,
@@ -200,7 +202,7 @@ def refine_eicr(
 
         # dictionary that will hold the section processing instructions
         # this is based on the combination of parameters passed to `refine`
-        # as well as deails from REFINER_DETAILS
+        # as well as details from REFINER_DETAILS
         section_processing = dict(REFINER_DETAILS["sections"].items())
 
         namespaces = {"hl7": "urn:hl7-org:v3"}
@@ -638,3 +640,30 @@ def _create_minimal_section(section: _Element) -> None:
 
     # add nullFlavor="NI" to the <section> element
     section.attrib["nullFlavor"] = "NI"
+
+def build_condition_eicr_pairs(
+    parsed_eicr: etree._Element,
+    reportable_conditions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Generate pairs of reportable conditions and a deepcopy of the original eICR XML.
+
+    Each reportable condition gets its own copy of the eICR document so that
+    condition-specific refinement can be performed independently.
+
+    Args:
+        parsed_eicr (etree._Element): The original parsed eICR XML document.
+        reportable_conditions (list[dict]): List of reportable condition objects with 'code' keys.
+
+    Returns:
+        list[dict[str, Any]]: A list of dictionaries, each containing a `reportable_condition` and `eicr_copy`.
+    """
+    condition_eicr_pairs = []
+
+    for condition in reportable_conditions:
+        condition_eicr_pairs.append({
+            "reportable_condition": condition,
+            "eicr_copy": deepcopy(parsed_eicr),
+        })
+
+    return condition_eicr_pairs


### PR DESCRIPTION

# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

<!--
What changes are being proposed?
-->

- Update to split eicr based on reportable condition 
- Update frontend to accept new data
- Update frontend to display first item in map until dropdown selector is connected 

## 🔗 Related Issue

<!--
add the issue number in both places:
Fixes #3
- #3
-->

Fixes #102 
- #102 

## ✅ Acceptance Criteria

<!--
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
-->

- For each reportable condition in the RR, a new eICR object will be created and scoped to a single condition
- For each new eICR object created, the original RR document will be paired with it
- The refine function should make the original eICR/RR pair and all newly created eICR/RR pairs available for future usage

## 🧪 How to test

Testing the application:

1. Run `docker compose up`
2. Check that both services are up and running with `docker ps`
3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
4. You should be able to run the test and see a refined ecr 


## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
