### PR TITLE
fix: `S3_ENDPOINT_URL` should not need to be provided in a live environment

### DIFF
--- a/refiner/app/services/aws/s3.py
+++ b/refiner/app/services/aws/s3.py
@@ -1,3 +1,4 @@
+import os
 from datetime import date
 from io import BytesIO
 from logging import Logger
@@ -13,7 +14,7 @@ s3_client = boto3.client(
     region_name=ENVIRONMENT["AWS_REGION"],
     aws_access_key_id=ENVIRONMENT["AWS_ACCESS_KEY_ID"],
     aws_secret_access_key=ENVIRONMENT["AWS_SECRET_ACCESS_KEY"],
-    endpoint_url=ENVIRONMENT["S3_ENDPOINT_URL"],
+    endpoint_url=os.getenv("S3_ENDPOINT_URL"),
 )
 
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR addresses an issue where the `S3_ENDPOINT_URL` environment variable needed for localstack was marked as required. This variable does not need to be set in live environments.

## 🧪 How to test

1. Shut down your containers
2. Delete `S3_ENDPOINT_URL` from `docker-compose.yaml`
3. Start your containers up
4. You should see the application load up and work