### PR TITLE
feat(refine): implement reportable condition extraction per RR spec

### DIFF
--- a/refiner/app/services/refine.py
+++ b/refiner/app/services/refine.py
@@ -83,22 +83,31 @@ def validate_sections_to_include(
 
 def get_reportable_conditions(root: _Element) -> list[dict[str, str]] | None:
     """
-    Get SNOMED CT codes and display names from the Report Summary section.
+    Get reportable conditions from the Report Summary section.
 
-    Scan the Report Summary section for SNOMED CT codes and return
-    them as a comma-separated string, or None if none found.
+    Following RR spec 1.1 structure:
+    - Summary Section (55112-7) contains exactly one RR11 organizer
+    - RR11 Coded Information Organizer contains condition observations
+    - Each observation must have:
+      - Template ID 2.16.840.1.113883.10.20.15.2.3.12
+      - RR1 determination code with RRVS1 value for reportable conditions
+      - SNOMED CT code in value element (codeSystem 2.16.840.1.113883.6.96)
 
     Args:
         root: The root element of the XML document to parse.
 
     Returns:
-        str | None: Comma-separated SNOMED CT codes or None if none found.
+        list[dict[str, str]] | None: List of reportable conditions or None if none found.
+        Each condition is a dict with 'code' and 'displayName' keys.
 
     Raises:
-        XMLParsingError
+        StructureValidationError: If RR11 Coded Information Organizer is missing (invalid RR)
+        XMLParsingError: If XPath evaluation fails
     """
+
     conditions = []
 
+    # standard CDA namespace declarations required for RR documents
     namespaces = {
         "cda": "urn:hl7-org:v3",
         "sdtc": "urn:hl7-org:sdtc",
@@ -107,22 +116,65 @@ def get_reportable_conditions(root: _Element) -> list[dict[str, str]] | None:
     }
 
     try:
-        # find sections with loinc code 55112-7
-        for section in root.xpath(
-            ".//cda:section[cda:code/@code='55112-7']", namespaces=namespaces
-        ):
-            # Find all value elements with the specified codeSystem
-            values = section.xpath(
-                ".//cda:value[@codeSystem='2.16.840.1.113883.6.96']",
+        # the summary section (55112-7) must contain exactly one RR11 organizer
+        # this is specified in the RR IG
+        coded_info_organizers = root.xpath(
+            ".//cda:section[cda:code/@code='55112-7']"
+            "//cda:entry/cda:organizer[cda:code/@code='RR11']",
+            namespaces=namespaces,
+        )
+
+        # if there is no coded information organizer then the RR is not valid
+        # this would be a major problem
+        if not coded_info_organizers:
+            raise StructureValidationError(
+                message="Missing required RR11 Coded Information Organizer",
+                details={
+                    "document_type": "RR",
+                    "error": "RR11 organizer with cardinality 1..1 not found in Summary Section",
+                },
+            )
+
+        # we can safely take [0] because cardinality is 1..1
+        coded_info_organizer = coded_info_organizers[0]
+
+        # find all condition observations using the specified templateId
+        # This templateId is fixed in the RR spec and identifies condition observations
+        observations = coded_info_organizer.xpath(
+            ".//cda:observation[cda:templateId[@root='2.16.840.1.113883.10.20.15.2.3.12']]",
+            namespaces=namespaces,
+        )
+
+        for observation in observations:
+            # RR1 with value RRVS1 indicates a "reportable" condition
+            # this is how the RR explicitly marks conditions that should be reported
+            # other values like "not reportable" or "may be reportable" are filtered out
+            determination = observation.xpath(
+                ".//cda:observation[cda:code/@code='RR1']/cda:value[@code='RRVS1']",
                 namespaces=namespaces,
             )
-            for value in values:
-                code = value.get("code")
-                display_name = value.get(
-                    "displayName", "Condition display name not found"
+
+            if determination:
+                # per RR spec, each reportable condition observation MUST contain
+                # a valid SNOMED CT code (CONF:3315-552) in its value element
+                # codeSystem 2.16.840.1.113883.6.96 is required for SNOMED CT
+                value = observation.xpath(
+                    ".//cda:value[@codeSystem='2.16.840.1.113883.6.96']",
+                    namespaces=namespaces,
                 )
-                if code:
-                    conditions.append({"code": code, "displayName": display_name})
+                if value:
+                    code = value[0].get("code")
+                    display_name = value[0].get(
+                        "displayName", "Condition display name not found"
+                    )
+                    if code:
+                        # when a condition is reportable, we must capture its
+                        # required SNOMED CT code and display name and build the
+                        # condition object and ensure uniqueness--duplicate conditions
+                        # should not be reported multiple times
+                        condition = {"code": code, "displayName": display_name}
+                        if condition not in conditions:
+                            conditions.append(condition)
 
     except etree.XPathEvalError as e:
         raise XMLParsingError(

--- a/refiner/tests/test_service_refine.py
+++ b/refiner/tests/test_service_refine.py
@@ -349,7 +349,11 @@ def test_get_reportable_conditions_no_codes():
             </component>
         </ClinicalDocument>
     """)
-    assert get_reportable_conditions(root) is None
+
+    with pytest.raises(StructureValidationError) as exc_info:
+        get_reportable_conditions(root)
+
+    assert "Missing required RR11 Coded Information Organizer" in str(exc_info.value)
 
 
 def test_process_section_no_observations():

--- a/refiner/tests/test_service_refine.py
+++ b/refiner/tests/test_service_refine.py
@@ -435,6 +435,31 @@ def test_get_reportable_conditions_uniqueness():
     assert result == expected_conditions
 
 
+def test_get_reportable_conditions_empty_rr11():
+    """
+    Test that RR11 organizer with no qualifying observations returns None.
+    """
+
+    root = etree.fromstring("""
+        <ClinicalDocument xmlns="urn:hl7-org:v3">
+            <component>
+                <section>
+                    <code code="55112-7"/>
+                    <entry>
+                        <organizer>
+                            <code code="RR11"/>
+                            <!-- Empty RR11 organizer -->
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+        </ClinicalDocument>
+    """)
+
+    result = get_reportable_conditions(root)
+    assert result is None
+
+
 def test_process_section_no_observations():
     """
     Test _process_section when no observations are found.


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

<!--
What changes are being proposed?
-->

This change enhances the backend to properly extract truly reportable 
conditions following the RR specification requirements. Key changes:

- Add strict `RR11` container validation (cardinality 1..1)
- Implement `RR1`/`RRVS1` determination checks for true reportability
- Ensure SNOMED CT codes with `displayNames` are properly extracted
- Add deduplication of reportable conditions
- Update tests to verify conformance and reportability logic

The implementation now correctly:
- Only returns conditions marked as reportable via `RR1`/`RRVS1`
- Includes required SNOMED CT codes and `displayNames`
- Maintains established json response structure
- Enforces RR spec conformance requirements
- Prevents duplicate conditions in output

## 🔗 Related Issue

<!--
add the issue number in both places:
Fixes #3
- #3
-->

Fixes #118 
- #118 

## ✅ Acceptance Criteria

<!--
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
-->

- [x] Only conditions that are truly "reportable" (per RR logic) are included in the backend response.
- [x] Each returned condition includes both its SNOMED CT code and displayName.
- [x] The list of conditions returned to the UI contains no duplicates (uniqueness enforced by code).
- [x] The backend maintains the established JSON response structure (a list of objects, each with `code` and `displayName`).
- [x] Tests are updated or added to verify that only unique, reportable conditions are returned in all relevant flows.
- [x] Non-reportable or duplicate conditions are not present in the API payload consumed by the UI.
- [ ] The solution remains extensible for future RR logic enhancements or additional condition metadata.

## 🧪 How to test

<!--
Unit tests

1. From the project root make sure you're in the `refiner/` directory
2. Activate a virtual environment using your tool of choice
3. Make sure that both `requirements.txt` and `requirements-dev.txt` are installed
4. Run the unit tests with `pytest -vv tests/`
5. Additionally you can check coverage with `pytest --cov=app tests`

or

Testing the application:

1. Run `docker compose up`
2. Check that both services are up and running with `docker ps`
3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
4. You should be able to [insert goal you want to accomplish!]
-->

1. Run `docker compose up`
2. Check that both services are up and running with `docker ps`
3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
4. You should be able to now only see the two reportable conditions from our new sample data `.zip`

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->

for the last AC item:

> The solution remains extensible for future RR logic enhancements or additional condition metadata.

I think we should think post-CSTE about an overarching design pattern for how the app works. Maybe a design doc or RFC like we talked about during eng sync today could be worked on