### PR TITLE
fix: do not require `S3_ENDPOINT_URL` environment variable to be present

### DIFF
--- a/refiner/app/core/config.py
+++ b/refiner/app/core/config.py
@@ -47,6 +47,5 @@ ENVIRONMENT: dict[str, str] = {
     "AWS_ACCESS_KEY_ID": _get_env_variable("AWS_ACCESS_KEY_ID"),
     "AWS_SECRET_ACCESS_KEY": _get_env_variable("AWS_SECRET_ACCESS_KEY"),
     "AWS_REGION": _get_env_variable("AWS_REGION"),
-    "S3_ENDPOINT_URL": _get_env_variable("S3_ENDPOINT_URL"),
     "S3_UPLOADED_FILES_BUCKET_NAME": _get_env_variable("S3_UPLOADED_FILES_BUCKET_NAME"),
 }

--- a/refiner/app/services/aws/s3.py
+++ b/refiner/app/services/aws/s3.py
@@ -19,7 +19,9 @@ s3_client = boto3.client(
     region_name=ENVIRONMENT["AWS_REGION"],
     aws_access_key_id=ENVIRONMENT["AWS_ACCESS_KEY_ID"],
     aws_secret_access_key=ENVIRONMENT["AWS_SECRET_ACCESS_KEY"],
-    endpoint_url=os.getenv("S3_ENDPOINT_URL"),
+    endpoint_url=os.getenv(
+        "S3_ENDPOINT_URL"
+    ),  # Only needed for local dev to connect to localstack
     config=config,
 )
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR fixes an issue where the app was requiring `S3_ENDPOINT_URL` to be present in the environment in a non-local dev scenario. There is no need for it to be present in live environments.

## 🧪 How to test

- Shutting down and restarting your docker compose setup locally should function exactly the same
- S3 downloads in the demo environment should be unchanged (need to deploy the change to test this)