### PR TITLE
style: Make download link style consistent

### DIFF
--- a/client/src/components/Button/index.tsx
+++ b/client/src/components/Button/index.tsx
@@ -33,7 +33,7 @@ export function Button({
       variant === 'disabled',
     'bg-transparent text-black hover:!bg-transparent hover:!text-black active:!bg-transparent active:!text-black':
       variant === 'selected',
-    '!bg-transparent !text-blue-cool-50 hover:!text-blue-cool-60  hover:cursor-pointer active:!text-blue-cool-60 !p-0 !m-0':
+    '!bg-transparent !text-blue-cool-60 hover:!underline hover:cursor-pointer !p-0 !m-0':
       variant === 'tertiary',
   });
 

--- a/client/src/components/Diff/index.tsx
+++ b/client/src/components/Diff/index.tsx
@@ -51,7 +51,6 @@ export function Diff({
               <Button
                 variant="tertiary"
                 onClick={() => downloadFile(refined_download_url)}
-                className="text-blue-400 underline"
               >
                 Download results
               </Button>

--- a/client/src/pages/Configurations/ConfigBuild/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/index.tsx
@@ -92,7 +92,7 @@ type ExportBuilderProps = {
 export function Export({ id }: ExportBuilderProps) {
   return (
     <a
-      className="text-blue-cool-50 mt-8 mb-6 self-end font-bold hover:cursor-pointer hover:underline"
+      className="text-blue-cool-60 mt-8 mb-6 self-end font-bold hover:cursor-pointer hover:underline"
       href={`/api/v1/configurations/${id}/export`}
       download
     >
@@ -191,7 +191,7 @@ function Builder({
               ADD
             </Button>
           </OptionsLabelContainer>
-          {/* render the first code set separately / as a sticky element 
+          {/* render the first code set separately / as a sticky element
           to bypass issues with tooltip clipping */}
 
           <OptionsListContainer>

--- a/client/src/pages/Testing/RunTest.tsx
+++ b/client/src/pages/Testing/RunTest.tsx
@@ -72,7 +72,7 @@ export function RunTest({
                 Use test file
               </Button>
               <a
-                className="text-blue-cool-60 justify-start font-bold hover:underline"
+                className="text-blue-cool-60 font-bold hover:underline"
                 href="/api/v1/demo/download"
                 download
               >


### PR DESCRIPTION
# 🔀 PULL REQUEST

This PR updates all links that perform file downloads (and buttons that look like links) so that they all appear the same way. It also changes the `Export configuration` link from having the color `blue-cool-50` to `blue-cool-60`. This both solves an a11y issue I'm encountering as well as ensures all links now use the same color.

a11y issue I was seeing previously:
<img width="1595" height="858" alt="image" src="https://github.com/user-attachments/assets/ed58785c-afcc-49d7-b205-5280f82554e3" />