### PR TITLE
build: Refactor Just a bit further

### DIFF
--- a/.justscripts/just/client.just
+++ b/.justscripts/just/client.just
@@ -6,10 +6,26 @@ alias help := _default
 @_default:
     just --list client
 
+npm := require('npm')
+
 alias r := run
 
 [group('npm')]
 [doc('Run arbitrary `npm run *` commands within `client/`')]
 run *ARGS:
-    @test  '{{ ARGS }}' == '' && npm run || echo
-    @for action in {{ ARGS }}; do npm run $action; done
+    @test '{{ ARGS }}' == '' && {{ npm }} run || echo
+    @for action in {{ ARGS }}; do {{ npm }} run $action; done
+
+alias i := install
+
+[group('dependencies')]
+[doc('Run arbitrary `npm install *` commands within `client/')]
+install *ARGS:
+    {{ npm }} install {{ ARGS }}
+
+alias t := test
+
+[group('test')]
+[doc('Run ui/ux tests')]
+test:
+    just client run test

--- a/.justscripts/just/client.just
+++ b/.justscripts/just/client.just
@@ -6,14 +6,9 @@ alias help := _default
 @_default:
     just --list client
 
-alias d := dev
-
-[doc("Run abitrary `docker compose *` commands using project's docker-compose.yaml file.")]
-dev +ARGS:
-    docker compose -f {{ absolute_path('../docker-compose.yaml') }} {{ ARGS }}
-
 alias r := run
 
+[group('npm')]
 [doc('Run arbitrary `npm run *` commands within `client/`')]
 run *ARGS:
     @test  '{{ ARGS }}' == '' && npm run || echo

--- a/.justscripts/just/server.just
+++ b/.justscripts/just/server.just
@@ -6,6 +6,7 @@ alias help := _default
 @_default:
     just --list server
 
+set dotenv-load
 
 # Convinience paths to scripts
 seed_terminology_db := absolute_path('scripts/seed_terminology_db.py')

--- a/.justscripts/just/server.just
+++ b/.justscripts/just/server.just
@@ -1,0 +1,34 @@
+set working-directory := '../../refiner'
+
+alias h := _default
+alias help := _default
+
+@_default:
+    just --list server
+
+
+# Convinience paths to scripts
+seed_terminology_db := absolute_path('scripts/seed_terminology_db.py')
+check_terminology_db := absolute_path('scripts/check_terminology_db.py')
+query_terminology_db := absolute_path('scripts/query_terminology_db.py')
+
+# WARN: Required environment variables that we want to break execution on when
+# using Just
+DB_URL := env('DB_URL')
+TES_API_URL := env('TES_API_URL')
+TES_API_KEY := env('TES_API_KEY')
+
+[group('db')]
+[doc('Seed the database with the terminology from TES')]
+seed-db:
+    python {{ seed_terminology_db }}
+
+[group('db')]
+[doc('Check the terminology in the database')]
+check-db:
+    python {{ check_terminology_db }}
+
+[group('db')]
+[doc('Query the terminology in the database')]
+query-db:
+    python {{ query_terminology_db }}

--- a/.justscripts/just/server.just
+++ b/.justscripts/just/server.just
@@ -9,9 +9,9 @@ alias help := _default
 set dotenv-load
 
 # Convinience paths to scripts
-seed_terminology_db := absolute_path('scripts/seed_terminology_db.py')
-check_terminology_db := absolute_path('scripts/check_terminology_db.py')
-query_terminology_db := absolute_path('scripts/query_terminology_db.py')
+seed_db := absolute_path('scripts/query_terminology_db.py')
+check_db := absolute_path('scripts/check_terminology_db.py')
+query_db := absolute_path('scripts/query_terminology_db.py')
 
 # WARN: Required environment variables that we want to break execution on when
 # using Just
@@ -22,14 +22,14 @@ TES_API_KEY := env('TES_API_KEY')
 [group('db')]
 [doc('Seed the database with the terminology from TES')]
 seed-db:
-    python {{ seed_terminology_db }}
+    python {{ seed_db }}
 
 [group('db')]
 [doc('Check the terminology in the database')]
 check-db:
-    python {{ check_terminology_db }}
+    python {{ check_db }}
 
 [group('db')]
 [doc('Query the terminology in the database')]
 query-db:
-    python {{ query_terminology_db }}
+    python {{ query_db }}

--- a/.justscripts/just/server.just
+++ b/.justscripts/just/server.just
@@ -9,7 +9,7 @@ alias help := _default
 set dotenv-load
 
 # Convinience paths to scripts
-seed_db := absolute_path('scripts/query_terminology_db.py')
+seed_db := absolute_path('scripts/seed_terminology_db.py')
 check_db := absolute_path('scripts/check_terminology_db.py')
 query_db := absolute_path('scripts/query_terminology_db.py')
 

--- a/justfile
+++ b/justfile
@@ -4,8 +4,19 @@ alias help := _default
 @_default:
     just --list
 
+[group('alias')]
 [doc('Alias for `client`')]
 mod c './.justscripts/just/client.just'
 
+[group('sub-command')]
 [doc('Run commands against `client/` code')]
 mod client './.justscripts/just/client.just'
+
+alias d := dev
+
+docker := require("docker")
+
+[group('docker')]
+[doc("Run abitrary `docker compose *` commands using project's docker-compose.yaml file.")]
+dev +ARGS:
+    {{ docker }} compose -f {{ absolute_path('./docker-compose.yaml') }} {{ ARGS }}

--- a/justfile
+++ b/justfile
@@ -8,9 +8,17 @@ alias help := _default
 [doc('Alias for `client`')]
 mod c './.justscripts/just/client.just'
 
+[group('alias')]
+[doc('Alias for `server`')]
+mod s './.justscripts/just/server.just'
+
 [group('sub-command')]
 [doc('Run commands against `client/` code')]
 mod client './.justscripts/just/client.just'
+
+[group('sub-command')]
+[doc('Run commands against `refiner/` code')]
+mod server './.justscripts/just/server.just'
 
 alias d := dev
 


### PR DESCRIPTION

# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

1. 💬 build: Move commands & add groups 🏷️ 50ddbb9
1. 💬 build: Add server-related recipes 🏷️ bc55c7c

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

We should now be able to see commands like the following:

- `just dev`
- `just client`
- `just server`

Also there should now be groupings when outputting recipes.
