### PR TITLE
chore: Add FastAPI GZip middleware

### DIFF
--- a/refiner/app/main.py
+++ b/refiner/app/main.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, FastAPI, Request, Response, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from psycopg.rows import dict_row
@@ -149,6 +150,7 @@ if ENVIRONMENT["ENV"] == "local":
     )
 
 app.add_middleware(SessionMiddleware, secret_key=get_session_secret_key())
+app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=5)
 
 
 @app.middleware("http")


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds the [FastAPI GZipMiddleware](https://fastapi.tiangolo.com/advanced/middleware/#gzipmiddleware) so that the assets sent to the client are automatically compressed. This should greatly reduce the amount of data going over the wire to the client's browser.

I have tested this both locally and in the live demo environment. It appears to work as expected in both places.

## 🧪 How to test

The easiest way to test this is to locally compare this branch with `main`. Here are the steps to do that:

Starting from the top-level directory: `dibbs-ecr-refiner`

1. Run `cd client && npm run build` to create a `dist` directory within `client`
2. Run `mv dist ../refiner`

Now that you have a current production build, you can view this at [http://localhost:8080](http://localhost:8080). I'd recommend switching over to `main` first and loading this up in an incognito tab (this will prevent extensions from skewing the results).

In the dev console click on the `Network` tab. Your browser should look something like this. Take a look at the bottom of the network tab and inspect the size of the data transferred.
<img width="1596" height="982" alt="image" src="https://github.com/user-attachments/assets/fecf577f-e9a7-4cc1-9b0b-6204435e0e53" />

Once you've made note of the above, swap over to this branch and reload the page (make sure you've cleared the network tab first). Take a look at the bottom of the network tab again and you should see a significantly reduced amount of data being transferred.

Here is what mine looks like:
<img width="1591" height="981" alt="image" src="https://github.com/user-attachments/assets/8885b0e6-53da-455b-9feb-8b5f82980197" />


## ℹ️ Additional Information

There are other things we can do to limit the amount of data we send to the client but this is a pretty solid first step.