### PR TITLE
Add PR image scanning workflow

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -1,0 +1,108 @@
+name: PR Security Scan
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  merge_group:
+    types:
+      - checks_requested
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write  # For adding comments to PRs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-scan:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        image:
+          - name: "refiner-app"
+            dockerfile: "Dockerfile.app"
+          - name: "refiner-lambda"
+            dockerfile: "Dockerfile.lambda"
+      fail-fast: false
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image locally (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          load: true  # Load locally for scanning only
+          tags: local-scan/${{ matrix.image.name }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: local-scan/${{ matrix.image.name }}:${{ github.sha }}
+          format: 'sarif'
+          output: 'trivy-${{ matrix.image.name }}-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          ignore-unfixed: true
+          timeout: '10m'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-${{ matrix.image.name }}-results.sarif'
+          category: 'pr-scan-${{ matrix.image.name }}'
+
+      - name: Generate scan summary
+        if: always()
+        run: |
+          echo "## Security Scan Results for ${{ matrix.image.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f "trivy-${{ matrix.image.name }}-results.sarif" ]; then
+            echo "Vulnerability scan completed successfully" >> $GITHUB_STEP_SUMMARY
+            echo "Results uploaded to Security tab" >> $GITHUB_STEP_SUMMARY
+            echo "Category: pr-scan-${{ matrix.image.name }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Scan failed or no results generated" >> $GITHUB_STEP_SUMMARY
+          fi
+
+  scan-summary:
+    runs-on: ubuntu-latest
+    needs: build-and-scan
+    if: always()
+    
+    steps:
+      - name: PR Security Summary
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const conclusion = '${{ needs.build-and-scan.result }}';
+            const prNumber = context.payload.pull_request?.number;
+            
+            if (!prNumber) return;
+            
+            let message = `## Security Scan Summary\n\n`;
+            message += `**Scanned Images**: refiner-app, refiner-lambda\n`;
+            message += `**Scan Time**: ${new Date().toISOString()}\n`;
+            message += `**Status**: ${conclusion === 'success' ? 'Completed' : 'Failed'}\n\n`;
+            message += `**View detailed results**: Navigate to Security tab → Code scanning alerts\n`;
+            message += `**Filter by**: \`pr-scan-refiner-app\` or \`pr-scan-refiner-lambda\``;
+            
+            // Add comment to PR
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message
+            });


### PR DESCRIPTION
# Changes Proposed

## Added automated image security scanning for all pull requests

- New workflow file:` .github/workflows/pr-security-scan.yml `

- PR-triggered scanning: Automatically scans container images on every pull request and merge group event

- Local image scanning: Builds and scans images locally without pushing to GHCR, preventing registry pollution

- Matrix strategy: Parallel scanning of both refiner-app and refiner-lambda images using their respective Dockerfiles

- Trivy integration: Comprehensive vulnerability detection with configurable severity thresholds (CRITICAL, HIGH, MEDIUM)`

- GitHub Security integration: Uploads SARIF reports categorized as pr-scan-refiner-app and pr-scan-refiner-lambda

- PR feedback: Automatic security summary comments on pull requests with scan results and links to detailed reports
- Concurrency control: Prevents multiple scans from running simultaneously on the same PR
- Build cache optimization: Leverages GitHub Actions cache to improve build performance

# Testing 

- Review the `.github/workflows/pr-security-scan.yml` file to ensure the matrix strategy correctly targets both Docker images with proper build contexts and that Trivy scanner configuration includes appropriate severity levels and SARIF output formatting.
- Verify that the PR security scanning workflow runs correctly by creating a test pull request after the merge and confirming that both container images are built, scanned, and results are uploaded to the Security tab with proper categorization.
