### PR TITLE
fix: label and condition combo box should render together

### DIFF
--- a/client/src/pages/Configurations/index.tsx
+++ b/client/src/pages/Configurations/index.tsx
@@ -119,26 +119,32 @@ function NewConfigModal({ modalRef }: NewConfigModalProps) {
       <p id="add-configuration-modal-description" className="sr-only">
         Select a reportable condition you'd like to configure.
       </p>
-      <Label htmlFor="new-condition" className="!leading-6" data-focus="true">
-        Condition
-      </Label>
       {isLoading || !response?.data ? (
-        'Loading...'
+        'Loading conditions...'
       ) : (
-        <ComboBox
-          id="new-condition"
-          ref={comboBoxRef}
-          name="new-condition"
-          options={response?.data.map((condition) => ({
-            value: condition.id,
-            label: condition.display_name,
-          }))}
-          onChange={(conditionId) => {
-            const found =
-              response.data.find((c) => c.id === conditionId) ?? null;
-            setSelectedCondition(found);
-          }}
-        />
+        <>
+          <Label
+            htmlFor="new-condition"
+            className="!leading-6"
+            data-focus="true"
+          >
+            Condition
+          </Label>
+          <ComboBox
+            id="new-condition"
+            ref={comboBoxRef}
+            name="new-condition"
+            options={response?.data.map((condition) => ({
+              value: condition.id,
+              label: condition.display_name,
+            }))}
+            onChange={(conditionId) => {
+              const found =
+                response.data.find((c) => c.id === conditionId) ?? null;
+              setSelectedCondition(found);
+            }}
+          />
+        </>
       )}
       <ModalFooter className="flex justify-self-end">
         <Button


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR fixes an issue with the "set up a new condition" modal where the label would be present but the combo box it describes was not. The combo box is only rendered once a successful API call to fetch conditions is returned to the client.

The label and combo box will now be rendered together once the data for the combo box is available.

## 🧪 How to test

On `main`, you'll see that Chrome gives an error in the dev tools about this issue. You'll no longer see this reported when using this branch.
<img width="606" height="1182" alt="image" src="https://github.com/user-attachments/assets/8479d8a2-65af-462f-bf1d-273752e80997" />

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
