### PR TITLE
style: Nav links should display on small screens

### DIFF
--- a/client/src/components/Layout/index.tsx
+++ b/client/src/components/Layout/index.tsx
@@ -29,7 +29,7 @@ export function Layout({ children }: LayoutProps) {
 export function Header() {
   return (
     <header>
-      <div className="bg-blue-cool-80 flex items-center justify-between px-2 py-4 xl:px-20">
+      <div className="bg-blue-cool-80 flex flex-col items-start justify-between gap-4 px-2 py-4 sm:flex-row sm:items-center xl:px-20">
         <Link to="/">
           <h1 className="flex items-center gap-3">
             <img src={DibbsLogo} alt="DIBBs" />
@@ -38,6 +38,7 @@ export function Header() {
             </span>
           </h1>
         </Link>
+
         <NavigationBar />
       </div>
     </header>

--- a/client/src/components/NavigationBar/index.tsx
+++ b/client/src/components/NavigationBar/index.tsx
@@ -5,7 +5,7 @@ export default function NavigationBar() {
   return (
     <nav
       aria-label="Primary navigation"
-      className="usa-nav flex justify-end !text-lg text-white"
+      className="!text-md flex justify-end gap-4 text-white"
     >
       <NavigationLink to="/" title="Configurations" />
       <NavigationLink to="/testing" title="Testing" />

--- a/client/src/components/StatusPill/index.tsx
+++ b/client/src/components/StatusPill/index.tsx
@@ -5,10 +5,13 @@ interface StatusPillProps {
 }
 
 export function StatusPill({ status }: StatusPillProps) {
-  const styles = classNames('rounded-full px-2 py-1 font-bold text-white', {
-    'bg-state-success-dark': status === 'on',
-    'bg-state-error-dark': status === 'off',
-  });
+  const styles = classNames(
+    'rounded-full px-2 py-1 font-bold text-white text-nowrap',
+    {
+      'bg-state-success-dark': status === 'on',
+      'bg-state-error-dark': status === 'off',
+    }
+  );
 
   return <span className={styles}>Refiner {status}</span>;
 }


### PR DESCRIPTION
This PR is a small fix to make sure that the `Configurations` and `Testing` links remain visible on narrow screens. Without this fix they'll disappear when the screen gets too small.

I also included some styling to ensure the pill component's text no longer wraps when displayed on smaller screens.

Here's an example:
![Kapture 2025-07-17 at 13 38 08](https://github.com/user-attachments/assets/e9169d88-45f3-4b4f-99df-0f01400525b3)
