### PR TITLE
feat: Adds a new `just demo-db-url` that uses az

### DIFF
--- a/.justscripts/just/cloud.just
+++ b/.justscripts/just/cloud.just
@@ -1,0 +1,16 @@
+alias h := _default
+alias help := _default
+
+@_default:
+    just --list cloud
+
+az := require("az")
+
+[doc('Retrieve the DB_URL for the Demo environment')]
+[group('azure')]
+demo-db-url:
+    {{ az }} container show \
+      --name dibbs-er-demo-aci \
+      --resource-group dibbs-er-demo \
+      --query "containers[0].environmentVariables[?name=='DB_URL']" \
+      -o table

--- a/justfile
+++ b/justfile
@@ -20,6 +20,10 @@ mod m './.justscripts/just/migrate.just'
 [doc('Alias for `server`')]
 mod s './.justscripts/just/server.just'
 
+[group('alias')]
+[doc('Alias for `cloud`')]
+mod cd './.justscripts/just/cloud.just'
+
 [group('sub-command')]
 [doc('Run commands against `client/` code')]
 mod client './.justscripts/just/client.just'
@@ -44,6 +48,10 @@ mod migrate './.justscripts/just/migrate.just'
 [doc('Run server commands against `refiner/` code')]
 mod server './.justscripts/just/server.just'
 
+[group('sub-command')]
+[doc('Run commands against Azure')]
+mod cloud './.justscripts/just/cloud.just'
+
 alias l := lint
 alias t := test
 
@@ -58,14 +66,3 @@ test:
     just server::test
     just client::run test:coverage
     just client::run e2e
-
-az := require("az")
-
-[doc('Retrieve the DB_URL for the Demo environment')]
-[group('azure')]
-demo-db-url:
-    {{ az }} container show \
-      --name dibbs-er-demo-aci \
-      --resource-group dibbs-er-demo \
-      --query "containers[0].environmentVariables[?name=='DB_URL']" \
-      -o table


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

Adds a recipe that allows users to get the database URL for the Demo environment
using the `az` CLI tool. It requires users to login first.

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

Log into your Azure account using `az login`. Once logged in, run `just
cloud demo-db-url` to get an output that looks similar to the following.

```
Name    Value
------  ------------------------------
DB_URL  postgres://<REDACTED_PSQL_URL>
```
