### PR TITLE
refactor: Prefer `mutate` to `mutateAsync`

### DIFF
--- a/client/src/pages/Configurations/ConfigBuild/index.test.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/index.test.tsx
@@ -183,7 +183,7 @@ describe('Config builder page', () => {
     });
 
     (useDeleteCustomCodeFromConfiguration as unknown as Mock).mockReturnValue({
-      mutateAsync: vi.fn().mockReturnValue({ data: {} }),
+      mutate: vi.fn().mockReturnValue({ data: {} }),
       isPending: false,
       isError: false,
       reset: vi.fn(),
@@ -238,7 +238,7 @@ describe('Config builder page', () => {
     });
 
     (useDeleteCustomCodeFromConfiguration as unknown as Mock).mockReturnValue({
-      mutateAsync: vi.fn().mockReturnValue({ data: {} }),
+      mutate: vi.fn().mockReturnValue({ data: {} }),
       isPending: false,
       isError: false,
       reset: vi.fn(),
@@ -291,7 +291,7 @@ describe('Config builder page', () => {
     });
 
     (useDeleteCustomCodeFromConfiguration as unknown as Mock).mockReturnValue({
-      mutateAsync: vi.fn().mockReturnValue({ data: {} }),
+      mutate: vi.fn().mockReturnValue({ data: {} }),
       isPending: false,
       isError: false,
       reset: vi.fn(),

--- a/client/src/pages/Configurations/ConfigBuild/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/index.tsx
@@ -248,7 +248,7 @@ function CustomCodesDetail({
   modalRef,
   customCodes,
 }: CustomCodesDetailProps) {
-  const { mutateAsync: deleteCode } = useDeleteCustomCodeFromConfiguration();
+  const { mutate: deleteCode } = useDeleteCustomCodeFromConfiguration();
   const [selectedCustomCode, setSelectedCustomCode] =
     useState<DbConfigurationCustomCode | null>(null);
   const queryClient = useQueryClient();
@@ -292,8 +292,8 @@ function CustomCodesDetail({
                 <button
                   className="!text-blue-cool-50 !no-underline hover:!cursor-pointer hover:!underline"
                   aria-label={`Delete custom code ${customCode.name}`}
-                  onClick={async () => {
-                    await deleteCode(
+                  onClick={() => {
+                    deleteCode(
                       {
                         code: customCode.code,
                         system: customCode.system,

--- a/client/src/pages/Configurations/index.test.tsx
+++ b/client/src/pages/Configurations/index.test.tsx
@@ -28,7 +28,7 @@ vi.mock('../../api/configurations/configurations', async () => {
       error: null,
     })),
     useCreateConfiguration: vi.fn(() => ({
-      mutateAsync: vi.fn().mockResolvedValue({ data: {} }),
+      mutate: vi.fn().mockResolvedValue({ data: {} }),
       isPending: false,
       isError: false,
       reset: vi.fn(),
@@ -98,7 +98,7 @@ describe('Configurations Page', () => {
     const user = userEvent.setup();
 
     // Mock the mutation to trigger onError
-    const mockMutateAsync = vi.fn().mockImplementation(
+    const mockMutate = vi.fn().mockImplementation(
       (
         _: { data: { condition_id: string } },
         options: {
@@ -115,7 +115,7 @@ describe('Configurations Page', () => {
     );
 
     (useCreateConfiguration as unknown as Mock).mockReturnValue({
-      mutateAsync: mockMutateAsync,
+      mutate: mockMutate,
       isPending: false,
       isError: false,
       reset: vi.fn(),
@@ -151,7 +151,7 @@ describe('Configurations Page', () => {
       name: 'Anaplasmosis',
     };
 
-    const mockMutateAsync = vi.fn().mockImplementation(
+    const mockMutate = vi.fn().mockImplementation(
       (
         _: { data: { condition_id: string } },
         options: {
@@ -168,7 +168,7 @@ describe('Configurations Page', () => {
 
     // navigate to reportable conditions
     (useCreateConfiguration as unknown as Mock).mockReturnValue({
-      mutateAsync: mockMutateAsync,
+      mutate: mockMutate,
       data: { data: response },
       isLoading: false,
       isError: false,

--- a/client/src/pages/Configurations/index.tsx
+++ b/client/src/pages/Configurations/index.tsx
@@ -102,7 +102,7 @@ function NewConfigModal({ modalRef }: NewConfigModalProps) {
   const [selectedCondition, setSelectedCondition] =
     useState<GetConditionsResponse | null>(null);
 
-  const { mutateAsync } = useCreateConfiguration();
+  const { mutate: createConfig } = useCreateConfiguration();
   const navigate = useNavigate();
   const formatError = useApiErrorFormatter();
 
@@ -154,37 +154,33 @@ function NewConfigModal({ modalRef }: NewConfigModalProps) {
         <Button
           variant={`${selectedCondition ? 'primary' : 'disabled'}`}
           disabled={!selectedCondition}
-          onClick={async () => {
+          onClick={() => {
             if (!selectedCondition) return;
-            try {
-              await mutateAsync(
-                { data: { condition_id: selectedCondition.id } },
-                {
-                  onSuccess: async (resp) => {
-                    await navigate(`/configurations/${resp.data.id}/build`);
-                    comboBoxRef.current?.clearSelection();
-                    modalRef.current?.toggleModal();
-                    showToast({
-                      heading: 'New configuration created',
-                      body: selectedCondition?.display_name ?? '',
-                    });
-                    setSelectedCondition(null);
-                  },
-                  onError: (e) => {
-                    showToast({
-                      heading: 'Configuration could not be created',
-                      variant: 'error',
-                      body: formatError(e),
-                    });
-                    comboBoxRef.current?.clearSelection();
-                    modalRef.current?.toggleModal();
-                    setSelectedCondition(null);
-                  },
-                }
-              );
-            } catch {
-              // no-op: handled in onError
-            }
+            createConfig(
+              { data: { condition_id: selectedCondition.id } },
+              {
+                onSuccess: async (resp) => {
+                  await navigate(`/configurations/${resp.data.id}/build`);
+                  comboBoxRef.current?.clearSelection();
+                  modalRef.current?.toggleModal();
+                  showToast({
+                    heading: 'New configuration created',
+                    body: selectedCondition?.display_name ?? '',
+                  });
+                  setSelectedCondition(null);
+                },
+                onError: (e) => {
+                  showToast({
+                    heading: 'Configuration could not be created',
+                    variant: 'error',
+                    body: formatError(e),
+                  });
+                  comboBoxRef.current?.clearSelection();
+                  modalRef.current?.toggleModal();
+                  setSelectedCondition(null);
+                },
+              }
+            );
           }}
         >
           Add condition


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR modifies a few existing usages of `mutateAsync` to instead be `mutate`. This was due to a misunderstanding initially about which function is the correct function to use.

We should generally reach for `mutate`, however, it is [worth understanding when mutateAsync should be used](https://tanstack.com/query/v5/docs/framework/react/guides/mutations#promises). We use `mutateAsync` in the demo flow to upload a file, which is a correct usage.


## 🧪 How to test

Automated tests (`npm run test`) continue to pass and the app functions as it did previously.