### PR TITLE
feat(db): modify configurations table schema to handle status and versioning

### DIFF
--- a/refiner/migrations/000005_activate_configs.down.sql
+++ b/refiner/migrations/000005_activate_configs.down.sql
@@ -26,7 +26,6 @@ ALTER TABLE configurations
 DROP COLUMN status,
 DROP COLUMN last_activated_at,
 DROP COLUMN last_activated_by,
-DROP COLUMN s3_url,
 DROP COLUMN condition_canonical_url;
 
 -- status enum

--- a/refiner/migrations/000005_activate_configs.up.sql
+++ b/refiner/migrations/000005_activate_configs.up.sql
@@ -6,7 +6,6 @@ ALTER TABLE configurations
 ADD COLUMN status configuration_status DEFAULT 'draft',
 ADD COLUMN last_activated_at TIMESTAMPTZ,
 ADD COLUMN last_activated_by UUID,
-ADD COLUMN s3_url TEXT,
 ADD COLUMN condition_canonical_url TEXT;
 
 -- add fk reference


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds migrations scripts that make modifications to the `configurations` table needed for the configuration activation feature.

The migration script will handle updates to existing configuration rows.

> [!NOTE]
> This PR won't affect currently configuration functionality. App server changes will come in a follow-up PR.

New columns added:
- `status` - defaults to `draft` (can be `draft`, `active`, `inactive`)
- `last_activated_at` - timestamp of the last time a config's status was set to `active`
- `last_activated_by` - user ID of the user who last changed the status to `active` (FK on `users.id`)
- `condition_canonical_url` - gets copied from the condition row when a configuration is created. This will remain the same throughout time and can be used to guarantee uniqueness
- ~~`s3_url` - this will hold the S3 URL to where we write the serialized config file (Not used immediately - we can delete it if we'd prefer)~~

Also includes:
- Constraint that only one config can be `draft` at a time per `condition_canonical_url`/`jurisdiction_id`
- Constraint that only one config can be `active` at a time per `condition_canonical_url`/`jurisdiction_id`
- `last_activated_at` is set automatically when a config goes from `draft` or `inactive` to `active`
- `version` will auto increment when a new draft is created. If one doesn't exist yet, it starts at `1`. Otherwise, it finds the highest version number based on a `condition_canonical_url`/`jurisdiction_id` pair and adds `1` to it
- `condition_canonical_url` is set automatically upon draft creation

## 🧪 How to test

1. DON'T RUN A REFRESH
2. Create a few configurations
3. Run `just migrate local`, this should put you on migration version 5
4. Run `just migrate local down 1`, this should put you back on migration version 4
5. Run `just migrate local` again
6. Take a look at your `configurations` table, you should see the new columns. A couple of these will automatically have data
7. Try using the app. You should see that it behaves exactly as it did previously

Other things you may want to try out:
- In your DB, switch a configuration's status to `active` - you'll see `last_activated_at` will be auto-populated
- Try creating two drafts that have the same `condition_canonical_url`/`jurisdiction_id` pair and you should see that you cannot
- Try creating two active configs that have the same `condition_canonical_url`/`jurisdiction_id` pair and you should see that you cannot

### Comprehensive testing 🙂

Clear your database and add a single `COVID-19` configuration through the app UI.

Try running this insert statement to create another draft.

```sql
INSERT INTO public.configurations(
	jurisdiction_id, name, included_conditions, custom_codes, condition_id, local_codes, section_processing, status)
	VALUES ('SDDH', 
	'COVID-19', 
	'["69d800a3-37a0-41ce-bc68-c74d1c5dca5d"]'::jsonb,
	'{}'::jsonb, 
	'69d800a3-37a0-41ce-bc68-c74d1c5dca5d', 
	'{}'::jsonb, 
	'[]'::jsonb, 
	'draft');
```

This should not work since a draft for this condition in this JD already exists.

Update the draft to be `active` instead.
```sql
update configurations
set status = 'active'
```

Try creating another `active` config for this condition in this JD.
```sql
INSERT INTO public.configurations(
	jurisdiction_id, name, included_conditions, custom_codes, condition_id, local_codes, section_processing, status)
	VALUES ('SDDH', 
	'COVID-19', 
	'["69d800a3-37a0-41ce-bc68-c74d1c5dca5d"]'::jsonb,
	'{}'::jsonb, 
	'69d800a3-37a0-41ce-bc68-c74d1c5dca5d', 
	'{}'::jsonb, 
	'[]'::jsonb, 
	'active');
```

This should not work since we already have an active config for this condition in this JD already.

Now that we have an active condition, try creating a new draft.
```sql
INSERT INTO public.configurations(
	jurisdiction_id, name, included_conditions, custom_codes, condition_id, local_codes, section_processing, status)
	VALUES ('SDDH', 
	'COVID-19', 
	'["69d800a3-37a0-41ce-bc68-c74d1c5dca5d"]'::jsonb,
	'{}'::jsonb, 
	'69d800a3-37a0-41ce-bc68-c74d1c5dca5d', 
	'{}'::jsonb, 
	'[]'::jsonb, 
	'draft');
```

You should see that this does work because we can have a single config active while we also have a single config in draft mode.

Lastly, let's take a look at the configurations table.
```sql
select * from configurations
order by version desc
```
You'll see two `COVID-19` configurations for the same JD. You'll notice one is `draft` and one is `active`. You'll also notice that the version of the newly created draft was automatically set to `2`.

The application has not been updated to handle multiple configs of the same condition in a JD yet, so you shouldn't expect this to work correctly. You can refresh your DB at this point.

## ℹ️ Additional Information

- ~~Do we want to keep `s3_url` or delete it?~~
  - We'll revisit this when/if we actually need it
- Do `last_activated_at` and `last_activated_by` fully cover our needs?
  - We already have the activity log which covers a more complete history 
- What did I miss?
