### PR TITLE
fix: `users` and `sessions` tables should be created upon DB startup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,7 +65,8 @@ services:
       timeout: 5s
       retries: 10
     volumes:
-      - ./refiner/tests/integration/seeding/seed-data.sql:/docker-entrypoint-initdb.d/seed-data.sql
+      - ./refiner/tests/integration/seeding/seed-data.sql:/docker-entrypoint-initdb.d/01-seed-data.sql
+      - ./refiner/app/db/schema.sql:/docker-entrypoint-initdb.d/02-schema.sql
       - ./refiner/app/db:/app/db
       - pgdata:/var/lib/postgresql/data
 volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,7 +67,6 @@ services:
     volumes:
       - ./refiner/tests/integration/seeding/seed-data.sql:/docker-entrypoint-initdb.d/01-seed-data.sql
       - ./refiner/app/db/schema.sql:/docker-entrypoint-initdb.d/02-schema.sql
-      - ./refiner/app/db:/app/db
       - pgdata:/var/lib/postgresql/data
 volumes:
   pgdata:

--- a/refiner/tests/integration/conftest.py
+++ b/refiner/tests/integration/conftest.py
@@ -83,6 +83,19 @@ def setup(request):
     refiner_service.wait_for("http://0.0.0.0:8080/api/healthcheck")
     print("✨ Message refiner services ready to test!")
 
+    print("🧠 Seeding database with TES data...")
+    refiner_service.exec_in_container(
+        [
+            "psql",
+            "-U",
+            "postgres",
+            "refiner",
+            "-f",
+            "/docker-entrypoint-initdb.d/01-seed-data.sql",
+        ],
+        "db",
+    )
+
     # Set up database schema
     print("Applying database schema...")
     refiner_service.exec_in_container(
@@ -93,24 +106,12 @@ def setup(request):
             "-d",
             "refiner",
             "-f",
-            "/app/db/schema.sql",
+            "/docker-entrypoint-initdb.d/02-schema.sql",
         ],
         "db",
     )
     print("✅ Schema applied")
 
-    print("🧠 Seeding database with TES data...")
-    refiner_service.exec_in_container(
-        [
-            "psql",
-            "-U",
-            "postgres",
-            "refiner",
-            "-f",
-            "/docker-entrypoint-initdb.d/seed-data.sql",
-        ],
-        "db",
-    )
     print("🧠 Seeding database with test user...")
     seed_user = f"""
     DO $$


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

It was noticed that running the design script would not create `users` and `sessions` table, which means folks were not able to log in due to the app crashing. This PR ensures that the SQL script defining `users` and `sessions` runs when the local DB initializes as part of the Docker Compose setup.

[Confirmed this change worked with the design script](https://skylight-hq.slack.com/archives/C08H7EV6M37/p1753393524963209?thread_ts=1753363138.114949&cid=C08H7EV6M37).

## 🧪 How to test

1. Shut down and delete your containers
2. Delete your DB volume to ensure no data remains (Should be called `dibbs-ecr-refiner_pgdata`)
3. Run `docker compose up`
4. You should be able to load up [http://localhost:8081](http://localhost:8081) and log in without performing any other steps prior