### PR TITLE
chore: enable `tseslint.configs.recommendedTypeChecked` ESLint rules

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -14,12 +14,16 @@ export default tseslint.config(
       js.configs.recommended,
       eslintConfigPrettier,
       importPlugin.flatConfigs.recommended,
-      ...tseslint.configs.recommended,
+      ...tseslint.configs.recommendedTypeChecked,
     ],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     plugins: {
       'react-hooks': reactHooks,
@@ -32,6 +36,7 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
       'import/no-duplicates': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
     },
     settings: {
       'import/resolver': {

--- a/client/src/components/ConfigurationsTable/index.test.tsx
+++ b/client/src/components/ConfigurationsTable/index.test.tsx
@@ -28,7 +28,7 @@ const testCfg = {
 };
 
 describe('Configurations Table component', () => {
-  it('should render a table when supplied with data', async () => {
+  it('should render a table when supplied with data', () => {
     render(
       <BrowserRouter>
         <ConfigurationsTable columns={testCfg.columns} data={testCfg.data} />
@@ -41,7 +41,7 @@ describe('Configurations Table component', () => {
       expect(row).toHaveTextContent(`Refiner ${status}`);
     });
   });
-  it('should render an error message if no data is supplied', async () => {
+  it('should render an error message if no data is supplied', () => {
     render(
       <BrowserRouter>
         <ConfigurationsTable columns={testCfg.columns} data={[]} />

--- a/client/src/components/Search/index.test.tsx
+++ b/client/src/components/Search/index.test.tsx
@@ -11,12 +11,12 @@ const renderComponentView = (text?: string) =>
   );
 
 describe('Search component', () => {
-  it('should have a default placeholder text', async () => {
+  it('should have a default placeholder text', () => {
     renderComponentView();
 
     expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
   });
-  it('should have a custom placeholder text', async () => {
+  it('should have a custom placeholder text', () => {
     renderComponentView('My custom placeholder text');
 
     expect(

--- a/client/src/components/StatusPill/index.test.tsx
+++ b/client/src/components/StatusPill/index.test.tsx
@@ -11,12 +11,12 @@ const renderComponentView = (status: 'on' | 'off') =>
   );
 
 describe('Status pill component', () => {
-  it('should render with status on', async () => {
+  it('should render with status on', () => {
     renderComponentView('on');
 
     expect(screen.getByText('Refiner on')).toBeInTheDocument();
   });
-  it('should render with status off', async () => {
+  it('should render with status off', () => {
     renderComponentView('off');
 
     expect(screen.getByText('Refiner off')).toBeInTheDocument();

--- a/client/src/hooks/Login.tsx
+++ b/client/src/hooks/Login.tsx
@@ -21,7 +21,7 @@ export function useLogin(): [User | null, boolean] {
           return;
         }
 
-        const data: User | null = await resp.json();
+        const data = (await resp.json()) as User | null;
         if (data) {
           setUser(data);
           setIsLoading(false);
@@ -34,7 +34,7 @@ export function useLogin(): [User | null, boolean] {
         setIsLoading(false);
       }
     }
-    fetchUserInfo();
+    void fetchUserInfo();
   }, []);
 
   return [user, isLoading];

--- a/client/src/pages/Configurations/index.test.tsx
+++ b/client/src/pages/Configurations/index.test.tsx
@@ -11,12 +11,12 @@ const renderPageView = () =>
   );
 
 describe('Configurations', () => {
-  it('should contain a table with certain columns', async () => {
+  it('should contain a table with certain columns', () => {
     renderPageView();
 
     expect(screen.getByTestId('table')).toBeInTheDocument();
   });
-  it('should contain a call-to-action button', async () => {
+  it('should contain a call-to-action button', () => {
     renderPageView();
     expect(
       screen.getByText('Set up new condition', {
@@ -24,7 +24,7 @@ describe('Configurations', () => {
       })
     ).toBeInTheDocument();
   });
-  it('should have a search component with correct placeholder', async () => {
+  it('should have a search component with correct placeholder', () => {
     renderPageView();
     expect(
       screen.getByPlaceholderText('Search configurations')

--- a/client/src/pages/Testing/RunTest.tsx
+++ b/client/src/pages/Testing/RunTest.tsx
@@ -51,7 +51,10 @@ export function RunTest({
                 <span>You can try out eCR Refiner with our test file.</span>
               </p>
               <div className="flex flex-col items-center gap-4 md:flex-row">
-                <Button variant="secondary" onClick={onClickSampleFile}>
+                <Button
+                  variant="secondary"
+                  onClick={() => void onClickSampleFile()}
+                >
                   Use test file
                 </Button>
                 <a
@@ -100,7 +103,7 @@ function UploadZipFile({
         {selectedFile ? <p>{selectedFile.name}</p> : null}
         <div className="flex items-center gap-4">
           {selectedFile ? (
-            <Button onClick={onClick}>Upload .zip file</Button>
+            <Button onClick={() => void onClick()}>Upload .zip file</Button>
           ) : null}
           <label className={labelStyling} htmlFor="zip-upload">
             {selectedFile ? (

--- a/client/src/pages/Testing/Success.tsx
+++ b/client/src/pages/Testing/Success.tsx
@@ -86,7 +86,7 @@ export function Success({
           </div>
           <div>
             <div className="flex flex-col items-start gap-3">
-              <Button onClick={async () => await downloadFile(downloadToken)}>
+              <Button onClick={() => void downloadFile(downloadToken)}>
                 Download results
               </Button>
               {downloadError ? <span>File download has expired.</span> : null}

--- a/client/src/services/demo.ts
+++ b/client/src/services/demo.ts
@@ -48,11 +48,11 @@ export async function uploadCustomZipFile(
   const resp = await fetch(uploadRoute, options);
 
   if (!resp.ok) {
-    const errorResp: DemoUploadError = await resp.json();
+    const errorResp = (await resp.json()) as DemoUploadError;
     throw new ApiUploadError(errorResp.detail);
   }
 
-  return resp.json();
+  return (await resp.json()) as DemoUploadResponse;
 }
 
 /**
@@ -71,5 +71,5 @@ export async function uploadDemoFile(): Promise<DemoUploadResponse> {
     throw new ApiUploadError('Unable to perform demo upload.');
   }
 
-  return resp.json();
+  return (await resp.json()) as DemoUploadResponse;
 }

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -21,5 +21,5 @@
     "noUncheckedSideEffectImports": false,
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "tests/setup.ts"]
 }


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This is a small quality of life change that enforces stricter rules in the client TypeScript code. ESLint will now make use of TypeScript type info to try to prevent mistakes it wasn't able to discover before, such as enforcing that Promises be awaited.