### PR TITLE
docs(refiner): Update the diagram & link to steps;

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The linter can be run two different ways: either manually via the `ruff` command
 
 ### Manually
 
-1. Activate the `refiner` virtual environment (steps listed [here](./api/refiner/README.md#running-from-python-source-code))
+1. Activate the `refiner` virtual environment (steps listed [here](./refiner/README.md#running-from-python-source-code))
 2. Install dev dependencies with `pip install -r requirements.txt -r requirements-dev.txt`
 3. Run any `ruff` command you'd like (see [here](https://docs.astral.sh/ruff/linter/))
 

--- a/refiner/README.md
+++ b/refiner/README.md
@@ -64,8 +64,8 @@ subgraph service[REST API Service]
 direction TB
 subgraph mr["fab:fa-docker container"]
 refiner["fab:fa-python <code>message-refiner<br>HTTP:8080/</code>"]
+refiner <==> db["fas:fa-database SQLite DB"]
 end
-mr <==> db["fas:fa-database SQLite DB"]
 end
 
 subgraph response["Responses"]

--- a/refiner/README.md
+++ b/refiner/README.md
@@ -65,10 +65,7 @@ direction TB
 subgraph mr["fab:fa-docker container"]
 refiner["fab:fa-python <code>message-refiner<br>HTTP:8080/</code>"]
 end
-subgraph tcr["fab:fa-docker container"]
-tcr-service["fab:fa-python <code>trigger-code-reference<br>HTTP:8081/</code>"] <==> db["fas:fa-database SQLite DB"]
-end
-mr <==> |<code>/get-value-sets</code>| tcr
+mr <==> db["fas:fa-database SQLite DB"]
 end
 
 subgraph response["Responses"]


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

The Trigger Code Reference service was removed as a dependency in #19 and
relevant code was integrated into the `refiner/app/db.py` file.

## 🔗 Related Issue

- #19
- an inter-team communication were the catalysts for this change.

Fixes #

- `n/a`

## ✅ Acceptance Criteria

The Mermaid diagram for the software architecture doesn't contain a Trigger
Code Reference service container reference any more. And the linking from the
root `README.md` references the `refiner/README.md` correctly.

## 🧪 How to test

Verify that the changes under the AC above are present in the repository.

## ℹ️ Additional Information

- [Question about whether our team uses the TCR service container 🔒](https://skylight-hq.slack.com/archives/C08H7EV6M37/p1750776980718729)
