### PR TITLE
feat: Add improved session redirect page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ refined-ecr
 
 test-results/
 playwright-report/
+
+e2e/downloads/

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import ConfigTest from './pages/Configurations/ConfigTest';
 import ConfigActivate from './pages/Configurations/ConfigActivate';
 
 import 'react-toastify/dist/ReactToastify.css';
+import SessionRedirect from './pages/SessionRedirect';
 
 function App() {
   const [user, isLoading] = useLogin();
@@ -22,7 +23,7 @@ function App() {
     return (
       <Routes>
         <Route path="/" index element={<Home />} />
-        <Route path="*" element={<NotFound />} />
+        <Route path="*" element={<SessionRedirect />} />
       </Routes>
     );
   }

--- a/client/src/components/Button/index.tsx
+++ b/client/src/components/Button/index.tsx
@@ -10,6 +10,9 @@ interface ButtonProps extends Omit<UswdsButtonProps, 'type'> {
   variant?: 'primary' | 'secondary' | 'disabled' | 'selected' | 'tertiary';
   to?: string;
 }
+export const PRIMARY_BUTTON_STYLES =
+  '!bg-violet-warm-60 hover:!bg-violet-warm-70';
+
 export const SECONDARY_BUTTON_STYLES =
   '!bg-white !text-violet-warm-60 !border-violet-warm-60 !border-[2px] !rounded-sm hover:!border-violet-warm-70 hover:!text-violet-warm-70';
 /**
@@ -27,7 +30,7 @@ export function Button({
   ...props
 }: ButtonProps) {
   const styles = classNames(className, {
-    '!bg-violet-warm-60 hover:!bg-violet-warm-70': variant === 'primary',
+    [PRIMARY_BUTTON_STYLES]: variant === 'primary',
     [SECONDARY_BUTTON_STYLES]: variant === 'secondary',
     '!bg-disabled-light !text-disabled-dark hover:!bg-disabled-light !cursor-not-allowed':
       variant === 'disabled',

--- a/client/src/pages/SessionRedirect/index.tsx
+++ b/client/src/pages/SessionRedirect/index.tsx
@@ -1,0 +1,36 @@
+import { Icon } from '@trussworks/react-uswds';
+import classNames from 'classnames';
+import { Link } from 'react-router';
+import { PRIMARY_BUTTON_STYLES } from '../../components/Button';
+import { Footer, Header } from '../../components/Layout';
+
+export default function SessionRedirect() {
+  return (
+    <div>
+      <Header />
+
+      <main>
+        <div className="flex h-screen items-center justify-center bg-gray-200">
+          <div className="mx-auto flex max-w-[40rem] flex-col items-center">
+            <Icon.Home className="text-gray-cool-50 !h-[120px] !w-[120px]"></Icon.Home>
+            <h1 className="text-center">
+              Your session has ended. <br />
+              Please log back in to access the app.
+            </h1>
+            <Link
+              to="/"
+              className={classNames(
+                PRIMARY_BUTTON_STYLES,
+                'usa-button !w-[12.5rem]'
+              )}
+            >
+              Return to home page
+            </Link>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/refiner/app/api/auth/handlers.py
+++ b/refiner/app/api/auth/handlers.py
@@ -12,6 +12,7 @@ from ...db.users.db import IdpUserResponse, upsert_user_db
 from ...services.logger import get_logger
 from .config import ENVIRONMENT, get_oauth_provider
 from .session import (
+    SESSION_EXPIRY_SECONDS,
     create_session,
     delete_session,
     get_user_from_session,
@@ -142,7 +143,7 @@ async def auth_callback(
             key="refiner-session",
             value=session_token,
             httponly=True,
-            max_age=3600,
+            max_age=SESSION_EXPIRY_SECONDS,
             samesite="lax",
             secure=env != "local",  # We'll be serving over https in live envs
         )

--- a/refiner/app/api/auth/session.py
+++ b/refiner/app/api/auth/session.py
@@ -12,7 +12,8 @@ from ...core.config import ENVIRONMENT
 from ...db.pool import db
 from ...db.users.model import DbUser
 
-SESSION_TTL = timedelta(hours=1)
+SESSION_EXPIRY_SECONDS = 3600  # one hour
+SESSION_TTL = timedelta(seconds=SESSION_EXPIRY_SECONDS)
 SESSION_SECRET_KEY = ENVIRONMENT["SESSION_SECRET_KEY"].encode("utf-8")
 
 
@@ -102,7 +103,7 @@ async def run_expired_session_cleanup_task(logger: Logger) -> None:
     """
     Task that can be scheduled to run session cleanup once per hour.
     """
-    cleanup_interval_seconds = 3600  # Run once per hour
+    cleanup_interval_seconds = SESSION_EXPIRY_SECONDS  # Run once per hour
     while True:
         try:
             await _delete_expired_sessions()


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary
Adds an improved redirect page for session expiry. 

https://github.com/user-attachments/assets/6cb39e1b-361c-414e-92c9-ea643cd8f5f0

Pushed [this branch](https://github.com/CDCgov/dibbs-ecr-refiner/tree/bob/447-test) that has session expiry set to 5 seconds for testing

## 🔗 Related Issue

Fixes #447 
- #447 

## ✅ Acceptance Criteria

- [ ] Copy "Your session has expired and you'll need to log in again." "Return to homepage" button
- [ ] Redirect to intermediate screen when user session times out with option log in again


## 🧪 How to test
- Pull the [test branch](https://github.com/CDCgov/dibbs-ecr-refiner/tree/bob/447-test) that has a shortenend session expiry for testing
- Log into the app and wait five seconds
- Refresh the page and observe the new redirect page
