### PR TITLE
chore: update build and push job to support AIMS dev ECR

### DIFF
--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -1,4 +1,4 @@
-name: Build and push Refiner images to GHCR and AWS ECR
+name: Build and push Refiner Docker images to GHCR and AWS ECR
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A production-ready Docker image is created automatically every time code is merg
 
 ### Manually creating a production build
 
-A production build of the application can be created using the [`Build and push Refiner image to GHCR`](https://github.com/CDCgov/dibbs-ecr-refiner/actions/workflows/docker-build-ghcr.yml) GitHub Actions workflow. This will build the image and will store it in the Refiner's GitHub Container Registry.
+A production build of the application can be created using the [`Build and push Refiner image to GHCR`](https://github.com/CDCgov/dibbs-ecr-refiner/actions/workflows/docker-image-push.yml) GitHub Actions workflow. This will build the image and will store it in the Refiner's GitHub Container Registry.
 
 ## Running the linter
 

--- a/refiner/app/lambda/README.md
+++ b/refiner/app/lambda/README.md
@@ -8,4 +8,4 @@ The Lambda function is packaged as a Docker image and is defined by [Dockerfile.
 
 You'll notice that this code is packaged in a way where `app` is the top-level and other required modules are siblings to the `lambda` directory. The reason for this is because we want to be able to import core Refiner functionality into the Lambda module in the same way that we do for the FastAPI version of the Refiner, which this structure mirrors exactly.
 
-This Docker image, along with [Dockerfile.app](/Dockerfile.app), is built, tagged, and pushed automatically when a branch is merged into `main` as part of the [Build and push Refiner image to GHCR](/.github/workflows/docker-build-ghcr.yml) job.
+This Docker image, along with [Dockerfile.app](/Dockerfile.app), is built, tagged, and pushed automatically when a branch is merged into `main` as part of the [Build and push Refiner image to GHCR](/.github/workflows/docker-image-push.yml) job.


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the "build and push" job that builds the application and Lambda Docker images and pushes them to the registry. In addition to already pushing to the existing Refiner GHCR registry, this job will also now push the same images to the AIMS dev ECR registry.

This job will continue to run automatically when a branch is merged to `main`. We can also continue to run this job manually on a per-branch basis as needed.

## 🧪 How to test

Take a look at [this test job run](https://github.com/CDCgov/dibbs-ecr-refiner/actions/runs/19973394706). I was able to confirm the images are showing up in AWS.