### PR TITLE
fix: accept S3 upload bucket name as an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The eCR Refiner requires the following environment variables to be specified in 
 - `AWS_ACCESS_KEY_ID`: The access key for your AWS account
 - `AWS_SECRET_ACCESS_KEY`: The secret key for your AWS account
 - `AWS_REGION`: The AWS region to use
+- `S3_UPLOADED_FILES_BUCKET_NAME`: Name of the S3 bucket that holds user-uploaded eICR/RR pairs
 
 Examples of the required environment variables can be seen in the project's [docker-compose.yaml](./docker-compose.yaml) file under `refiner-service`.
 

--- a/client/src/api/configurations/configurations.ts
+++ b/client/src/api/configurations/configurations.ts
@@ -369,8 +369,8 @@ export const useAssociateConditionWithConfiguration = <TError = AxiosError<HTTPV
 Args:
     configuration_id (UUID): ID of the configuration
     condition_id (UUID): ID of the condition to remove
-    user (dict[str, Any], optional): User making the request
-    db (AsyncDatabaseConnection, optional): Database connection
+    user (DbUser): User making the request
+    db (AsyncDatabaseConnection): Database connection
 
 Raises:
     HTTPException: 404 if configuration is not found in JD

--- a/client/src/api/schemas/associateCodesetResponse.ts
+++ b/client/src/api/schemas/associateCodesetResponse.ts
@@ -7,9 +7,6 @@
  */
 import type { ConditionEntry } from './conditionEntry';
 
