### PR TITLE
docs(rfc): Restrict concurrent editing of configurations

### DIFF
--- a/docs/decisions/0001_2025-10-31_restrict-concurrent-configuration-editing.md
+++ b/docs/decisions/0001_2025-10-31_restrict-concurrent-configuration-editing.md
@@ -59,10 +59,12 @@ We will implement a single-editor lock system for configuration editing:
 - Lock tied to user session; auto-release after timeout
 - Audit trail for troubleshooting
 - Configurable timeout via environment variable
-- Lock released backend when user navigates away (browser unload, route change, logout)
+- Lock released backend when user navigates away (browser unload, route change,
+  logout)
 - Expiry time set when lock acquired. Starts at time user opens a configuration
   for edit.
-- Expiry resets on each user action (save, field change, other edit). Timeout always relative to latest activity.
+- Expiry resets on each user action (save, field change, other edit). Timeout
+  always relative to latest activity.
 - Backend only allows configuration edit/update if `userId` matches
   `lock.userId`.
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This patch adds the ADR for #571. This ADR is a proposed plan for how to handle
this feature.

## 🔗 Related Issue

Closes #571

Related to #423

## ✅ Acceptance Criteria

- [x] An RFC document that contains the high-level architecture for the feature.

## 🧪 How to test

You can read the RFC and discuss it in this ticket. There is no app
functionality in these changes.
