### PR TITLE
chore: Add ESLint rule to disallow use of React component typing helpers

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -55,6 +55,25 @@ export default defineConfig(
       '@typescript-eslint/no-misused-promises': 'off',
       '@typescript-eslint/no-redundant-type-constituents': 'off',
       '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-restricted-types': [
+        'error',
+        {
+          types: {
+            'React.FC': {
+              message:
+                'Useless and has some drawbacks, see https://github.com/facebook/create-react-app/pull/8177',
+            },
+            'React.FunctionComponent': {
+              message:
+                'Useless and has some drawbacks, see https://github.com/facebook/create-react-app/pull/8177',
+            },
+            'React.FunctionalComponent': {
+              message:
+                'Preact specific, useless and has some drawbacks, see https://github.com/facebook/create-react-app/pull/8177',
+            },
+          },
+        },
+      ],
     },
     settings: {
       react: {


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

In an effort to continue automatically enforcing client code style and consistency, this PR adds an ESLint rule to disallow the usage of various React helper types when typing components. While we currently do not have any usages of `React.FC` or `React.FunctionComponent` in the code base, this rule should make it much easier to prevent any from slipping in.

I sourced this rule from this [Stackoverflow post](https://stackoverflow.com/a/76818791).

## 🧪 How to test

Try adding a component using `React.FC`. You'll see a message from ESLint saying:
```
Don't use `React.FC` as a type. 
Useless and has some drawbacks, see https://github.com/facebook/create-react-app/pull/8177eslint[@typescript-eslint/no-restricted-types](https://typescript-eslint.io/rules/no-restricted-types)
```
