### PR TITLE
fix: Bring in changes to testing upgrades

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -34,6 +34,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^24.10.0",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "@typescript-eslint/parser": "^8.43.0",
@@ -3938,13 +3939,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -12267,9 +12268,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/client/package.json
+++ b/client/package.json
@@ -47,6 +47,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^24.10.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@typescript-eslint/parser": "^8.43.0",

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -5,6 +5,6 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vitest/globals", "@testing-library/jest-dom", "node"]
   }
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -11,13 +11,7 @@ const uswdsIncludePaths = [
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    // prevent Vitest from running Playwright tests or dependency's tests.
-    exclude: ['e2e', 'e2e/**/*', 'node_modules'],
-    setupFiles: 'tests/setup.ts',
-  },
+
   css: {
     preprocessorOptions: {
       scss: {

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    // prevent Vitest from running Playwright tests or dependency's tests.
+    exclude: ['e2e', 'e2e/**/*', 'node_modules'],
+    setupFiles: 'tests/setup.ts',
+  },
+});


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

I'm not entirely sure right now how this happened. But I'll look into it. The
two errors I was encountering are over here: https://github.com/CDCgov/dibbs-ecr-refiner/actions/runs/19241807464/job/55006085326?pr=604#step:4:538

**Error 1**

```
------
6.114 playwright.config.ts(10,17): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
6.114 playwright.config.ts(11,12): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
```

**Error 2**

```
6.843 vite.config.ts(14,3): error TS2769: No overload matches this call.
6.843   The last overload gave the following error.
6.843     Object literal may only specify known properties, and 'test' does not exist in type 'UserConfigExport'.
------
```

I may cherry-pick these into a new PR so it doesn't force this PR to get merged
in just to fix `app-build`.

## 🔗 Related Issue

- Found in #604

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

GitHub Actions should be all passing.
