### PR TITLE
fix: prefer `isPending` to `isLoading` when performing requests

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -95,9 +95,9 @@ Continuing from the example above, the `useGetConfigurations` hook will be gener
 
 ```tsx
 function MyPage() {
-  const { data, isError, isLoading } = useGetConfigurations();
+  const { data, isPending, isError } = useGetConfigurations();
 
-  if (isLoading || !data?.data) return 'Loading...';
+  if (isPending) return 'Loading...';
   if (isError) return 'Error occurred!';
 
   return <div>{data.data.length === 0 ? 'No data' : data.data[0].name}</div>;

--- a/client/src/pages/Configurations/ConfigBuild/index.test.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/index.test.tsx
@@ -50,8 +50,6 @@ vi.mock('../../../api/configurations/configurations', async () => {
           ],
         },
       },
-      isLoading: false,
-      isError: false,
     })),
   };
 });
@@ -72,8 +70,6 @@ vi.mock('../../../api/conditions/conditions', async () => {
           ],
         },
       },
-      isLoading: false,
-      isError: false,
     })),
     useGetConditions: vi.fn(() => ({
       data: {
@@ -83,8 +79,6 @@ vi.mock('../../../api/conditions/conditions', async () => {
           { id: 'gonorrhea-1', display_name: 'Gonorrhea' },
         ],
       },
-      isLoading: false,
-      error: null,
     })),
   };
 });
@@ -188,22 +182,16 @@ describe('Config builder page', () => {
 
     (useAddCustomCodeToConfiguration as unknown as Mock).mockReturnValue({
       mutate: vi.fn().mockReturnValue({ data: {} }),
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 
     (useEditCustomCodeFromConfiguration as unknown as Mock).mockReturnValue({
       mutate: vi.fn().mockReturnValue({ data: {} }),
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 
     (useDeleteCustomCodeFromConfiguration as unknown as Mock).mockReturnValue({
       mutate: vi.fn().mockReturnValue({ data: {} }),
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 
@@ -243,22 +231,16 @@ describe('Config builder page', () => {
 
     (useAddCustomCodeToConfiguration as unknown as Mock).mockReturnValue({
       mutate: vi.fn().mockReturnValue({ data: {} }),
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 
     (useEditCustomCodeFromConfiguration as unknown as Mock).mockReturnValue({
       mutate: vi.fn().mockReturnValue({ data: {} }),
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 
     (useDeleteCustomCodeFromConfiguration as unknown as Mock).mockReturnValue({
       mutate: vi.fn().mockReturnValue({ data: {} }),
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 
@@ -296,22 +278,16 @@ describe('Config builder page', () => {
 
     (useAddCustomCodeToConfiguration as unknown as Mock).mockReturnValue({
       mutate: vi.fn().mockReturnValue({ data: {} }),
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 
     (useEditCustomCodeFromConfiguration as unknown as Mock).mockReturnValue({
       mutate: vi.fn().mockReturnValue({ data: {} }),
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 
     (useDeleteCustomCodeFromConfiguration as unknown as Mock).mockReturnValue({
       mutate: vi.fn().mockReturnValue({ data: {} }),
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 

--- a/client/src/pages/Configurations/ConfigBuild/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/index.tsx
@@ -47,15 +47,9 @@ import { useApiErrorFormatter } from '../../../hooks/useErrorFormatter';
 
 export default function ConfigBuild() {
   const { id } = useParams<{ id: string }>();
-  const {
-    data: response,
-    isLoading,
-    isError,
-  } = useGetConfiguration(id ?? '', {
-    query: { enabled: !!id },
-  });
+  const { data: response, isPending, isError } = useGetConfiguration(id ?? '');
 
-  if (isLoading || !response?.data) return 'Loading...';
+  if (isPending) return 'Loading...';
   if (!id || isError) return 'Error!';
 
   return (
@@ -65,7 +59,7 @@ export default function ConfigBuild() {
       </TitleContainer>
       <NavigationContainer>
         <StepsContainer>
-          <Steps configurationId={response?.data.id} />
+          <Steps configurationId={response.data.id} />
           <Button to={`/configurations/${id}/test`}>
             Next: Test configuration
           </Button>
@@ -467,7 +461,7 @@ interface ConditionCodeTableProps {
 function ConditionCodeTable({ conditionId }: ConditionCodeTableProps) {
   const DEBOUNCE_TIME_MS = 300;
 
-  const { data: response, isLoading, isError } = useGetCondition(conditionId);
+  const { data: response, isPending, isError } = useGetCondition(conditionId);
   const [selectedCodeSystem, setSelectedCodeSystem] = useState<string>('all');
   const [isLoadingResults, setIsLoadingResults] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
@@ -507,7 +501,7 @@ function ConditionCodeTable({ conditionId }: ConditionCodeTableProps) {
   // Show only the filtered codes if the user isn't searching
   const visibleCodes = searchText ? results.map((r) => r.item) : filteredCodes;
 
-  if (isLoading || !response?.data) return 'Loading...';
+  if (isPending) return 'Loading...';
   if (isError) return 'Error!';
 
   function handleCodeSystemSelect(event: React.ChangeEvent<HTMLSelectElement>) {

--- a/client/src/pages/Configurations/ConfigTest/index.test.tsx
+++ b/client/src/pages/Configurations/ConfigTest/index.test.tsx
@@ -63,8 +63,6 @@ vi.mock('../../../api/configurations/configurations', async () => {
           ],
         },
       },
-      isLoading: false,
-      isError: false,
     })),
     useRunInlineConfigurationTest: vi.fn(() => ({
       mutateAsync: vi.fn().mockResolvedValue({ data: {} }),
@@ -76,8 +74,6 @@ vi.mock('../../../api/configurations/configurations', async () => {
           refined_download_url: 'http://mocks3download.com',
         },
       },
-      isLoading: false,
-      isError: false,
     })),
   };
 });

--- a/client/src/pages/Configurations/ConfigTest/index.tsx
+++ b/client/src/pages/Configurations/ConfigTest/index.tsx
@@ -22,13 +22,13 @@ export default function ConfigTest() {
   const { id } = useParams<{ id: string }>();
   const {
     data: response,
-    isLoading,
+    isPending,
     isError,
   } = useGetConfiguration(id ?? '', {
     query: { enabled: !!id },
   });
 
-  if (isLoading || !response?.data) return 'Loading...';
+  if (isPending) return 'Loading...';
   if (!id || isError) return 'Error!';
 
   return (

--- a/client/src/pages/Configurations/index.test.tsx
+++ b/client/src/pages/Configurations/index.test.tsx
@@ -24,13 +24,9 @@ vi.mock('../../api/configurations/configurations', async () => {
           { id: '3', name: 'Zika Virus Disease', is_active: false },
         ],
       },
-      isLoading: false,
-      error: null,
     })),
     useCreateConfiguration: vi.fn(() => ({
       mutate: vi.fn().mockResolvedValue({ data: {} }),
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     })),
     useGetConfiguration: vi.fn(() => ({
@@ -50,8 +46,6 @@ vi.mock('../../api/configurations/configurations', async () => {
           ],
         },
       },
-      isLoading: false,
-      isError: false,
     })),
   };
 });
@@ -67,8 +61,6 @@ vi.mock('../../api/conditions/conditions', async () => {
           { id: 'exists-id', display_name: 'already-created' },
         ],
       },
-      isLoading: false,
-      error: null,
     })),
   };
 });
@@ -124,8 +116,6 @@ describe('Configurations Page', () => {
 
     (useCreateConfiguration as unknown as Mock).mockReturnValue({
       mutate: mockMutate,
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 
@@ -178,8 +168,6 @@ describe('Configurations Page', () => {
     (useCreateConfiguration as unknown as Mock).mockReturnValue({
       mutate: mockMutate,
       data: { data: response },
-      isLoading: false,
-      isError: false,
       reset: vi.fn(),
     });
 

--- a/client/src/pages/Configurations/index.tsx
+++ b/client/src/pages/Configurations/index.tsx
@@ -46,7 +46,7 @@ interface ConfigurationsTable {
 }
 
 export function Configurations() {
-  const { data: response, isLoading } = useGetConfigurations();
+  const { data: response, isPending, isError } = useGetConfigurations();
 
   const configs = useMemo(() => response?.data ?? [], [response?.data]);
 
@@ -56,7 +56,9 @@ export function Configurations() {
 
   const modalRef = useRef<ModalRef>(null);
 
-  if (isLoading || !response?.data) return 'Loading...';
+  if (isPending) return 'Loading...';
+
+  if (isError) return 'Error!';
 
   return (
     <section className="mx-auto p-3">
@@ -102,7 +104,7 @@ interface NewConfigModalProps {
 function NewConfigModal({ modalRef }: NewConfigModalProps) {
   const showToast = useToast();
   const comboBoxRef = useRef<ComboBoxRef>(null);
-  const { data: response, isLoading } = useGetConditions();
+  const { data: response, isPending, isError } = useGetConditions();
   const [selectedCondition, setSelectedCondition] =
     useState<GetConditionsResponse | null>(null);
 
@@ -127,8 +129,12 @@ function NewConfigModal({ modalRef }: NewConfigModalProps) {
       <p id="add-configuration-modal-description" className="sr-only">
         Select a reportable condition you'd like to configure.
       </p>
-      {isLoading || !response?.data ? (
-        'Loading conditions...'
+      {isPending ? (
+        'Loading...'
+      ) : isError ? (
+        <p className="text-state-error-dark">
+          Failed to load conditions. Please try again.
+        </p>
       ) : (
         <>
           <Label

--- a/client/src/pages/Testing/index.test.tsx
+++ b/client/src/pages/Testing/index.test.tsx
@@ -69,8 +69,6 @@ describe('Demo', () => {
     (useUploadEcr as unknown as Mock).mockReturnValue({
       mutateAsync: mockMutateAsync,
       data: { data: mockUploadResponse },
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 
@@ -112,8 +110,6 @@ describe('Demo', () => {
     (useUploadEcr as unknown as Mock).mockReturnValue({
       mutateAsync: mockMutateAsync,
       data: { data: mockCustomUploadResponse },
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     });
 
@@ -180,9 +176,6 @@ describe('Demo', () => {
 
             throw error;
           }),
-          data: null,
-          isPending: false,
-          isError: false,
           reset: vi.fn(),
         };
       }
@@ -216,9 +209,6 @@ it('should show PHI/PII banner in the "local" environment', () => {
   (useUploadEcr as unknown as Mock).mockImplementation(() => {
     return {
       mutateAsync: vi.fn().mockImplementation(() => {}),
-      data: null,
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     };
   });
@@ -234,9 +224,6 @@ it('should show PHI/PII banner in the "demo" environment', () => {
   (useUploadEcr as unknown as Mock).mockImplementation(() => {
     return {
       mutateAsync: vi.fn().mockImplementation(() => {}),
-      data: null,
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     };
   });
@@ -252,9 +239,6 @@ it('should NOT show PHI/PII banner in the "prod" environment', () => {
   (useUploadEcr as unknown as Mock).mockImplementation(() => {
     return {
       mutateAsync: vi.fn().mockImplementation(() => {}),
-      data: null,
-      isPending: false,
-      isError: false,
       reset: vi.fn(),
     };
   });

--- a/client/tests/setup.ts
+++ b/client/tests/setup.ts
@@ -2,9 +2,19 @@
 import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
-// import * as matchers from "@testing-library/jest-dom/matchers";
 
-// expect.extend(matchers);
+/**
+ * Simulates index.html having this meta tag
+ * <meta name="app-env" content="test" />
+ *
+ * Prevents console errors from being written during testing.
+ */
+beforeAll(() => {
+  const meta = document.createElement('meta');
+  meta.name = 'app-env';
+  meta.content = 'test';
+  document.head.appendChild(meta);
+});
 
 async function mock(mockedUri: string, stub: unknown) {
   const { Module } = (await import('module')) as unknown as {


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

<!--
What changes are being proposed?
-->

## 🔗 Related Issue

<!--
add the issue number in both places:
Fixes #3
- #3
-->

Fixes #
- #

## ✅ Acceptance Criteria

<!--
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
-->

## 🧪 How to test

<!--
Unit tests

1. From the project root make sure you're in the `refiner/` directory
2. Activate a virtual environment using your tool of choice
3. Make sure that both `requirements.txt` and `requirements-dev.txt` are installed
4. Run the unit tests with `pytest -vv tests/`
5. Additionally you can check coverage with `pytest --cov=app tests`

or

Testing the application:

1. Run `docker compose up`
2. Check that both services are up and running with `docker ps`
3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
4. You should be able to [insert goal you want to accomplish!]
-->

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
