### PR TITLE
fix: Change default action to `refine` & update UI

### DIFF
--- a/client/src/pages/Configurations/ConfigBuild/EicrSectionReview.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/EicrSectionReview.tsx
@@ -113,12 +113,12 @@ export default function EicrSectionReview({
       <p className="!mb-2 leading-8">Options:</p>
       <ul className="!mb-4 list-inside list-disc pl-4">
         <li>
-          <span className="font-bold">Include & refine section:</span> Includes
-          only the coded data you've chosen to retain in your configuration.
-        </li>
-        <li>
           <span className="font-bold">Include entire section:</span> Includes
           everything from this section, ignoring your configuration.
+        </li>
+        <li>
+          <span className="font-bold">Include & refine section:</span> Includes
+          only the coded data you've chosen to retain in your configuration.
         </li>
         <li>
           <span className="font-bold">Remove section:</span> Excludes this
@@ -141,10 +141,10 @@ export default function EicrSectionReview({
               Section name
             </th>
             <th scope="col" className="!text-gray-cool-60 text-center">
-              Include &amp; <br /> refine section
+              Include <br /> entire section
             </th>
             <th scope="col" className="!text-gray-cool-60 text-center">
-              Include <br /> entire section
+              Include &amp; <br /> refine section
             </th>
             <th scope="col" className="!text-gray-cool-60 text-center">
               Remove section

--- a/refiner/app/db/configurations/db.py
+++ b/refiner/app/db/configurations/db.py
@@ -67,7 +67,7 @@ async def insert_configuration_db(
         {
             "name": details["display_name"],
             "code": code,
-            "action": "retain",
+            "action": "refine",
         }
         for code, details in section_details.items()
     ]


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

Kyle reached out to me about the default action should be `refine` or **Include
& refine section**. I've updated to the new default action. Also, I noticed some
issues with the ordering of copy around the actions so that's fixed in this
patch as well.

## 🔗 Related Issue

- #146

## ✅ Acceptance Criteria

- [x] **Include & refine section** is the default action picked on first load of
      the new Sections panel.

## 🧪 How to test

- Run `just dev up` and go to http://localhost:8081.
- Create a new configuration
- Navigate to sections
- Note that the first column is selected by default
