### PR TITLE
style: Demo content updates

### DIFF
--- a/client/src/pages/Demo/ReportableConditions.tsx
+++ b/client/src/pages/Demo/ReportableConditions.tsx
@@ -15,10 +15,10 @@ export function ReportableConditions({
       <Content className="flex flex-col">
         <img className="p-3" src={InformationSvg} alt="Information icon" />
         <div className="flex flex-col items-center gap-10">
-          <div className="flex flex-col gap-6">
+          <div className="flex flex-col items-center gap-6">
             <div className="flex flex-col items-center gap-3">
               <p className="text-center text-xl font-bold text-black">
-                We found the following reportable condition(s):
+                We found the following reportable condition(s) in the RR:
               </p>
               {conditionNames.length > 0 ? (
                 <ul className="list-disc text-xl font-bold text-black">
@@ -28,11 +28,13 @@ export function ReportableConditions({
                 </ul>
               ) : null}
             </div>
-            <div className="flex flex-col items-center gap-2">
+            <div className="flex max-w-[800px] flex-col items-center gap-4 text-center">
               <p>Would you like to refine the eCR?</p>
               <p>
-                Taking this action will retain information relevant only to the
-                conditions listed.
+                Taking this action will split the original eICR into two eICRs,
+                one for each reportable condition, and retain content relevant
+                only to that condition as defined in the TES (see landing page
+                for more details).
               </p>
             </div>
           </div>

--- a/client/src/pages/Demo/RunTest.tsx
+++ b/client/src/pages/Demo/RunTest.tsx
@@ -11,8 +11,13 @@ export function RunTest({ onClick }: RunTestProps) {
       <Content className="flex gap-3">
         <img src={UploadSvg} alt="" className="p-3" />
         <div className="flex flex-col items-center gap-6">
-          <p className="font-normal text-black">
-            We will upload a test file for you to view the refinement results
+          <p className="flex max-w-[500px] flex-col gap-4 text-center font-normal text-black">
+            For this demo, we've provided a synthetic eICR/RR pair to test the
+            Refiner that contains two reportable conditions.
+            <span>
+              The "Run test" button below will upload the test files to the
+              Refiner.
+            </span>
           </p>
           <Button onClick={onClick}>Run test</Button>
           <a

--- a/client/src/pages/Demo/Success.tsx
+++ b/client/src/pages/Demo/Success.tsx
@@ -58,7 +58,7 @@ export function Success({ conditions, downloadToken }: SuccessProps) {
         <Content className="flex flex-col items-start gap-4">
           <div className="flex flex-col">
             <h1 className="!m-0 !p-0 text-xl font-bold text-black">
-              eCR successfully refined!
+              eICR successfully refined!
             </h1>
           </div>
           <div className="flex min-h-full min-w-full flex-col items-center justify-between gap-4 sm:flex-row">

--- a/client/src/pages/Demo/index.test.tsx
+++ b/client/src/pages/Demo/index.test.tsx
@@ -15,7 +15,7 @@ const mockUploadResponse: DemoUploadResponse = {
       display_name: 'mock condition name',
       unrefined_eicr: '<data>tons of data here</data>',
       refined_eicr: '<data>less data</data>',
-      stats: ['eCR reduced by 59%'],
+      stats: ['eICR reduced by 59%'],
     },
   ],
   refined_download_token: 'test-token',
@@ -43,7 +43,7 @@ describe('Demo', () => {
 
     // check that we start on the "run test" page
     const runTestPageText =
-      'We will upload a test file for you to view the refinement results';
+      "For this demo, we've provided a synthetic eICR/RR pair to test the Refiner that contains two reportable conditions.";
     expect(screen.getByText(runTestPageText)).toBeInTheDocument();
 
     // navigate to reportable conditions
@@ -53,16 +53,18 @@ describe('Demo', () => {
 
     // check reportable conditions view
     expect(
-      screen.getByText('We found the following reportable condition(s):')
+      screen.getByText(
+        'We found the following reportable condition(s) in the RR:'
+      )
     ).toBeInTheDocument();
     expect(screen.getByText('mock condition name')).toBeInTheDocument();
     await user.click(screen.getByText('Refine eCR', { selector: 'button' }));
 
     // check success page
-    expect(screen.getByText('eCR successfully refined!')).toBeInTheDocument();
+    expect(screen.getByText('eICR successfully refined!')).toBeInTheDocument();
     expect(screen.getByText('tons of data here')).toBeInTheDocument();
     expect(screen.getByText('less data')).toBeInTheDocument();
-    expect(screen.getByText('eCR reduced by 59%')).toBeInTheDocument();
+    expect(screen.getByText('eICR reduced by 59%')).toBeInTheDocument();
   });
 
   it('should navigate to the error view when the upload request fails', async () => {

--- a/client/src/pages/Home/index.tsx
+++ b/client/src/pages/Home/index.tsx
@@ -73,7 +73,7 @@ function HowItWorks() {
             The Refiner splits the original eICR into child eICRs - one per
             reportable condition in the RR - and applies a filter that retains
             only the information associated with the relevant clinical concept
-            codes identified in the TES.
+            codes identified in the TES for that condition.
           </p>
         </li>
       </ol>

--- a/refiner/app/api/v1/demo.py
+++ b/refiner/app/api/v1/demo.py
@@ -198,7 +198,7 @@ async def demo_upload(
                     "unrefined_eicr": xml_files.eicr,
                     "refined_eicr": refined_eicr,
                     "stats": [
-                        f"eCR file size reduced by {
+                        f"eICR file size reduced by {
                             _get_file_size_difference_percentage(
                                 xml_files.eicr, refined_eicr
                             )


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

The following content changes have been made:

- (Landing Page) On the landing page, would like the 3rd "How it works" section to read: "The Refiner splits the original eICR into child eICRs - one per reportable condition in the RR - and applies a filter that retains only the information associated with the relevant clinical concept codes identified in the TES for that condition." (bold bit is new)
- (Run Test File Page) Would like the upload test file copy to read: "For this demo, we’ve provided a synthetic eICR/RR pair to test the Refiner that contains two reportable conditions. The "Run test" button below will upload the test files to the Refiner.”
- (Reportable Condition and Refinement Page) Would like the copy on this page to read: "We found the following reportable condition(s) in the RR:", followed by the reportable conditions, followed by "Would you like to refine the eICR?", then on the next line: "Taking this action will split the original eICR into two eICRs, one for each reportable condition, and retain content relevant only to that condition as defined in the TES (see landing page for more details)"
- (Results/Metrics Page) Would like to replace mentions of eCR with eICR to be more accurate to what's happening: "eICR successfully refined!" and "eICR file size reduced by XX%"

## 🧪 How to test

1. Run `docker compose up`
2. Check that both services are up and running with `docker ps`
3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
4. You should be able to see the new content listed above on each of the pages