### PR TITLE
test: update integration test to use correct endpoint

### DIFF
--- a/refiner/tests/conftest.py
+++ b/refiner/tests/conftest.py
@@ -11,7 +11,7 @@ os.environ["SESSION_SECRET_KEY"] = "mock-session-secret"
 
 os.environ["AWS_ACCESS_KEY_ID"] = "mock-aws-access-key-id"
 os.environ["AWS_SECRET_ACCESS_KEY"] = "mock-aws-secret-access-key"
-os.environ["AWS_REGION"] = "us-mock-1"
+os.environ["AWS_REGION"] = "us-east-1"
 os.environ["S3_ENDPOINT_URL"] = "http://localhost:4566"
 os.environ["S3_UPLOADED_FILES_BUCKET_NAME"] = "mock-bucket"
 

--- a/refiner/tests/integration/test_export.py
+++ b/refiner/tests/integration/test_export.py
@@ -15,7 +15,7 @@ class TestConfigurationExportBasic:
     async def test_export_endpoint_does_not_crash(self, setup, authed_client):
         # Use a dummy UUID so we don't depend on seeded data
         dummy_id = "00000000-0000-0000-0000-000000000000"
-        response = await authed_client.get(f"/api/configurations/{dummy_id}/export")
+        response = await authed_client.get(f"/api/v1/configurations/{dummy_id}/export")
 
         # Endpoint should at least return a proper HTTP status, not hang.
         # Accept 200 (success), 404 (not found), or 500 (server error when DB empty).


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

- Update the route in the test to include `/v1/`
- Update mock AWS region to `us-east-1` (arbitrary choice) so that localstack doesn't display a warning about an incorrect region being used