### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,9 @@ on:
         required: true
         type: number
 
+permissions:
+  contents: read
+
 jobs:
   run-python-linter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/CDCgov/dibbs-ecr-refiner/security/code-scanning/8](https://github.com/CDCgov/dibbs-ecr-refiner/security/code-scanning/8)

To fix the issue, we will add a `permissions` block to the root of the workflow. This block will apply to all jobs in the workflow unless overridden at the job level. Since the workflow only performs linting and formatting tasks, it does not require write permissions. We will set the `contents` permission to `read`, which is the minimal permission required for most workflows.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
