### PR TITLE
fix: correct a11y regression

### DIFF
--- a/client/src/pages/Configurations/ConfigBuild/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/index.tsx
@@ -176,10 +176,12 @@ function Builder({
                   )}
                 >
                   <ConditionCodeSetButton
-                    codeSetId={codeSet.condition_id}
                     codeSetName={codeSet.display_name}
                     codeSetTotalCodes={codeSet.total_codes}
                     onViewCodeSet={() => onCodesetClick(codeSet.condition_id)}
+                    aria-controls={
+                      selectedCodesetId ? 'codeset-table' : undefined
+                    }
                   />
                   {i === 0 ? (
                     <span className="text-gray-cool-40 mr-2 hidden italic group-hover:block">
@@ -284,18 +286,17 @@ function Builder({
   );
 }
 
-interface ConditionCodeSetButtonProps {
-  codeSetId: string;
+type ConditionCodeSetButtonProps = {
   codeSetName: string;
   codeSetTotalCodes: number;
   onViewCodeSet: () => void;
-}
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 function ConditionCodeSetButton({
-  codeSetId,
   codeSetName,
   codeSetTotalCodes,
   onViewCodeSet,
+  ...props
 }: ConditionCodeSetButtonProps) {
   return (
     <button
@@ -303,7 +304,7 @@ function ConditionCodeSetButton({
         'group flex h-full w-full flex-row items-center justify-between gap-3 rounded p-1 text-left align-middle hover:cursor-pointer sm:p-4'
       )}
       onClick={onViewCodeSet}
-      aria-controls={codeSetId ? 'codeset-table' : undefined}
+      {...props}
     >
       <span aria-hidden>{codeSetName}</span>
       <span aria-hidden className="group-hover:hidden">


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

A small mistake was made in #448 where the `ConditionCodeSetButton` made use of the `codeSet.condition_id` instead of the `selectedCodesetId`. This caused the `aria-controls` value to always be `codeset-table` which is not correct. When a user is not viewing the code set table, the value should be `undefined`.

Before fix:
<img width="1598" height="779" alt="image" src="https://github.com/user-attachments/assets/26f2f0d0-433d-4b62-9e78-2a6337bcf118" />

After fix:
<img width="1599" height="779" alt="image" src="https://github.com/user-attachments/assets/926078bc-401b-4292-b6ae-40afdae86412" />

## 🧪 How to test

On the config builder page, when you click on `custom codes` or `sections` and then run an Axe test, you should no longer see any issues reported.