### PR TITLE
fix: Remove hard-requirement for now

### DIFF
--- a/.justscripts/just/cloud.just
+++ b/.justscripts/just/cloud.just
@@ -4,12 +4,10 @@ alias help := _default
 @_default:
     just --list cloud
 
-az := require("az")
-
 [doc('Retrieve the DB_URL for the Demo environment')]
 [group('azure')]
 demo-db-url:
-    {{ az }} container show \
+    az container show \
       --name dibbs-er-demo-aci \
       --resource-group dibbs-er-demo \
       --query "containers[0].environmentVariables[?name=='DB_URL']" \


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

Fixes issues where if the `az` command is errors out. This makes the `az` binary
a responsibility for the user running the command.

## 🔗 Related Issue

- [Discussed in Slack here 🔒](https://skylight-hq.slack.com/archives/C08H7EV6M37/p1760113130143959)

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

Folks running the design script should not have to have `az` installed locally.
