### PR TITLE
feat: Add a way for operators to gather data

### DIFF
--- a/.justscripts/just/cloud.just
+++ b/.justscripts/just/cloud.just
@@ -12,3 +12,8 @@ demo-db-url:
     --resource-group dibbs-er-demo \
     --query "containers[0].environmentVariables[?name=='DB_URL'].value | [0]" \
     -o tsv
+
+[doc('Retrieve a list of jurisdictions who have authored conditions in the demo application')]
+[group('azure')]
+demo-jurisdiction-authored:
+    psql $(just cloud demo-db-url) -c "SELECT c.jurisdiction_id, c.name FROM configurations AS c ORDER BY c.jurisdiction_id;"


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

We've been asked to gather data from our demo environment on a regular cadence
that displays the number of jurisdictions who have authored conditions. This
command helps operators with access to the demo environment to pull data from
the running database.

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

> [!WARNING]
> Make sure you have the appropriate permissions to access the demo database
> from your local machine. Without it, this command will fail.

Run `just cloud demo-jurisdiction-authored` in the terminal.
