### PR TITLE
feat(ui): Add `<ConfigurationsTable />` component

### DIFF
--- a/client/src/components/ConfigurationsTable/index.test.tsx
+++ b/client/src/components/ConfigurationsTable/index.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it } from 'vitest';
+import { getByText, render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router';
+import { ConfigurationsTable } from '.';
+
+const tableData = {
+  columns: ['Reportable condition', 'Status'],
+  data: [
+    {
+      name: 'Chlamydia trachomatis infection',
+      status: 'on',
+      id: 'asdf-zxcv-qwer-hjkl',
+    },
+    {
+      name: 'Disease caused by Enterovirus',
+      status: 'off',
+      id: 'asdf-zxcv-qwer-hjkl',
+    },
+  ],
+};
+
+const renderComponentView = () =>
+  render(
+    <BrowserRouter>
+      <ConfigurationsTable columns={tableData.columns} data={tableData.data} />
+    </BrowserRouter>
+  );
+
+describe('Configurations Table component', () => {
+  it('should render a table when supplied with data', async () => {
+    renderComponentView();
+
+    const table = screen.getByTestId('table');
+    const firstRow = getByText(table, tableData.data[0].name).parentElement;
+    const secondRow = getByText(table, tableData.data[1].name).parentElement;
+
+    expect(table).toBeInTheDocument();
+    expect(firstRow).toHaveTextContent(tableData.data[0].name);
+    expect(firstRow).toHaveTextContent(`Refiner ${tableData.data[0].status}`);
+    expect(secondRow).toHaveTextContent(tableData.data[1].name);
+    expect(secondRow).toHaveTextContent(`Refiner ${tableData.data[1].status}`);
+  });
+});

--- a/client/src/components/ConfigurationsTable/index.tsx
+++ b/client/src/components/ConfigurationsTable/index.tsx
@@ -1,0 +1,61 @@
+import { Table as UswdsTable } from '@trussworks/react-uswds';
+import { StatusPill } from '../StatusPill';
+
+interface HeaderProps {
+  items: string[];
+}
+
+interface TableBodyProps {
+  data: Array<TableItem>;
+}
+
+interface TableItem {
+  name: string;
+  status: string;
+  id: string;
+}
+
+interface ConfigurationsTableProps {
+  columns: string[];
+  data: Array<TableItem>;
+}
+
+function TableHeader({ items }: HeaderProps) {
+  return (
+    <thead>
+      <tr>
+        {items.map((name, idx) => {
+          return <th key={idx} scope="col">{name}</th>;
+        })}
+      </tr>
+    </thead>
+  );
+}
+
+function TableBody({ data }: TableBodyProps) {
+  return (
+    <tbody>
+      {data.map((row, idx) => {
+        return (
+          <tr key={idx}>
+            <th scope="row">{row.name}</th>
+            <td>
+              <StatusPill status={row.status} />
+            </td>
+          </tr>
+        );
+      })}
+    </tbody>
+  );
+}
+export function ConfigurationsTable({
+  columns,
+  data,
+}: ConfigurationsTableProps) {
+  return (
+    <UswdsTable stackedStyle="headers">
+      <TableHeader items={columns} />
+      <TableBody data={data} />
+    </UswdsTable>
+  );
+}

--- a/client/src/components/Layout/index.tsx
+++ b/client/src/components/Layout/index.tsx
@@ -47,6 +47,7 @@ export function Footer() {
             href="https://www.cdc.gov"
             target="_blank"
             rel="noreferrer noopener"
+            className="inline-block"
           >
             <img src={CdcLogo} alt="" />
           </a>

--- a/client/src/components/Layout/index.tsx
+++ b/client/src/components/Layout/index.tsx
@@ -11,8 +11,14 @@ interface LayoutProps {
 export function Layout({ children }: LayoutProps) {
   return (
     <div className="flex min-h-screen flex-col">
+      <a className="usa-skipnav" href="#main-content">
+        Skip to main content
+      </a>
       <Header />
-      <main className="bg-primary-container flex grow flex-col">
+      <main
+        id="main-content"
+        className="bg-primary-container flex grow flex-col"
+      >
         {children}
       </main>
       <Footer />

--- a/client/src/components/NavigationBar/index.tsx
+++ b/client/src/components/NavigationBar/index.tsx
@@ -20,11 +20,11 @@ type NavigationLinkProps = Pick<NavLinkProps, 'to' | 'title'>;
  */
 function NavigationLink({ to, title }: NavigationLinkProps) {
   return (
-<NavLink to={to} className="text-blue-cool-5">
+    <NavLink to={to} className="text-blue-cool-5">
       {({ isActive }) => (
         <span
           className={classNames('mx-6 inline-block py-1', {
-            'border-b-4 border-blue-cool-30': isActive,
+            'border-blue-cool-30 border-b-4': isActive,
           })}
         >
           {title}

--- a/client/src/components/NavigationBar/index.tsx
+++ b/client/src/components/NavigationBar/index.tsx
@@ -20,11 +20,11 @@ type NavigationLinkProps = Pick<NavLinkProps, 'to' | 'title'>;
  */
 function NavigationLink({ to, title }: NavigationLinkProps) {
   return (
-    <NavLink to={to}>
+<NavLink to={to} className="text-blue-cool-5">
       {({ isActive }) => (
         <span
           className={classNames('mx-6 inline-block py-1', {
-            'border-b-4': isActive,
+            'border-b-4 border-blue-cool-30': isActive,
           })}
         >
           {title}

--- a/client/src/components/StatusPill/index.test.tsx
+++ b/client/src/components/StatusPill/index.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router';
+import { StatusPill } from '.';
+
+const renderComponentView = (status: string) =>
+  render(
+    <BrowserRouter>
+      <StatusPill status={status} />
+    </BrowserRouter>
+  );
+
+describe('Status pill component', () => {
+  it('should render with status on', async () => {
+    renderComponentView('on');
+
+    expect(screen.getByTestId('status-pill')).toBeInTheDocument();
+expect(screen.getByTestId('status-pill')).toHaveAttribute('data-configuration-status', 'on')
+  });
+  it('should render with status off', async () => {
+    renderComponentView('off');
+
+    expect(screen.getByTestId('status-pill')).toBeInTheDocument();
+expect(screen.getByTestId('status-pill')).toHaveAttribute('data-configuration-status', 'off')
+  });
+});

--- a/client/src/components/StatusPill/index.tsx
+++ b/client/src/components/StatusPill/index.tsx
@@ -1,0 +1,15 @@
+interface StatusPillProps {
+  status: string;
+}
+
+export function StatusPill({ status }: StatusPillProps) {
+  return (
+    <span
+      data-configuration-status={status}
+      data-testid='status-pill'
+      className="rounded-full px-2 py-1 text-white font-bold"
+    >
+      Refiner {status}
+    </span>
+  );
+}

--- a/client/src/pages/Configurations/index.tsx
+++ b/client/src/pages/Configurations/index.tsx
@@ -1,8 +1,42 @@
 import { Title } from '../../components/Title';
 import { Button } from '../../components/Button';
 import { Search } from '../../components/Search';
+import { ConfigurationsTable } from '../../components/ConfigurationsTable';
+
+
 
 export function Configurations() {
+  const tableData = {
+    columns: ['Reportable condition', 'Status'],
+    data: [
+      {
+        name: 'Chlamydia trachomatis infection',
+        status: 'on',
+        id: 'asdf-zxcv-qwer-hjkl',
+      },
+      {
+        name: 'Disease caused by Enterovirus',
+        status: 'off',
+        id: 'asdf-zxcv-qwer-hjkl',
+      },
+      {
+        name: 'Human immunodeficiency virus infection (HIV)',
+        status: 'off',
+        id: 'asdf-zxcv-qwer-hjkl',
+      },
+      {
+        name: 'Syphilis',
+        status: 'on',
+        id: 'asdf-zxcv-qwer-hjkl',
+      },
+      {
+        name: 'Viral hepatitis, type A',
+        status: 'on',
+        id: 'asdf-zxcv-qwer-hjkl',
+      },
+    ],
+  };
+
   return (
     <section className="mx-auto p-3">
       <div className="flex flex-col gap-4 py-10">
@@ -23,6 +57,7 @@ export function Configurations() {
           <Button>Set up new condition</Button>
         </div>
       </div>
+      <ConfigurationsTable columns={tableData.columns} data={tableData.data} />
     </section>
   );
 }

--- a/client/src/styles/index.scss
+++ b/client/src/styles/index.scss
@@ -2,7 +2,7 @@
 @forward 'uswds';
 
 [href]:focus:not(:focus-visible) {
-  outline:none;
+  outline: none;
 }
 
 input:not([disabled]):focus,
@@ -12,7 +12,7 @@ button:not([disabled]):focus,
 iframe:focus-visible,
 [href]:focus-visible,
 [tabindex]:focus-visible,
-[contentEditable=true]:focus-visible {
+[contentEditable='true']:focus-visible {
   outline: 0.25rem solid var(--color-blue-cool-30);
   outline-offset: 2px;
 }

--- a/client/src/styles/index.scss
+++ b/client/src/styles/index.scss
@@ -2,7 +2,8 @@
 @forward 'uswds';
 
 /**
-  * @mixin Sets outline to a better complimentary and WCAG AA rated contrast
+  * @mixin
+  * @desc Sets outline to a better complimentary and WCAG AA rated contrast
   * raio of `5.93:1` which works for graphic and large text.
   * source: https://webaim.org/resources/contrastchecker/?fcolor=82B4C9&bcolor=14333D
   */
@@ -12,18 +13,18 @@
 }
 
 /**
-  * Removes the focus outline when mouse-based or touch-based interactions
-  * interact with any anchors to avoid two visual indicators.
+  * @desc Removes the focus outline when mouse-based or touch-based
+  * interactions interact with any anchors to avoid two visual indicators.
   */
 [href]:focus:not(:focus-visible) {
   outline: none;
 }
 
 /**
-  * Use a custom outline for anything that appears on a dark background such as
-  * the <header /> and <footer /> elements for now. Targets the Tailwind
-  * selector for the dark background set in the HTML rather than specific
-  * HTML elements.
+  * @desc Use a custom outline for anything that appears on a dark background
+  * such as the <header /> and <footer /> elements for now. Targets the
+  * Tailwind selector for the dark background set in the HTML rather than
+  * specific HTML elements.
   */
 .bg-blue-cool-80 {
   input:not([disabled]):focus,

--- a/client/src/styles/index.scss
+++ b/client/src/styles/index.scss
@@ -1,18 +1,43 @@
 @forward 'uswds-theme';
 @forward 'uswds';
 
+/**
+  * @mixin Sets outline to a better complimentary and WCAG AA rated contrast
+  * raio of `5.93:1` which works for graphic and large text.
+  * source: https://webaim.org/resources/contrastchecker/?fcolor=82B4C9&bcolor=14333D
+  */
+@mixin outline-on-dark-bg {
+  outline: 0.25rem solid var(--color-blue-cool-30);
+  outline-offset: 2px;
+}
+
+/**
+  * Removes the focus outline when mouse-based or touch-based interactions
+  * interact with any anchors to avoid two visual indicators.
+  */
 [href]:focus:not(:focus-visible) {
   outline: none;
 }
 
-input:not([disabled]):focus,
-select:not([disabled]):focus,
-textarea:not([disabled]):focus,
-button:not([disabled]):focus,
-iframe:focus-visible,
-[href]:focus-visible,
-[tabindex]:focus-visible,
-[contentEditable='true']:focus-visible {
-  outline: 0.25rem solid var(--color-blue-cool-30);
-  outline-offset: 2px;
+/**
+  * Use a custom outline for anything that appears on a dark background such as
+  * the <header /> and <footer /> elements for now. Targets the Tailwind
+  * selector for the dark background set in the HTML rather than specific
+  * HTML elements.
+  */
+.bg-blue-cool-80 {
+  input:not([disabled]):focus,
+  select:not([disabled]):focus,
+  textarea:not([disabled]):focus,
+  button:not([disabled]):focus,
+  iframe:focus-visible,
+  [href]:focus-visible,
+  [tabindex]:focus-visible,
+  [contentEditable='true']:focus-visible {
+    @include outline-on-dark-bg;
+  }
+}
+
+.usa-skipnav[href]:focus-visible {
+  @include outline-on-dark-bg;
 }

--- a/client/src/styles/index.scss
+++ b/client/src/styles/index.scss
@@ -1,2 +1,18 @@
 @forward 'uswds-theme';
 @forward 'uswds';
+
+[href]:focus:not(:focus-visible) {
+  outline:none;
+}
+
+input:not([disabled]):focus,
+select:not([disabled]):focus,
+textarea:not([disabled]):focus,
+button:not([disabled]):focus,
+iframe:focus-visible,
+[href]:focus-visible,
+[tabindex]:focus-visible,
+[contentEditable=true]:focus-visible {
+  outline: 0.25rem solid var(--color-blue-cool-30);
+  outline-offset: 2px;
+}

--- a/client/src/tailwind.css
+++ b/client/src/tailwind.css
@@ -18,6 +18,15 @@
   select {
     @apply !m-0;
   }
+
+  [data-configuration-status='on'] {
+    @apply bg-state-success-dark;
+  }
+
+  [data-configuration-status='off'] {
+    @apply bg-state-error-dark;
+  }
+
 }
 @layer utilities {
   .border-thin {
@@ -66,4 +75,44 @@
   --color-violet-warm-60: #864381;
   --color-violet-warm-70: #5c395a;
   --color-violet-warm-80: #382936;
+}
+
+/**
+  * README:
+  * Overriding USWDS styles here with a mixture of raw CSS and applying
+  * Tailwind classes as needed. This makes having the minimal amount of classes
+  * in the components that leverage the USWDS Table HTML to not require having
+  * a lot of Tailwind class names.
+  */
+
+.usa-table {
+  @apply rounded-sm w-full border-1 border-gray-cool-30;
+  box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.15);
+}
+
+.usa-table--borderless thead th {
+  @apply text-blue-cool-90 bg-gray-cool-10 uppercase py-3 border-none;
+  line-height: 26px;
+}
+
+.usa-table tbody th,
+.usa-table tbody td {
+  @apply py-5 border-0 cursor-pointer;
+}
+
+.usa-table tbody tr {
+  @apply border-gray-cool-30 border-t;
+}
+
+.usa-table tbody tr:hover th,
+.usa-table tbody tr:hover td {
+  @apply bg-gray-200;
+}
+
+.usa-table tbody th {
+  width: 400px;
+}
+
+.usa-table tbody td {
+  width: 720px;
 }

--- a/client/src/tailwind.css
+++ b/client/src/tailwind.css
@@ -38,6 +38,7 @@
   --color-blue-cool-5: #e7f2f5;
   --color-blue-cool-10: #dae9ee;
   --color-blue-cool-20: #adcfdc;
+  --color-blue-cool-30: #82b4c9;
   --color-blue-cool-40: #6499af;
   --color-blue-cool-50: #3a7d95;
   --color-blue-cool-60: #2e6276;

--- a/client/src/tailwind.css
+++ b/client/src/tailwind.css
@@ -43,11 +43,25 @@
   --color-blue-cool-50: #3a7d95;
   --color-blue-cool-60: #2e6276;
   --color-blue-cool-80: #14333d;
+  --color-blue-cool-90: #0f191c;
 
   --color-gray-100: #fbfcfd;
   --color-gray-200: #f3f3f3;
 
+  --color-gray-cool-10: #dfe1e2;
+  --color-gray-cool-20: #c6cace;
+  --color-gray-cool-30: #a9aeb1;
+  --color-gray-cool-40: #8d9297;
+  --color-gray-cool-50: #71767a;
+  --color-gray-cool-60: #565c65;
+  --color-gray-cool-70: #3d4551;
+  --color-gray-cool-80: #2d2e2f;
+  --color-gray-cool-90: #1c1d1f;
+
   --color-red-300: #e41d3d;
+
+  --color-state-success-dark: #216e1f;
+  --color-state-error-dark: #b50909;
 
   --color-violet-warm-60: #864381;
   --color-violet-warm-70: #5c395a;


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

1. 💬 chore(ui): Bring in more colors from design system 🏷️ dc28404
1. 💬 feat(ui): Add component <ConfigurationsTable /> 🏷️ 2d60cc6

## 🔗 Related Issue

- #164

## ✅ Acceptance Criteria

- [ ] ~~Header navigation between configurations page and testing page for all pages incl. testing flow~~
- [ ] ~~Remove landing page~~
- [ ] ~~Remove "Return to landing page" buttons in testing flow~~
- [ ] ~~Configurations page title and subtitle copy~~
- [x] Empty table (or no table if easier to add later)

## 🧪 How to test

There are unit tests associated with the `<ConfigurationsTable />` component
and the `<StatusPill />` component. You can also load up the app locally and
see the Configurations page has a table component now that matches the designs.

## ℹ️ Additional Information

The table is using sample data from the original designs. This means that when
writing the retrieval from the database, we may need to refactor parts of this
component and add data-fetching. As part of this ticket, I want to add keyboard
navigation to the Table component to be able to meet accessibility needs when
JavaScript is enabled. I have a rough sketch, but am worried that it might
extend this work longer and should probably just be done in a separate ticket.
