### PR TITLE
fix: Explicitly set S3 signature version

### DIFF
--- a/refiner/app/services/aws/s3.py
+++ b/refiner/app/services/aws/s3.py
@@ -5,11 +5,14 @@ from logging import Logger
 from uuid import UUID
 
 import boto3
+from botocore.client import Config
 from botocore.exceptions import ClientError
 
 from ...core.config import ENVIRONMENT
 
 uploaded_artifact_bucket_name = ENVIRONMENT["S3_UPLOADED_FILES_BUCKET_NAME"]
+
+config = Config(signature_version="s3v4")
 
 s3_client = boto3.client(
     "s3",
@@ -17,6 +20,7 @@ s3_client = boto3.client(
     aws_access_key_id=ENVIRONMENT["AWS_ACCESS_KEY_ID"],
     aws_secret_access_key=ENVIRONMENT["AWS_SECRET_ACCESS_KEY"],
     endpoint_url=os.getenv("S3_ENDPOINT_URL"),
+    config=config,
 )
 
 


### PR DESCRIPTION
# 🔀 PULL REQUEST


## 💡 Summary

This PR explicitly sets the S3 signature version to V4. This change is required to fix an error we were seeing when attempting to download KMS encrypted files.

[More detail here.](https://skylight-hq.slack.com/archives/C08H7EV6M37/p1758657045916439?thread_ts=1758649387.009659&cid=C08H7EV6M37)

## 🧪 How to test

- [Confirmed with Alis this works in the demo environment](https://skylight-hq.slack.com/archives/C08H7EV6M37/p1758748434427329?thread_ts=1758649387.009659&cid=C08H7EV6M37)
- You should see no change when downloading a refined file locally