-/**
- * Response from adding a code set to a config.
- */
 export interface AssociateCodesetResponse {
   id: string;
   included_conditions: ConditionEntry[];

--- a/client/src/api/schemas/condition.ts
+++ b/client/src/api/schemas/condition.ts
@@ -7,9 +7,6 @@
  */
 import type { ConditionProcessingInfo } from './conditionProcessingInfo';
 
-/**
- * Model for a Condition.
- */
 export interface Condition {
   code: string;
   display_name: string;

--- a/client/src/api/schemas/conditionEntry.ts
+++ b/client/src/api/schemas/conditionEntry.ts
@@ -6,9 +6,6 @@
  * OpenAPI spec version: 1.0.0
  */
 
-/**
- * Condition model.
- */
 export interface ConditionEntry {
   canonical_url: string;
   version: string;

--- a/client/src/api/schemas/conditionProcessingInfo.ts
+++ b/client/src/api/schemas/conditionProcessingInfo.ts
@@ -6,9 +6,6 @@
  * OpenAPI spec version: 1.0.0
  */
 
-/**
- * Model for a Condition's processing information.
- */
 export interface ConditionProcessingInfo {
   condition_specific: boolean;
   sections_processed: string;

--- a/client/src/api/schemas/configurationCustomCodeResponse.ts
+++ b/client/src/api/schemas/configurationCustomCodeResponse.ts
@@ -8,9 +8,6 @@
 import type { DbTotalConditionCodeCount } from './dbTotalConditionCodeCount';
 import type { DbConfigurationCustomCode } from './dbConfigurationCustomCode';
 
-/**
- * Configuration response for custom code operations (add/edit/delete).
- */
 export interface ConfigurationCustomCodeResponse {
   id: string;
   display_name: string;

--- a/client/src/api/schemas/createConfigurationResponse.ts
+++ b/client/src/api/schemas/createConfigurationResponse.ts
@@ -6,9 +6,6 @@
  * OpenAPI spec version: 1.0.0
  */
 
-/**
- * Configuration creation response model.
- */
 export interface CreateConfigurationResponse {
   id: string;
   name: string;

--- a/client/src/api/schemas/dbConfigurationCustomCode.ts
+++ b/client/src/api/schemas/dbConfigurationCustomCode.ts
@@ -7,9 +7,6 @@
  */
 import type { DbConfigurationCustomCodeSystem } from './dbConfigurationCustomCodeSystem';
 
-/**
- * Custom code associated with a Configuration.
- */
 export interface DbConfigurationCustomCode {
   code: string;
   system: DbConfigurationCustomCodeSystem;

--- a/client/src/api/schemas/dbTotalConditionCodeCount.ts
+++ b/client/src/api/schemas/dbTotalConditionCodeCount.ts
@@ -6,9 +6,6 @@
  * OpenAPI spec version: 1.0.0
  */
 
-/**
- * Total code count model.
- */
 export interface DbTotalConditionCodeCount {
   condition_id: string;
   display_name: string;

--- a/client/src/api/schemas/getConditionCode.ts
+++ b/client/src/api/schemas/getConditionCode.ts
@@ -6,9 +6,6 @@
  * OpenAPI spec version: 1.0.0
  */
 
-/**
- * Model for a condition code.
- */
 export interface GetConditionCode {
   code: string;
   system: string;

--- a/client/src/api/schemas/getConditionResponse.ts
+++ b/client/src/api/schemas/getConditionResponse.ts
@@ -7,9 +7,6 @@
  */
 import type { GetConditionCode } from './getConditionCode';
 
-/**
- * Condition response model.
- */
 export interface GetConditionResponse {
   id: string;
   display_name: string;

--- a/client/src/api/schemas/getConditionsResponse.ts
+++ b/client/src/api/schemas/getConditionsResponse.ts
@@ -6,9 +6,6 @@
  * OpenAPI spec version: 1.0.0
  */
 
-/**
- * Conditions response model.
- */
 export interface GetConditionsResponse {
   id: string;
   display_name: string;

--- a/client/src/api/schemas/getConfigurationResponse.ts
+++ b/client/src/api/schemas/getConfigurationResponse.ts
@@ -9,9 +9,6 @@ import type { DbTotalConditionCodeCount } from './dbTotalConditionCodeCount';
 import type { IncludedCondition } from './includedCondition';
 import type { DbConfigurationCustomCode } from './dbConfigurationCustomCode';
 
-/**
- * Information about a specific configuration to return to the client.
- */
 export interface GetConfigurationResponse {
   id: string;
   display_name: string;

--- a/client/src/api/schemas/getConfigurationsResponse.ts
+++ b/client/src/api/schemas/getConfigurationsResponse.ts
@@ -6,9 +6,6 @@
  * OpenAPI spec version: 1.0.0
  */
 
-/**
- * Model for a user-defined configuration.
- */
 export interface GetConfigurationsResponse {
   id: string;
   name: string;

--- a/client/src/api/schemas/includedCondition.ts
+++ b/client/src/api/schemas/includedCondition.ts
@@ -6,9 +6,6 @@
  * OpenAPI spec version: 1.0.0
  */
 
-/**
- * Model for a condition that is associated with a configuration.
- */
 export interface IncludedCondition {
   id: string;
   display_name: string;

--- a/client/src/api/schemas/refinedTestingDocument.ts
+++ b/client/src/api/schemas/refinedTestingDocument.ts
@@ -7,9 +7,6 @@
  */
 import type { Condition } from './condition';
 
-/**
- * Model for the response when uploading a document in the testing suite.
- */
 export interface RefinedTestingDocument {
   message: string;
   conditions_found: number;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=refiner
       - AWS_REGION=us-east-1
       - S3_ENDPOINT_URL=http://localhost:4566
+      - S3_UPLOADED_FILES_BUCKET_NAME=refiner-app
     logging:
       driver: "json-file"
     depends_on:

--- a/refiner/app/core/config.py
+++ b/refiner/app/core/config.py
@@ -48,4 +48,5 @@ ENVIRONMENT: dict[str, str] = {
     "AWS_SECRET_ACCESS_KEY": _get_env_variable("AWS_SECRET_ACCESS_KEY"),
     "AWS_REGION": _get_env_variable("AWS_REGION"),
     "S3_ENDPOINT_URL": _get_env_variable("S3_ENDPOINT_URL"),
+    "S3_UPLOADED_FILES_BUCKET_NAME": _get_env_variable("S3_UPLOADED_FILES_BUCKET_NAME"),
 }

--- a/refiner/app/services/aws/s3.py
+++ b/refiner/app/services/aws/s3.py
@@ -36,7 +36,6 @@ def upload_refined_ecr(
         str: The pre-signed S3 URL to download the uploaded file
     """
 
-    # bucket_name = "refiner-app"
     expires = 3600  # 1 hour
 
     try:

--- a/refiner/app/services/aws/s3.py
+++ b/refiner/app/services/aws/s3.py
@@ -9,6 +9,8 @@ from botocore.exceptions import ClientError
 
 from ...core.config import ENVIRONMENT
 
+uploaded_artifact_bucket_name = ENVIRONMENT["S3_UPLOADED_FILES_BUCKET_NAME"]
+
 s3_client = boto3.client(
     "s3",
     region_name=ENVIRONMENT["AWS_REGION"],
@@ -34,18 +36,18 @@ def upload_refined_ecr(
         str: The pre-signed S3 URL to download the uploaded file
     """
 
-    bucket_name = "refiner-app"
+    # bucket_name = "refiner-app"
     expires = 3600  # 1 hour
 
     try:
         today = date.today().isoformat()  # YYYY-MM-DD
         key = f"refiner-test-suite/{today}/{user_id}/{filename}"
 
-        s3_client.upload_fileobj(file_buffer, bucket_name, key)
+        s3_client.upload_fileobj(file_buffer, uploaded_artifact_bucket_name, key)
 
         presigned_url = s3_client.generate_presigned_url(
             "get_object",
-            Params={"Bucket": bucket_name, "Key": key},
+            Params={"Bucket": uploaded_artifact_bucket_name, "Key": key},
             ExpiresIn=expires,
         )
 
@@ -56,7 +58,7 @@ def upload_refined_ecr(
             "Attempted refined file upload to S3 failed",
             extra={
                 "error": str(e),
-                "bucket": bucket_name,
+                "bucket": uploaded_artifact_bucket_name,
                 "key": key,
                 "user_id": user_id,
             },

--- a/refiner/tests/conftest.py
+++ b/refiner/tests/conftest.py
@@ -13,6 +13,7 @@ os.environ["AWS_ACCESS_KEY_ID"] = "mock-aws-access-key-id"
 os.environ["AWS_SECRET_ACCESS_KEY"] = "mock-aws-secret-access-key"
 os.environ["AWS_REGION"] = "us-mock-1"
 os.environ["S3_ENDPOINT_URL"] = "http://localhost:4566"
+os.environ["S3_UPLOADED_FILES_BUCKET_NAME"] = "mock-bucket"
 
 from pathlib import Path
 from zipfile import ZipFile


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the app to accept an `S3_UPLOADED_FILES_BUCKET_NAME`, which is the bucket where user uploaded files will be stored. It was previously hard-coded to `refiner-app` but now that we're deploying to a live environment this won't suffice anymore.

> [!NOTE]
> Ignore the generated files. It looks like the latest changes may not have made it into a previous PR and should have. This is not related to the environment variable change.

## 🧪 How to test

Refined file downloading should continue to work locally as it did previously.

**Make sure to stop your containers and bring them up again so the environment variable gets loaded in**.