### PR TITLE
fix: seeding script prefers `title` over `name` for condition's `display_name`

### DIFF
--- a/refiner/scripts/seed_db.py
+++ b/refiner/scripts/seed_db.py
@@ -296,7 +296,7 @@ def seed_database(db_url) -> None:
                     "canonical_url": parent.get("url"),
                     "version": parent.get("version"),
                     "display_name": (
-                        parent.get("name") or parent.get("title") or ""
+                        parent.get("title") or parent.get("name") or ""
                     ).replace("_", " "),
                     "child_rsg_snomed_codes": list(child_snomed_codes),
                     "loinc_codes": json.dumps(aggregated_codes["loinc_codes"]),


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

It was [noted](https://skylight-hq.slack.com/archives/C08H7EV6M37/p1757002082098679) that some of the condition names displayed by the Refiner UI were being bunched together.

This PR updates the seeding script to check if a condition's `title` is available first and to use that over `name` (when possible) to populate a condition's `display_name` field.

## 📺 Example

Here are a few conditions I've picked out to help clearly display the change:
<img width="1261" height="465" alt="image" src="https://github.com/user-attachments/assets/2c2b6a41-3314-4e41-885b-9727de6f6482" />

## 🧪 How to test

Testing the application:

1. Run `docker compose up`
2. Run `just db seed` to run the seeding script
3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
4. Try adding a new configuration
5. You'll notice the names in the condition list now look as they should (for example, `COVID-19` instead of `COVID19`)