### PR TITLE
refactor(refine): Update search and filter logic with XPath; update HTML table output

### DIFF
--- a/refiner/app/services/refine.py
+++ b/refiner/app/services/refine.py
@@ -868,21 +868,19 @@ def _extract_clinical_data(
     clinical_element: _Element,
 ) -> dict[str, str | bool | None]:
     """
-    Extract data from a clinical element.
+    Extract basic data from a clinical element.
 
-    The is_trigger_code field is determined during the two-step processing:
-    1. Element must first pass contextual filtering (SNOMED condition match)
-    2. Then checked for trigger code template ancestry within that context
+    Extracts display text, code, and code system from clinical elements.
 
-    This approach ensures trigger codes are only identified among clinically
-    relevant elements, not as standalone artifacts.
+    * Note: Trigger code status is handled separately through the trigger_analysis
+      dictionary in the section processing pipeline.
 
     Args:
         clinical_element: The clinical element to extract data from.
 
     Returns:
-        dict[str, str | bool]: Dictionary containing the extracted clinical data
-                               with display_text, code, code_system and is_trigger_code.
+        dict[str, str | None]: Dictionary containing the extracted clinical data
+                               with display_text, code, and code_system.
     """
 
     # find the code element
@@ -910,15 +908,10 @@ def _extract_clinical_data(
         if isinstance(code_system_raw, str):
             code_system = code_system_raw
 
-    # NOTE: _is_trigger_code is determined during processing via trigger_analysis
-    # The getattr here provides a fallback for any elements that might have
-    # the attribute set directly, but the primary mechanism is the two-step
-    # filtering process in _process_section
     return {
         "display_text": display_text,
         "code": code,
         "code_system": code_system,
-        "is_trigger_code": getattr(clinical_element, "_is_trigger_code", False),
     }
 
 

--- a/refiner/eCR-CDA-Notes.md
+++ b/refiner/eCR-CDA-Notes.md
@@ -635,31 +635,11 @@ This maintains consistency through the entire eCR process while ensuring standar
 
 The refiner processes eICR documents by:
 
-1. **Condition Code Input**: Takes SNOMED condition codes from RR reportable conditions
-2. **Clinical Code Lookup**: Uses the terminology database to find related clinical codes via ProcessedGrouper
+1. **Condition Code Input**: Takes SNOMED condition codes from RR reportability response's coded information organizer
+2. **Clinical Code Lookup**: Uses the terminology database (based on APHL's Terminology Exchange Service) to find related clinical codes via `ProcessedGrouper`
 3. **XPath Generation**: Builds XPath expressions to locate matching clinical elements
 4. **Section Processing**: For each section, preserves only entries that contain matching codes
 5. **Minimal Sections**: Sections with no matches get replaced with minimal content and `nullFlavor="NI"`
-
-### ProcessedGrouper Integration
-
-The `ProcessedGrouper` class bridges condition codes to clinical codes:
-
-```python
-# Example: COVID-19 condition code
-condition_code = "840539006"  # SARS-CoV-2 disease
-
-# ProcessedGrouper finds related clinical codes from terminology database
-processed = ProcessedGrouper.from_grouper_row(grouper_row)
-xpath = processed.build_xpath("any")  # Generates XPath for all element types
-```
-
-### Section Filtering Rules
-
-* **Sections to Include**: If specified, these sections are preserved completely unmodified
-* **Other Sections**: Filtered to keep only entries with matching clinical codes
-* **No Matches**: Section becomes minimal with `nullFlavor="NI"`
-* **Entry Preservation**: Complete `<entry>` elements are kept (not individual codes)
 
 ### XPath Strategy
 
@@ -693,10 +673,5 @@ How does it do this?
 - **Flexible**: Automatically finds codes in any CDA element type without hardcoding
 - **Comprehensive**: Catches direct codes, child codes, and translations
 - **Future-proof**: Will work with new CDA element types as they're added
-
-The `ProcessedGrouper` uses `search_in="any"` for comprehensive matching, ensuring all condition-related clinical data is captured regardless of which CDA element contains it.
-
-**Backward Compatibility:**
-The system maintains `search_in="observation"` for legacy behavior that only searches observation elements.
 
 This ensures all relevant clinical data related to the condition is preserved while removing unrelated entries.

--- a/refiner/eCR-CDA-Notes.md
+++ b/refiner/eCR-CDA-Notes.md
@@ -628,3 +628,75 @@ Using COVID-19 example:
 ```
 
 This maintains consistency through the entire eCR process while ensuring standardized terminology and proper determination of reportability.
+
+## Refiner Processing Logic
+
+### How the Refiner Works
+
+The refiner processes eICR documents by:
+
+1. **Condition Code Input**: Takes SNOMED condition codes from RR reportable conditions
+2. **Clinical Code Lookup**: Uses the terminology database to find related clinical codes via ProcessedGrouper
+3. **XPath Generation**: Builds XPath expressions to locate matching clinical elements
+4. **Section Processing**: For each section, preserves only entries that contain matching codes
+5. **Minimal Sections**: Sections with no matches get replaced with minimal content and `nullFlavor="NI"`
+
+### ProcessedGrouper Integration
+
+The `ProcessedGrouper` class bridges condition codes to clinical codes:
+
+```python
+# Example: COVID-19 condition code
+condition_code = "840539006"  # SARS-CoV-2 disease
+
+# ProcessedGrouper finds related clinical codes from terminology database
+processed = ProcessedGrouper.from_grouper_row(grouper_row)
+xpath = processed.build_xpath("any")  # Generates XPath for all element types
+```
+
+### Section Filtering Rules
+
+* **Sections to Include**: If specified, these sections are preserved completely unmodified
+* **Other Sections**: Filtered to keep only entries with matching clinical codes
+* **No Matches**: Section becomes minimal with `nullFlavor="NI"`
+* **Entry Preservation**: Complete `<entry>` elements are kept (not individual codes)
+
+### XPath Strategy
+
+The refiner uses union XPath expressions to find clinical elements:
+
+```xpath
+.//hl7:*[hl7:code[@code='123456' or @code='789012']] |
+.//hl7:code[@code='123456' or @code='789012'] |
+.//hl7:translation[@code='123456' or @code='789012']
+```
+
+Element Types Searched:
+
+* **Observations**: Lab results, vital signs, clinical findings
+* **Organizers**: Result batteries, procedure groups
+* **Acts**: Procedures, encounters, administrative acts
+* **Manufactured Products**: Medications, vaccines, medical devices
+* **Substance Administrations**: Medication administrations, immunizations
+
+How does it do this?
+
+**Search Patterns:**
+- **`hl7:*[hl7:code[...]]`**: Any HL7 element that has a `<code>` child with matching codes
+  - Captures `<observation>`, `<act>`, `<organizer>`, `<procedure>`, `<substanceAdministration>`, etc.
+- **`hl7:code[...]`**: Direct `<code>` element matches
+  - Captures standalone code elements
+- **`hl7:translation[...]`**: Code translation elements
+  - Captures alternative code representations
+
+**Why This Works:**
+- **Flexible**: Automatically finds codes in any CDA element type without hardcoding
+- **Comprehensive**: Catches direct codes, child codes, and translations
+- **Future-proof**: Will work with new CDA element types as they're added
+
+The `ProcessedGrouper` uses `search_in="any"` for comprehensive matching, ensuring all condition-related clinical data is captured regardless of which CDA element contains it.
+
+**Backward Compatibility:**
+The system maintains `search_in="observation"` for legacy behavior that only searches observation elements.
+
+This ensures all relevant clinical data related to the condition is preserved while removing unrelated entries.

--- a/refiner/scripts/query_terminology_db.py
+++ b/refiner/scripts/query_terminology_db.py
@@ -1,0 +1,275 @@
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+# constants for querying - edit these values as needed
+
+# SNOMED code to query the groupers table
+CONDITION_CODE = "840539006"
+
+# set CODE_TO_SEARCH to None if you just want to view all codes without checking
+# CODE_TO_SEARCH = None
+CODE_TO_SEARCH: dict[str, str] | None = {
+    # options: loinc_codes, snomed_codes, icd10_codes, rxnorm_codes
+    "column": "loinc_codes",
+    # the actual code to search for
+    "code": "34487-9",
+}
+
+
+def connect_to_db() -> tuple[sqlite3.Connection, sqlite3.Cursor]:
+    """
+    Connect to the terminology database.
+
+    Returns:
+        Tuple of database connection and cursor
+    """
+
+    script_dir = Path(__file__).parent
+    project_root = script_dir.parent
+    db_path = project_root / "app" / "terminology.db"
+
+    if not db_path.exists():
+        raise FileNotFoundError(f"Database not found at {db_path}")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    return conn, cursor
+
+
+def fetch_grouper_by_condition(
+    cursor: sqlite3.Cursor, condition_code: str
+) -> dict[str, Any] | None:
+    """
+    Fetch a grouper record by its condition code.
+
+    Args:
+        cursor: Database cursor for executing queries
+        condition_code: The condition code to search for
+
+    Returns:
+        Dictionary with the grouper data or None if not found
+    """
+
+    cursor.execute(
+        """
+        SELECT condition, display_name, loinc_codes, snomed_codes, icd10_codes, rxnorm_codes
+        FROM groupers
+        WHERE condition = ?
+        """,
+        (condition_code,),
+    )
+
+    row = cursor.fetchone()
+    if not row:
+        return None
+
+    return {
+        "condition": row[0],
+        "display_name": row[1],
+        "loinc_codes": json.loads(row[2]) if row[2] else [],
+        "snomed_codes": json.loads(row[3]) if row[3] else [],
+        "icd10_codes": json.loads(row[4]) if row[4] else [],
+        "rxnorm_codes": json.loads(row[5]) if row[5] else [],
+    }
+
+
+def check_for_code_in_column(
+    grouper_data: dict[str, Any], code_info: dict[str, str]
+) -> bool:
+    """
+    Check if a specific code exists in the specified column of the grouper.
+
+    Args:
+        grouper_data: Dictionary with grouper data
+        code_info: Dictionary with column and code to search for
+
+    Returns:
+        True if code is found, False otherwise
+    """
+
+    column = code_info["column"]
+    code_to_find = code_info["code"]
+
+    if column not in grouper_data:
+        return False
+
+    codes = grouper_data[column]
+
+    # check in the code array
+    for code_obj in codes:
+        # handle different possible structures
+        if (
+            isinstance(code_obj, dict)
+            and "code" in code_obj
+            and code_obj["code"] == code_to_find
+        ):
+            return True
+        elif isinstance(code_obj, str) and code_obj == code_to_find:
+            return True
+
+    return False
+
+
+def create_code_details_table(code_type: str, codes: list[dict[str, Any]]) -> Table:
+    """
+    Create a Rich table to display code details.
+
+    Args:
+        code_type: Type of the codes (LOINC, SNOMED, etc.)
+        codes: List of code objects
+
+    Returns:
+        Rich Table object
+    """
+    table = Table(title=f"{code_type} Codes")
+
+    # determine columns based on first code object
+    if not codes:
+        table.add_column("No codes found", style="red")
+        return table
+
+    # add columns based on the keys in the first code object
+    first_code = codes[0]
+    if isinstance(first_code, dict):
+        for key in first_code.keys():
+            table.add_column(key.capitalize(), style="cyan")
+
+        # add rows for each code
+        for code_obj in codes:
+            table.add_row(*[str(code_obj.get(key, "")) for key in first_code.keys()])
+    else:
+        # simple string codes
+        table.add_column("Code", style="cyan")
+        for code in codes:
+            table.add_row(str(code))
+
+    return table
+
+
+def display_grouper_details(grouper_data: dict[str, Any], console: Console) -> None:
+    """
+    Display detailed information about a grouper.
+
+    Args:
+        grouper_data: Dictionary with grouper data
+        console: Rich console for output formatting
+    """
+
+    console.print(
+        f"\n[bold green]Grouper Details for Condition: [cyan]{grouper_data['condition']}[/cyan][/bold green]"
+    )
+    console.print(f"Display Name: [yellow]{grouper_data['display_name']}[/yellow]")
+
+    # show code counts
+    counts_table = Table(title="Code Counts")
+    counts_table.add_column("Code Type", style="blue")
+    counts_table.add_column("Count", style="magenta", justify="right")
+
+    for code_type in ["loinc_codes", "snomed_codes", "icd10_codes", "rxnorm_codes"]:
+        display_name = code_type.replace("_codes", "").upper()
+        count = len(grouper_data[code_type])
+        counts_table.add_row(display_name, str(count))
+
+    console.print(counts_table)
+
+    # display each code type in detail
+    for code_type, codes in [
+        ("LOINC", grouper_data["loinc_codes"]),
+        ("SNOMED", grouper_data["snomed_codes"]),
+        ("ICD-10", grouper_data["icd10_codes"]),
+        ("RxNorm", grouper_data["rxnorm_codes"]),
+    ]:
+        if codes:
+            console.print(f"\n[bold blue]{code_type} Codes ({len(codes)})[/bold blue]")
+            console.print(create_code_details_table(code_type, codes))
+
+
+def search_for_specific_code(
+    grouper_data: dict[str, Any], code_info: dict[str, str], console: Console
+) -> None:
+    """
+    Search for a specific code in the grouper data and display the result.
+
+    Args:
+        grouper_data: Dictionary with grouper data
+        code_info: Dictionary with column and code to search for
+        console: Rich console for output formatting
+    """
+
+    column = code_info["column"]
+    code = code_info["code"]
+
+    # get readable column name
+    column_display = column.replace("_codes", "").upper()
+
+    found = check_for_code_in_column(grouper_data, code_info)
+
+    if found:
+        console.print(
+            f"\n[bold green]✓ Code [cyan]{code}[/cyan] FOUND in {column_display} codes[/bold green]"
+        )
+
+        # find and display the specific code details
+        codes = grouper_data[column]
+        matching_codes = []
+
+        for code_obj in codes:
+            if (
+                isinstance(code_obj, dict)
+                and "code" in code_obj
+                and code_obj["code"] == code
+            ):
+                matching_codes.append(code_obj)
+            elif isinstance(code_obj, str) and code_obj == code:
+                matching_codes.append(code_obj)
+
+        if matching_codes:
+            console.print("\n[bold blue]Matching Code Details:[/bold blue]")
+            console.print(json.dumps(matching_codes, indent=2))
+    else:
+        console.print(
+            f"\n[bold red]✗ Code [cyan]{code}[/cyan] NOT FOUND in {column_display} codes[/bold red]"
+        )
+
+
+def main() -> None:
+    """
+    Main function to run the script.
+    """
+
+    console = Console()
+    console.print("[bold blue]Terminology Database Query Tool[/bold blue]")
+
+    try:
+        conn, cursor = connect_to_db()
+
+        # fetch grouper by condition code
+        grouper_data = fetch_grouper_by_condition(cursor, CONDITION_CODE)
+
+        if not grouper_data:
+            console.print(
+                f"[bold red]No grouper found with condition code: {CONDITION_CODE}[/bold red]"
+            )
+            return
+
+        # display grouper details
+        display_grouper_details(grouper_data, console)
+
+        # check for specific code if requested
+        if CODE_TO_SEARCH:
+            search_for_specific_code(grouper_data, CODE_TO_SEARCH, console)
+
+    except Exception as e:
+        console.print(f"[bold red]Error: {str(e)}[/bold red]")
+    finally:
+        if "conn" in locals():
+            conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/refiner/tests/test_service_refine.py
+++ b/refiner/tests/test_service_refine.py
@@ -9,11 +9,11 @@ from app.core.exceptions import (
 )
 from app.core.models.types import XMLFiles
 from app.services.refine import (
-    CLINICAL_DATA_TABLE_HEADERS,  # Changed from OBSERVATION_TABLE_HEADERS
+    CLINICAL_DATA_TABLE_HEADERS,
     MINIMAL_SECTION_MESSAGE,
     REFINER_OUTPUT_TITLE,
     _create_or_update_text_element,
-    _extract_clinical_data,  # Changed from _extract_observation_data
+    _extract_clinical_data,
     _find_path_to_entry,
     _get_section_by_code,
     _process_section,
@@ -158,7 +158,7 @@ def test_prune_unwanted_siblings(xml_content, xpath, expected_entry_count):
     paths = [_find_path_to_entry(elem) for elem in matching_clinical_elements]
 
     # call with the section element (element is the section in this case)
-    _prune_unwanted_siblings(paths, matching_clinical_elements, element)
+    _prune_unwanted_siblings(paths, element)
 
     # verify the result
     remaining_entries = _get_entries_for_section(element)
@@ -522,7 +522,7 @@ def test_build_condition_eicr_pairs(sample_xml_files: XMLFiles):
     # verify each pair has the expected structure
     for i, pair in enumerate(pairs):
         assert "reportable_condition" in pair
-        assert "xml_files" in pair  # Changed from "eicr_copy"
+        assert "xml_files" in pair
         assert pair["reportable_condition"] == reportable_conditions[i]
 
         # verify the xml_files is a proper XMLFiles object

--- a/refiner/tests/test_service_refine.py
+++ b/refiner/tests/test_service_refine.py
@@ -2,20 +2,25 @@ from typing import Any
 
 import pytest
 from lxml import etree
+from lxml.etree import _Element
 
 from app.core.exceptions import (
     ConditionCodeError,
     StructureValidationError,
+    XMLParsingError,
 )
 from app.core.models.types import XMLFiles
 from app.services.refine import (
     CLINICAL_DATA_TABLE_HEADERS,
     MINIMAL_SECTION_MESSAGE,
     REFINER_OUTPUT_TITLE,
+    _analyze_trigger_codes_in_context,
     _create_or_update_text_element,
     _extract_clinical_data,
+    _find_condition_relevant_elements,
     _find_path_to_entry,
     _get_section_by_code,
+    _preserve_relevant_entries_and_generate_summary,
     _process_section,
     _prune_unwanted_siblings,
     build_condition_eicr_pairs,
@@ -25,15 +30,20 @@ from app.services.refine import (
 
 from .conftest import NAMESPACES
 
+# NOTE:
+# TEST FIXTURES AND SETUP
+
 
 @pytest.fixture(scope="session")
-def xml_test_setup(read_test_xml):
+def xml_test_setup(read_test_xml) -> dict[str, Any | _Element | None]:
     """
     Setup XML elements for testing section processing.
     """
 
-    test_message = read_test_xml("mon-mothma-covid-lab-positive_eicr.xml")
-    structured_body = test_message.find(".//{urn:hl7-org:v3}structuredBody", NAMESPACES)
+    test_message: Any = read_test_xml("mon-mothma-covid-lab-positive_eicr.xml")
+    structured_body: Any = test_message.find(
+        ".//{urn:hl7-org:v3}structuredBody", NAMESPACES
+    )
 
     return {
         "structured_body": structured_body,
@@ -46,27 +56,23 @@ def xml_test_setup(read_test_xml):
 @pytest.fixture(scope="session")
 def clinical_test_data(
     xml_test_setup,
-) -> dict[str, str | Any | None]:  # Renamed from observation_test_data
+) -> dict[str, str | Any | None]:
     """
     Setup clinical test data for section processing.
     """
 
     # use a simple XPath to find clinical elements with specific codes
-    clinical_xpath = './/hl7:observation[hl7:code[@code="94310-0"]]'  # Renamed from observation_xpath
+    clinical_xpath = './/hl7:observation[hl7:code[@code="94310-0"]]'
 
     # use direct XPath instead of _get_observations
-    clinical_elements = xml_test_setup[
-        "results_section"
-    ].xpath(  # Renamed from observations
+    clinical_elements: Any = xml_test_setup["results_section"].xpath(
         clinical_xpath, namespaces=NAMESPACES
     )
 
     return {
         "xpath": clinical_xpath,
-        "clinical_elements": clinical_elements,  # Renamed from observations
-        "single_clinical_element": clinical_elements[0]
-        if clinical_elements
-        else None,  # Renamed from single_observation
+        "clinical_elements": clinical_elements,
+        "single_clinical_element": clinical_elements[0] if clinical_elements else None,
     }
 
 
@@ -94,209 +100,20 @@ def _get_entries_for_section(
         list[etree.Element]: List of <entry> elements in the section
     """
 
-    entries = section.xpath(".//hl7:entry", namespaces=namespaces)
+    entries: Any = section.xpath(".//hl7:entry", namespaces=namespaces)
     return entries if entries is not None else []
 
 
-def test_find_path_to_entry_no_match():
-    """
-    Test finding path when no match exists.
-    """
-
-    clinical_element = etree.fromstring("""
-        <observation xmlns="urn:hl7-org:v3">
-            <code code="different"/>
-        </observation>
-    """)
-
-    with pytest.raises(StructureValidationError) as exc_info:
-        _find_path_to_entry(clinical_element)
-    assert "Parent <entry> element not found" in str(exc_info.value)
+# NOTE:
+# PUBLIC API FUNCTION TESTS
 
 
-@pytest.mark.parametrize(
-    "xml_content,xpath,expected_entry_count",
-    [
-        (
-            """
-            <section xmlns="urn:hl7-org:v3">
-              <entry>
-                <organizer>
-                  <component>
-                    <observation>
-                      <code code="94310-0"/>
-                    </observation>
-                  </component>
-                </organizer>
-              </entry>
-              <entry>
-                <organizer>
-                  <component>
-                    <observation>
-                      <code code="67890-1"/>
-                    </observation>
-                  </component>
-                </organizer>
-              </entry>
-            </section>
-            """,
-            './/hl7:observation[hl7:code[@code="94310-0"]]',
-            1,
-        ),
-    ],
-)
-def test_prune_unwanted_siblings(xml_content, xpath, expected_entry_count):
-    """
-    Test removal of non-matching sibling entries.
-    """
-
-    # parse the XML string into an element
-    element = etree.fromstring(xml_content)
-
-    # find matching clinical elements using XPath
-    matching_clinical_elements = element.xpath(xpath, namespaces=NAMESPACES)
-    paths = [_find_path_to_entry(elem) for elem in matching_clinical_elements]
-
-    # call with the section element (element is the section in this case)
-    _prune_unwanted_siblings(paths, element)
-
-    # verify the result
-    remaining_entries = _get_entries_for_section(element)
-    assert len(remaining_entries) == expected_entry_count
-
-
-@pytest.mark.parametrize(
-    "clinical_index,expected_data",  # Renamed from observation_index
-    [
-        (
-            0,
-            {
-                "display_text": "SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with probe detection",
-                "code": "94310-0",
-                "code_system": "LOINC",
-                "is_trigger_code": False,  # Always False now
-            },
-        ),
-    ],
-)
-def test_extract_clinical_data(  # Renamed from test_extract_observation_data
-    clinical_test_data,
-    clinical_index,
-    expected_data,  # Updated parameter name
-):
-    """
-    Test extraction of clinical element metadata.
-    """
-
-    clinical_element = clinical_test_data["clinical_elements"][clinical_index]
-    data = _extract_clinical_data(clinical_element)
-    assert data == expected_data
-
-
-def test_create_or_update_text_element(clinical_test_data):
-    """
-    Test creation of text element from clinical elements.
-    """
-
-    # updated function signature to include trigger_code_elements parameter
-    trigger_code_elements = set()  # Empty set for test
-    text_element = _create_or_update_text_element(
-        clinical_test_data["clinical_elements"], trigger_code_elements
-    )
-
-    # verify basic structure
-    assert text_element.tag.endswith("text")
-    assert text_element.find(".//table") is not None
-    assert text_element.find(".//title") is not None
-
-    # verify title contains expected text
-    title = text_element.find(".//title")
-    assert title.text == REFINER_OUTPUT_TITLE
-
-    # verify content
-    table = text_element.find(".//table")
-    rows = table.findall(".//tr")
-    assert len(rows) > 1  # Header row plus at least one data row
-
-    # verify header uses new constants
-    header = rows[0].findall(".//th")
-    assert [
-        h.text for h in header
-    ] == CLINICAL_DATA_TABLE_HEADERS  # Updated constant name
-
-
-@pytest.mark.parametrize(
-    "sections_to_include,condition_codes,expected_in_results",
-    [
-        # happy-path: must always provide condition_codes
-        (None, "840539006", True),
-        (["29762-2"], "840539006", True),
-        (["30954-2"], "840539006", True),
-    ],
-)
-def test_refine_eicr(
-    sample_xml_files: XMLFiles,
-    sections_to_include,
-    condition_codes,
-    expected_in_results,
-):
-    """
-    Test eICR refinement with required condition_codes.
-    """
-
-    refined_output = refine_eicr(
-        xml_files=sample_xml_files,
-        sections_to_include=sections_to_include,
-        condition_codes=condition_codes,
-    )
-
-    refined_doc = etree.fromstring(refined_output)
-    refined_structured_body = refined_doc.find(
-        ".//{urn:hl7-org:v3}structuredBody", {"hl7": "urn:hl7-org:v3"}
-    )
-    refined_results_section = _get_section_by_code(refined_structured_body, "30954-2")
-
-    xpath_query = ".//hl7:code"
-    result = bool(
-        refined_results_section.xpath(xpath_query, namespaces={"hl7": "urn:hl7-org:v3"})
-    )
-    assert result == expected_in_results
-
-
-def test_refine_eicr_requires_condition_codes(sample_xml_files: XMLFiles):
-    """
-    Test that refine_eicr raises ConditionCodeError if condition_codes is not provided.
-    """
-
-    with pytest.raises(ConditionCodeError) as excinfo:
-        refine_eicr(
-            xml_files=sample_xml_files,
-            sections_to_include=None,
-            condition_codes=None,
-        )
-    assert "No condition codes provided" in str(excinfo.value)
-
-
-def test_refine_eicr_empty_condition_codes(sample_xml_files: XMLFiles):
-    """
-    Test that refine_eicr raises ConditionCodeError if condition_codes is empty string.
-    """
-
-    with pytest.raises(ConditionCodeError) as excinfo:
-        refine_eicr(
-            xml_files=sample_xml_files,
-            sections_to_include=None,
-            condition_codes="",
-        )
-    assert "No condition codes provided" in str(excinfo.value)
-
-
-def test_get_reportable_conditions_no_codes():
+def test_get_reportable_conditions_no_codes() -> None:
     """
     Test get_reportable_conditions when no codes are found.
     """
 
-    root = etree.fromstring("""
+    root: _Element = etree.fromstring("""
         <ClinicalDocument xmlns="urn:hl7-org:v3">
             <component>
                 <section>
@@ -312,13 +129,13 @@ def test_get_reportable_conditions_no_codes():
     assert "Missing required RR11 Coded Information Organizer" in str(exc_info.value)
 
 
-def test_get_reportable_conditions_uniqueness():
+def test_get_reportable_conditions_uniqueness() -> None:
     """
     Test that get_reportable_conditions returns unique conditions only.
     Uses sample RR with duplicate reportable conditions to verify deduplication.
     """
 
-    root = etree.fromstring("""
+    root: _Element = etree.fromstring("""
         <ClinicalDocument xmlns="urn:hl7-org:v3">
             <component>
                 <section>
@@ -378,25 +195,25 @@ def test_get_reportable_conditions_uniqueness():
         </ClinicalDocument>
     """)
 
-    result = get_reportable_conditions(root)
+    result: list[dict[str, str]] | None = get_reportable_conditions(root)
 
     # verify we get exactly 2 unique conditions
     assert len(result) == 2
 
     # verify the specific conditions are present
-    expected_conditions = [
+    expected_conditions: list[dict[str, str]] = [
         {"code": "840539006", "displayName": "COVID-19"},
         {"code": "27836007", "displayName": "Pertussis"},
     ]
     assert result == expected_conditions
 
 
-def test_get_reportable_conditions_empty_rr11():
+def test_get_reportable_conditions_empty_rr11() -> None:
     """
     Test that RR11 organizer with no qualifying observations returns None.
     """
 
-    root = etree.fromstring("""
+    root: _Element = etree.fromstring("""
         <ClinicalDocument xmlns="urn:hl7-org:v3">
             <component>
                 <section>
@@ -412,16 +229,117 @@ def test_get_reportable_conditions_empty_rr11():
         </ClinicalDocument>
     """)
 
-    result = get_reportable_conditions(root)
+    result: list[dict[str, str]] | None = get_reportable_conditions(root)
     assert result is None
 
 
-def test_process_section_no_clinical_elements():
+@pytest.mark.parametrize(
+    "sections_to_include,condition_codes,expected_in_results",
+    [
+        # happy-path: must always provide condition_codes
+        (None, "840539006", True),
+        (["29762-2"], "840539006", True),
+        (["30954-2"], "840539006", True),
+    ],
+)
+def test_refine_eicr(
+    sample_xml_files: XMLFiles,
+    sections_to_include,
+    condition_codes,
+    expected_in_results,
+) -> None:
+    """
+    Test eICR refinement with required condition_codes.
+    """
+
+    refined_output: str = refine_eicr(
+        xml_files=sample_xml_files,
+        sections_to_include=sections_to_include,
+        condition_codes=condition_codes,
+    )
+
+    refined_doc: _Element = etree.fromstring(refined_output)
+    refined_structured_body: _Element | None = refined_doc.find(
+        path=".//{urn:hl7-org:v3}structuredBody", namespaces={"hl7": "urn:hl7-org:v3"}
+    )
+    refined_results_section = _get_section_by_code(refined_structured_body, "30954-2")
+
+    xpath_query = ".//hl7:code"
+    result: bool = bool(
+        refined_results_section.xpath(
+            _path=xpath_query, namespaces={"hl7": "urn:hl7-org:v3"}
+        )
+    )
+    assert result == expected_in_results
+
+
+def test_refine_eicr_requires_condition_codes(sample_xml_files: XMLFiles):
+    """
+    Test that refine_eicr raises ConditionCodeError if condition_codes is not provided.
+    """
+
+    with pytest.raises(ConditionCodeError) as excinfo:
+        refine_eicr(
+            xml_files=sample_xml_files,
+            sections_to_include=None,
+            condition_codes=None,
+        )
+    assert "No condition codes provided" in str(excinfo.value)
+
+
+def test_refine_eicr_empty_condition_codes(sample_xml_files: XMLFiles) -> None:
+    """
+    Test that refine_eicr raises ConditionCodeError if condition_codes is empty string.
+    """
+
+    with pytest.raises(ConditionCodeError) as excinfo:
+        refine_eicr(
+            xml_files=sample_xml_files,
+            sections_to_include=None,
+            condition_codes="",
+        )
+    assert "No condition codes provided" in str(excinfo.value)
+
+
+def test_build_condition_eicr_pairs(sample_xml_files: XMLFiles) -> None:
+    """
+    Test building condition-eICR pairs with XMLFiles objects.
+    """
+
+    reportable_conditions: list[dict[str, str]] = [
+        {"code": "840539006", "displayName": "COVID-19"},
+        {"code": "27836007", "displayName": "Pertussis"},
+    ]
+
+    pairs: list[dict[str, Any]] = build_condition_eicr_pairs(
+        original_xml_files=sample_xml_files, reportable_conditions=reportable_conditions
+    )
+
+    # verify we get the expected number of pairs
+    assert len(pairs) == 2
+
+    # verify each pair has the expected structure
+    for i, pair in enumerate(pairs):
+        assert "reportable_condition" in pair
+        assert "xml_files" in pair
+        assert pair["reportable_condition"] == reportable_conditions[i]
+
+        # verify the xml_files is a proper XMLFiles object
+        assert isinstance(pair["xml_files"], XMLFiles)
+        assert pair["xml_files"].eicr == sample_xml_files.eicr
+        assert pair["xml_files"].rr == sample_xml_files.rr
+
+
+# NOTE:
+# SECTION PROCESSING TESTS
+
+
+def test_process_section_no_clinical_elements() -> None:
     """
     Test _process_section when no clinical elements are found.
     """
 
-    section = etree.fromstring("""
+    section: _Element = etree.fromstring("""
         <section xmlns="urn:hl7-org:v3">
             <code code="30954-2"/>
         </section>
@@ -430,16 +348,19 @@ def test_process_section_no_clinical_elements():
     # pass empty XPath since no condition codes provided
     _process_section(
         section=section,
-        combined_xpath="",  # Empty XPath means no condition codes
+        # empty XPath means no condition codes
+        combined_xpath="",
         namespaces={"hl7": "urn:hl7-org:v3"},
     )
 
     # verify that a text element was created (minimal section)
-    text_elem = section.find(".//hl7:text", {"hl7": "urn:hl7-org:v3"})
+    text_elem: _Element | None = section.find(
+        path=".//hl7:text", namespaces={"hl7": "urn:hl7-org:v3"}
+    )
     assert text_elem is not None
 
     # verify table with message exists
-    table = text_elem.find("table")
+    table: _Element = text_elem.find(path="table")
     assert table is not None
     assert MINIMAL_SECTION_MESSAGE in table.findtext(".//td")
 
@@ -452,7 +373,7 @@ def test_process_section_with_error():
     Test error handling in _process_section.
     """
 
-    section = etree.fromstring("""
+    section: _Element = etree.fromstring("""
         <section xmlns="urn:hl7-org:v3">
             <code code="invalid"/>
             <entry>
@@ -477,16 +398,569 @@ def test_process_section_with_error():
     assert section.find("{urn:hl7-org:v3}text") is not None
 
     xpath_query = './/hl7:code[@code="nonexistent-code"]'
-    result = section.xpath(xpath_query, namespaces=NAMESPACES)
-    assert not result  # Empty list means no elements found
+    result = section.xpath(_path=xpath_query, namespaces=NAMESPACES)
+    # empty list means no elements found
+    assert not result
 
 
-def test_create_or_update_text_invalid_section():
+def test_find_condition_relevant_elements_with_matches(xml_test_setup) -> None:
+    """
+    Test _find_condition_relevant_elements with matching clinical elements.
+    """
+
+    section: Any = xml_test_setup["results_section"]
+    # use XPath that should find elements in the test data
+    xpath = './/hl7:observation[hl7:code[@code="94310-0"]]'
+
+    result: list[_Element] = _find_condition_relevant_elements(
+        section=section, combined_xpath=xpath, namespaces=NAMESPACES
+    )
+
+    assert isinstance(result, list)
+    assert len(result) > 0
+
+    # verify elements are actually clinical elements
+    for elem in result:
+        assert elem.tag.endswith("observation")
+
+
+def test_process_section_complete_workflow_with_matches(xml_test_setup) -> None:
+    """
+    Test complete _process_section workflow when matches are found.
+    """
+
+    section: Any = xml_test_setup["results_section"]
+    xpath = './/hl7:observation[hl7:code[@code="94310-0"]]'
+
+    _process_section(
+        section=section,
+        combined_xpath=xpath,
+        namespaces=NAMESPACES,
+        section_config=None,
+        version="1.1",
+    )
+
+    # verify section was processed (not minimal)
+    assert section.get("nullFlavor") != "NI"
+
+    # verify text element was updated
+    final_text: Any = section.find(".//hl7:text", namespaces=NAMESPACES)
+    assert final_text is not None
+
+    # verify table structure
+    table: Any = final_text.find("table")
+    assert table is not None
+    rows: Any = table.findall(".//tr")
+    # header + data rows
+    assert len(rows) > 1
+
+
+def test_find_condition_relevant_elements_no_matches(xml_test_setup) -> None:
+    """
+    Test _find_condition_relevant_elements when no elements match.
+    """
+
+    section: Any = xml_test_setup["results_section"]
+    # use XPath that won't match anything
+    xpath = './/hl7:observation[hl7:code[@code="nonexistent-code"]]'
+
+    result: list[_Element] = _find_condition_relevant_elements(
+        section=section, combined_xpath=xpath, namespaces=NAMESPACES
+    )
+
+    assert isinstance(result, list)
+    assert len(result) == 0
+
+
+def test_find_condition_relevant_elements_empty_xpath(xml_test_setup) -> None:
+    """
+    Test _find_condition_relevant_elements with empty XPath.
+    """
+
+    section: Any = xml_test_setup["results_section"]
+
+    # empty XPath should return empty list, not raise exception
+    result: list[_Element] = _find_condition_relevant_elements(
+        section=section, combined_xpath="", namespaces=NAMESPACES
+    )
+
+    assert isinstance(result, list)
+    assert len(result) == 0
+
+    # test whitespace-only XPath too
+    result_whitespace: list[_Element] = _find_condition_relevant_elements(
+        section=section, combined_xpath="   ", namespaces=NAMESPACES
+    )
+    assert isinstance(result_whitespace, list)
+    assert len(result_whitespace) == 0
+
+
+def test_find_condition_relevant_elements_invalid_xpath(xml_test_setup) -> None:
+    """
+    Test _find_condition_relevant_elements with invalid XPath.
+    """
+
+    section: Any = xml_test_setup["results_section"]
+    # invalid XPath syntax
+    invalid_xpath = ".//hl7:observation[["
+
+    with pytest.raises(XMLParsingError) as exc_info:
+        _find_condition_relevant_elements(
+            section=section, combined_xpath=invalid_xpath, namespaces=NAMESPACES
+        )
+
+    assert "Failed to evaluate XPath for condition-relevant elements" in str(
+        exc_info.value
+    )
+
+
+@pytest.mark.parametrize(
+    "trigger_templates,expected_trigger_count",
+    [
+        # no trigger templates configured
+        ([], 0),
+        # trigger templates that won't match
+        (["2.16.840.1.113883.10.20.15.2.3.99"], 0),
+        # valid trigger template
+        (["2.16.840.1.113883.10.20.15.2.3.12"], 0),
+    ],
+)
+def test_analyze_trigger_codes_in_context(
+    clinical_test_data, trigger_templates, expected_trigger_count
+) -> None:
+    """
+    Test _analyze_trigger_codes_in_context with various trigger template configurations.
+    """
+
+    contextual_matches: Any = clinical_test_data["clinical_elements"]
+
+    # mock section config
+    section_config: None = None
+    if trigger_templates:
+        section_config: None = {
+            "trigger_codes": {
+                "test_trigger": {"template_id_root": trigger_templates[0]}
+            }
+        }
+
+    result: dict[int, bool] = _analyze_trigger_codes_in_context(
+        contextual_matches, section_config
+    )
+
+    assert isinstance(result, dict)
+    assert len(result) == len(contextual_matches)
+
+    # count trigger codes
+    trigger_count: int = sum(1 for is_trigger in result.values() if is_trigger)
+    assert trigger_count == expected_trigger_count
+
+    # verify all elements have analysis
+    for elem in contextual_matches:
+        element_id: int = id(elem)
+        assert element_id in result
+        assert isinstance(result[element_id], bool)
+
+
+def test_analyze_trigger_codes_in_context_empty_matches() -> None:
+    """
+    Test _analyze_trigger_codes_in_context with empty contextual matches.
+    """
+
+    result: dict[int, bool] = _analyze_trigger_codes_in_context(
+        contextual_matches=[], section_config=None
+    )
+
+    assert isinstance(result, dict)
+    assert len(result) == 0
+
+
+def test_analyze_trigger_codes_in_context_no_config() -> None:
+    """
+    Test _analyze_trigger_codes_in_context with no section config.
+    """
+
+    # create mock clinical elements
+    clinical_elements: list[_Element] = [
+        etree.fromstring(
+            '<observation xmlns="urn:hl7-org:v3"><code code="test"/></observation>'
+        )
+    ]
+
+    result: dict[int, bool] = _analyze_trigger_codes_in_context(
+        contextual_matches=clinical_elements, section_config=None
+    )
+
+    assert isinstance(result, dict)
+    assert len(result) == 1
+    # all should be False when no trigger templates
+    assert all(not is_trigger for is_trigger in result.values())
+
+
+def test_trigger_code_identification_principle() -> None:
+    """
+    Test that trigger codes are only identified within contextually relevant elements.
+    """
+
+    # create elements that would have trigger templates but aren't contextually relevant
+    # this test validates the principle that trigger identification happens AFTER context filtering
+    trigger_element: _Element = etree.fromstring("""
+        <observation xmlns="urn:hl7-org:v3">
+            <templateId root="2.16.840.1.113883.10.20.15.2.3.12"/>
+            <code code="trigger-code"/>
+        </observation>
+    """)
+
+    non_trigger_element: _Element = etree.fromstring("""
+        <observation xmlns="urn:hl7-org:v3">
+            <code code="regular-code"/>
+        </observation>
+    """)
+
+    # only contextually relevant elements should be passed to trigger analysis
+    # trigger element is NOT in contextual matches
+    contextual_matches: list[_Element] = [non_trigger_element]
+
+    # verify trigger_element would be identified as trigger if it were in context
+    section_config: dict[str, dict[str, dict[str, str]]] = {
+        "trigger_codes": {
+            "test_trigger": {"template_id_root": "2.16.840.1.113883.10.20.15.2.3.12"}
+        }
+    }
+
+    # verify that trigger_element WOULD be identified if it were in contextual matches
+    result_with_trigger: dict[int, bool] = _analyze_trigger_codes_in_context(
+        contextual_matches=[trigger_element], section_config=section_config
+    )
+    assert len(result_with_trigger) == 1
+    assert result_with_trigger[id(trigger_element)] is True
+
+    # test with trigger_element excluded from context
+    result: dict[int, bool] = _analyze_trigger_codes_in_context(
+        contextual_matches, section_config
+    )
+    # even though trigger template exists, no elements should be marked as triggers
+    # because the trigger element wasn't in contextual matches
+    assert len(result) == 1
+    assert result[id(non_trigger_element)] is False
+
+
+@pytest.mark.parametrize(
+    "section_config,expected_template_count",
+    [
+        # no trigger codes configuration
+        (None, 0),
+        # empty trigger codes
+        ({"trigger_codes": {}}, 0),
+        # single trigger code
+        (
+            {
+                "trigger_codes": {
+                    "lab": {"template_id_root": "2.16.840.1.113883.10.20.15.2.3.12"}
+                }
+            },
+            1,
+        ),
+        # multiple trigger codes
+        (
+            {
+                "trigger_codes": {
+                    "lab": {"template_id_root": "2.16.840.1.113883.10.20.15.2.3.12"},
+                    "medication": {
+                        "template_id_root": "2.16.840.1.113883.10.20.15.2.3.13"
+                    },
+                }
+            },
+            2,
+        ),
+        # trigger code without template_id_root (should be ignored)
+        ({"trigger_codes": {"invalid": {"other_field": "value"}}}, 0),
+    ],
+)
+def test_trigger_template_extraction(section_config, expected_template_count) -> None:
+    """
+    Test extraction of trigger templates from section configuration.
+    """
+
+    # create a simple clinical element
+    clinical_element: _Element = etree.fromstring("""
+        <observation xmlns="urn:hl7-org:v3">
+            <code code="test"/>
+        </observation>
+    """)
+
+    result: dict[int, bool] = _analyze_trigger_codes_in_context(
+        contextual_matches=[clinical_element], section_config=section_config
+    )
+
+    # should get result for our element
+    assert len(result) == 1
+    assert id(clinical_element) in result
+
+
+def test_preserve_relevant_entries_and_generate_summary(xml_test_setup) -> None:
+    """
+    Test _preserve_relevant_entries_and_generate_summary integration.
+    """
+
+    section: Any = xml_test_setup["results_section"]
+
+    # find some clinical elements to work with
+    clinical_elements = section.xpath(
+        './/hl7:observation[hl7:code[@code="94310-0"]]', namespaces=NAMESPACES
+    )
+
+    if not clinical_elements:
+        pytest.skip("No clinical elements found in test data")
+
+    # mock trigger analysis (no triggers for simplicity)
+    trigger_analysis: dict[int, bool] = {id(elem): False for elem in clinical_elements}
+
+    # get initial entry count
+    initial_entries: Any = section.xpath(".//hl7:entry", namespaces=NAMESPACES)
+    initial_count: int = len(initial_entries)
+
+    _preserve_relevant_entries_and_generate_summary(
+        section=section,
+        contextual_matches=clinical_elements,
+        trigger_analysis=trigger_analysis,
+        namespaces=NAMESPACES,
+    )
+
+    # verify that we started with some entries (test data validation)
+    assert initial_count > 0, "Test data should contain entries"
+
+    # verify text element was updated
+    text_element: Any = section.find(".//hl7:text", namespaces=NAMESPACES)
+    assert text_element is not None
+
+    # verify table structure
+    table: Any = text_element.find("table")
+    assert table is not None
+
+    # verify title
+    title: Any = text_element.find("title")
+    assert title is not None
+    assert title.text == REFINER_OUTPUT_TITLE
+
+
+def test_preserve_relevant_entries_and_generate_summary_empty_matches() -> None:
+    """
+    Test _preserve_relevant_entries_and_generate_summary with empty matches.
+    """
+
+    # create a simple section
+    section: _Element = etree.fromstring("""
+        <section xmlns="urn:hl7-org:v3">
+            <code code="30954-2"/>
+            <entry>
+                <observation>
+                    <code code="test"/>
+                </observation>
+            </entry>
+        </section>
+    """)
+
+    _preserve_relevant_entries_and_generate_summary(
+        section=section,
+        contextual_matches=[],
+        trigger_analysis={},
+        namespaces=NAMESPACES,
+    )
+
+    # should still create/update text element even with no matches
+    text_element: _Element = section.find(path=".//hl7:text", namespaces=NAMESPACES)
+    assert text_element is not None
+
+
+def test_three_step_process_integration(xml_test_setup) -> None:
+    """
+    Test the complete three-step process integration.
+    """
+
+    section: Any = xml_test_setup["results_section"]
+    xpath = './/hl7:observation[hl7:code[@code="94310-0"]]'
+
+    # STEP 1: find contextual matches
+    contextual_matches: list[_Element] = _find_condition_relevant_elements(
+        section=section, combined_xpath=xpath, namespaces=NAMESPACES
+    )
+
+    # STEP 2: analyze trigger codes within context
+    trigger_analysis: dict[int, bool] = _analyze_trigger_codes_in_context(
+        contextual_matches=contextual_matches, section_config=None
+    )
+
+    # STEP 3: preserve entries and generate summary
+    _preserve_relevant_entries_and_generate_summary(
+        section=section,
+        contextual_matches=contextual_matches,
+        trigger_analysis=trigger_analysis,
+        namespaces=NAMESPACES,
+    )
+
+    # verify the complete process worked
+    assert len(contextual_matches) == len(trigger_analysis)
+
+    # verify text element was created/updated
+    text_element: Any = section.find(".//hl7:text", namespaces=NAMESPACES)
+    assert text_element is not None
+
+    # verify trigger analysis structure
+    for elem in contextual_matches:
+        element_id: int = id(elem)
+        assert element_id in trigger_analysis
+        assert isinstance(trigger_analysis[element_id], bool)
+
+
+# NOTE:
+# ENTRY AND ELEMENT TESTS
+
+
+def test_find_path_to_entry_no_match() -> None:
+    """
+    Test finding path when no match exists.
+    """
+
+    clinical_element: _Element = etree.fromstring("""
+        <observation xmlns="urn:hl7-org:v3">
+            <code code="different"/>
+        </observation>
+    """)
+
+    with pytest.raises(StructureValidationError) as exc_info:
+        _find_path_to_entry(element=clinical_element)
+    assert "Parent <entry> element not found" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "xml_content,xpath,expected_entry_count",
+    [
+        (
+            """
+            <section xmlns="urn:hl7-org:v3">
+              <entry>
+                <organizer>
+                  <component>
+                    <observation>
+                      <code code="94310-0"/>
+                    </observation>
+                  </component>
+                </organizer>
+              </entry>
+              <entry>
+                <organizer>
+                  <component>
+                    <observation>
+                      <code code="67890-1"/>
+                    </observation>
+                  </component>
+                </organizer>
+              </entry>
+            </section>
+            """,
+            './/hl7:observation[hl7:code[@code="94310-0"]]',
+            1,
+        ),
+    ],
+)
+def test_prune_unwanted_siblings(xml_content, xpath, expected_entry_count) -> None:
+    """
+    Test removal of non-matching sibling entries.
+    """
+
+    # parse the XML string into an element
+    element: _Element = etree.fromstring(xml_content)
+
+    # find matching clinical elements using XPath
+    matching_clinical_elements = element.xpath(xpath, namespaces=NAMESPACES)
+    paths: list[_Element] = [
+        _find_path_to_entry(elem) for elem in matching_clinical_elements
+    ]
+
+    # call with the section element (element is the section in this case)
+    _prune_unwanted_siblings(entry_paths=paths, section=element)
+
+    # verify the result
+    remaining_entries: list[Any] = _get_entries_for_section(section=element)
+    assert len(remaining_entries) == expected_entry_count
+
+
+# NOTE:
+# CLINICAL DATA EXTRACTION
+
+
+@pytest.mark.parametrize(
+    "clinical_index,expected_data",
+    [
+        (
+            0,
+            {
+                "display_text": "SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with probe detection",
+                "code": "94310-0",
+                "code_system": "LOINC",
+                # always False now
+                "is_trigger_code": False,
+            },
+        ),
+    ],
+)
+def test_extract_clinical_data(
+    clinical_test_data,
+    clinical_index,
+    expected_data,
+) -> None:
+    """
+    Test extraction of clinical element metadata.
+    """
+
+    clinical_element: Any = clinical_test_data["clinical_elements"][clinical_index]
+    data: dict[str, str | bool | None] = _extract_clinical_data(clinical_element)
+    assert data == expected_data
+
+
+# NOTE:
+# TEXT ELEMENT GENERATION TESTS
+
+
+def test_create_or_update_text_element(clinical_test_data) -> None:
+    """
+    Test creation of text element from clinical elements.
+    """
+
+    # updated function signature to include trigger_code_elements parameter
+    # empty set for test
+    trigger_code_elements: set[Any] = set()
+    text_element: _Element = _create_or_update_text_element(
+        clinical_elements=clinical_test_data["clinical_elements"],
+        trigger_code_elements=trigger_code_elements,
+    )
+
+    # verify basic structure
+    assert text_element.tag.endswith("text")
+    assert text_element.find(path=".//table") is not None
+    assert text_element.find(path=".//title") is not None
+
+    # verify title contains expected text
+    title: _Element | None = text_element.find(path=".//title")
+    assert title.text == REFINER_OUTPUT_TITLE
+
+    # verify content
+    table: _Element | None = text_element.find(".//table")
+    rows: list[_Element] = table.findall(path=".//tr")
+    # header row plus at least one data row
+    assert len(rows) > 1
+
+    # verify header uses new constants
+    header: list[_Element] = rows[0].findall(".//th")
+    assert [h.text for h in header] == CLINICAL_DATA_TABLE_HEADERS
+
+
+def test_create_or_update_text_invalid_section() -> None:
     """
     Test creating text element with invalid section.
     """
 
-    clinical_elements = [  # Renamed from observations
+    clinical_elements: list[_Element] = [
         etree.fromstring("""
             <observation xmlns="urn:hl7-org:v3">
                 <code code="test" displayName="Test Code" codeSystemName="Test System"/>
@@ -495,43 +969,16 @@ def test_create_or_update_text_invalid_section():
     ]
 
     # updated function signature
-    trigger_code_elements = set()
-    text_element = _create_or_update_text_element(
-        clinical_elements, trigger_code_elements
+    trigger_code_elements: set[Any] = set()
+    text_element: _Element = _create_or_update_text_element(
+        clinical_elements=clinical_elements, trigger_code_elements=trigger_code_elements
     )
     assert text_element is not None
     assert text_element.tag == "{urn:hl7-org:v3}text"
-    assert text_element.find("table") is not None
+    assert text_element.find(path="table") is not None
 
 
-def test_build_condition_eicr_pairs(sample_xml_files: XMLFiles):
-    """
-    Test building condition-eICR pairs with XMLFiles objects.
-    """
-
-    reportable_conditions = [
-        {"code": "840539006", "displayName": "COVID-19"},
-        {"code": "27836007", "displayName": "Pertussis"},
-    ]
-
-    pairs = build_condition_eicr_pairs(sample_xml_files, reportable_conditions)
-
-    # verify we get the expected number of pairs
-    assert len(pairs) == 2
-
-    # verify each pair has the expected structure
-    for i, pair in enumerate(pairs):
-        assert "reportable_condition" in pair
-        assert "xml_files" in pair
-        assert pair["reportable_condition"] == reportable_conditions[i]
-
-        # verify the xml_files is a proper XMLFiles object
-        assert isinstance(pair["xml_files"], XMLFiles)
-        assert pair["xml_files"].eicr == sample_xml_files.eicr
-        assert pair["xml_files"].rr == sample_xml_files.rr
-
-
-def test_text_constants():
+def test_text_constants() -> None:
     """
     Test that our text constants are properly defined and accessible.
     """
@@ -541,7 +988,7 @@ def test_text_constants():
         == "Output from CDC PRIME DIBBs eCR Refiner application by request of STLT"
     )
     assert MINIMAL_SECTION_MESSAGE == "Section details have been removed as requested"
-    assert CLINICAL_DATA_TABLE_HEADERS == [  # Updated constant name and values
+    assert CLINICAL_DATA_TABLE_HEADERS == [
         "Display Text",
         "Code",
         "Code System",

--- a/refiner/tests/test_service_refine.py
+++ b/refiner/tests/test_service_refine.py
@@ -898,8 +898,6 @@ def test_prune_unwanted_siblings(xml_content, xpath, expected_entry_count) -> No
                 "display_text": "SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with probe detection",
                 "code": "94310-0",
                 "code_system": "LOINC",
-                # always False now
-                "is_trigger_code": False,
             },
         ),
     ],

--- a/refiner/tests/test_service_terminology.py
+++ b/refiner/tests/test_service_terminology.py
@@ -103,33 +103,45 @@ def test_xpath_generation() -> None:
     """
     Test XPath generation with different inputs.
     """
+
     processed = ProcessedGrouper(
         condition="38362002", display_name="Test Condition", codes={"123", "456"}
     )
 
-    # default search_in (observation)
+    # default search now uses comprehensive "any" search
     xpath = processed.build_xpath()
-    # New implementation searches in observation by default
-    assert xpath.startswith(".//hl7:observation[")
-    assert '@code="123"' in xpath or '@code="456"' in xpath
-    assert " or " in xpath
 
-    # custom search_in (should be same as default unless your implementation changes)
-    custom_xpath = processed.build_xpath(search_in="observation")
-    assert custom_xpath.startswith(".//hl7:observation[hl7:code[")
+    # verify it contains the expected patterns (order-independent)
+    assert ".//hl7:*[hl7:code[" in xpath
+    assert ".//hl7:code[" in xpath
+    assert ".//hl7:translation[" in xpath
+    assert '@code="123"' in xpath  # Contains both codes
+    assert '@code="456"' in xpath
+    assert " | " in xpath  # Union operator
+
+    # test backward compatibility - observation-specific search
+    obs_xpath = processed.build_xpath(search_in="observation")
+    assert obs_xpath.startswith(".//hl7:observation[hl7:code[")
 
 
-def test_xpath_single_code() -> None:
+def test_xpath_any_search_type() -> None:
     """
-    Test XPath generation with a single code.
+    Test XPath generation with explicit 'any' search type.
     """
+
     processed = ProcessedGrouper(
-        condition="38362002", display_name="Test Condition", codes={"123"}
+        condition="38362002", display_name="Test Condition", codes={"123", "456"}
     )
 
-    xpath = processed.build_xpath()
-    expected_xpath = './/hl7:observation[hl7:code[@code="123"]]'
-    assert xpath == expected_xpath
+    xpath = processed.build_xpath(search_in="any")
+
+    # should match the comprehensive pattern (order-independent checks)
+    assert ".//hl7:*[hl7:code[" in xpath
+    assert ".//hl7:code[" in xpath
+    assert ".//hl7:translation[" in xpath
+    assert '@code="123"' in xpath  # Both codes present
+    assert '@code="456"' in xpath
+    assert " | " in xpath  # Union operator between different searches
 
 
 def test_xpath_empty_codes() -> None:

--- a/refiner/tests/test_service_terminology.py
+++ b/refiner/tests/test_service_terminology.py
@@ -1,6 +1,3 @@
-import pytest
-
-from app.core.exceptions import InputValidationError
 from app.db.models import GrouperRow
 from app.services.terminology import ProcessedGrouper
 
@@ -119,30 +116,6 @@ def test_xpath_generation() -> None:
     assert '@code="456"' in xpath
     assert " | " in xpath  # Union operator
 
-    # test backward compatibility - observation-specific search
-    obs_xpath = processed.build_xpath(search_in="observation")
-    assert obs_xpath.startswith(".//hl7:observation[hl7:code[")
-
-
-def test_xpath_any_search_type() -> None:
-    """
-    Test XPath generation with explicit 'any' search type.
-    """
-
-    processed = ProcessedGrouper(
-        condition="38362002", display_name="Test Condition", codes={"123", "456"}
-    )
-
-    xpath = processed.build_xpath(search_in="any")
-
-    # should match the comprehensive pattern (order-independent checks)
-    assert ".//hl7:*[hl7:code[" in xpath
-    assert ".//hl7:code[" in xpath
-    assert ".//hl7:translation[" in xpath
-    assert '@code="123"' in xpath  # Both codes present
-    assert '@code="456"' in xpath
-    assert " | " in xpath  # Union operator between different searches
-
 
 def test_xpath_empty_codes() -> None:
     """
@@ -154,18 +127,3 @@ def test_xpath_empty_codes() -> None:
     )
 
     assert processed.build_xpath() == ""
-
-
-def test_xpath_empty_search_in() -> None:
-    """
-    Test XPath generation with empty search_in parameter.
-    """
-
-    processed = ProcessedGrouper(
-        condition="38362002", display_name="Test Condition", codes={"123"}
-    )
-
-    with pytest.raises(InputValidationError) as exc_info:
-        processed.build_xpath(search_in="")
-
-    assert "Empty search element specified" in str(exc_info.value)


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

<!--
What changes are being proposed?
-->
Prior versions of the refiner were only looking for clinical data in `<observation>`s. This updated refactor will now extend this beyond simply the `<observation>`'s `<code code="code">`  but also include the `<value code="code">`. Additionally, we will search in the following locations:

This XPath search strategy is comprehensive and flexible because it will look in:
  * `<observation><code code="code">`
  * `<observation><value code="code">`
  * `<manufacturedProduct><code code="code">`
  * `<act><code code="code">`
  * `<procedure><code code="code">`
  * `<translation code="code">`
 
This will make sure that we're not over-refining the eICR output. The output in the integration test is still checking against this updated code and is valid.

## 🔗 Related Issue

<!--
add the issue number in both places:
Fixes #3
- #3
-->

Fixes #136 
- #136 

## ✅ Acceptance Criteria

<!--
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
-->
- [x] Entries/observations in each section are filtered to include only those matching the full set of codes from the ProcessedGrouper for each reportable condition.
- [x] All required section context and narrative is preserved and obsolete comments/artifacts are removed.
- [x] Section and document structure remains compliant with eICR 1.1 spec.
- [x] Filtering and refinement performance is acceptable for large files and multiple RRs.
- [x] Automated tests/checks verify that output contains only allowed codes and no required data is missing.
- [x] Documentation is updated to describe the filtering approach and rationale for both developers and product stakeholders.

## 🧪 How to test

Unit tests

1. From the project root make sure you're in the `refiner/` directory
2. Activate a virtual environment using your tool of choice
3. Make sure that both `requirements.txt` and `requirements-dev.txt` are installed
4. Run the unit tests with `pytest -vv tests/`
5. Additionally you can check coverage with `pytest --cov=app tests`

and

Testing the application:

1. Run `docker compose up`
2. Check that both services are up and running with `docker ps`
3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
4. You should be able to check the drop down for the covid and influenza eICR files to view the tables and the clinical data retained


## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
There is still more to do but this puts us in a better place! Next would be to consider the move to `refiner_config.json` over `refiner_details.json`. And to make sure we have a way to handle `<section>`s that are not a part of eICR but still appear in eICR files in the wild.