### PR TITLE
chore: add `just` command to refresh local database

### DIFF
--- a/.justscripts/just/database.just
+++ b/.justscripts/just/database.just
@@ -19,3 +19,8 @@ clean:
 [doc('Runs the seeding script to seed the database with condition data')]
 seed:
     docker compose run --rm seed
+
+[group('db')]
+[doc('Runs a full database refresh (wipe, migrate, seed)')]
+refresh:
+    just db clean && just migrate local && just db seed


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds a `just` helper command that performs a "refresh" of the local development database, which is a shortcut for running the following:
1. Wiping the DB of all data (`just db clean`)
2. Running migrations (`just migrate local`)
3. Seeding the database (`just db seed`)

## 🧪 How to test

With your containers running, you should be able to simply run `just db refresh`. Once complete, you should be able to log-in to the application locally and see that all user-created data has been wiped.
