### PR TITLE
chore: update codeql actions to v4

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -11,7 +11,7 @@ on:
 permissions:
   contents: read
   security-events: write
-  pull-requests: write  # For adding comments to PRs
+  pull-requests: write # For adding comments to PRs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -42,7 +42,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.image.dockerfile }}
-          load: true  # Load locally for scanning only
+          load: true # Load locally for scanning only
           tags: local-scan/${{ matrix.image.name }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -51,20 +51,18 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: local-scan/${{ matrix.image.name }}:${{ github.sha }}
-          format: 'sarif'
-          output: 'trivy-${{ matrix.image.name }}-results.sarif'
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          format: "sarif"
+          output: "trivy-${{ matrix.image.name }}-results.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
           ignore-unfixed: true
-          timeout: '10m'
-
-
+          timeout: "10m"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
-          sarif_file: 'trivy-${{ matrix.image.name }}-results.sarif'
-          category: 'pr-scan-${{ matrix.image.name }}'
+          sarif_file: "trivy-${{ matrix.image.name }}-results.sarif"
+          category: "pr-scan-${{ matrix.image.name }}"
 
       - name: Generate scan summary
         if: always()

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -35,7 +35,7 @@ jobs:
             path: "refiner"
           - name: "refiner-lambda"
             path: "lambda"
-      fail-fast: false  # Continue scanning other images if one fails
+      fail-fast: false # Continue scanning other images if one fails
 
     steps:
       - name: Checkout repository
@@ -74,18 +74,18 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ steps.check.outputs.image }}
-          format: 'sarif'
-          output: 'trivy-${{ matrix.image.name }}-results.sarif'
+          format: "sarif"
+          output: "trivy-${{ matrix.image.name }}-results.sarif"
           severity: ${{ steps.params.outputs.severity }}
           ignore-unfixed: true
-          timeout: '10m'
+          timeout: "10m"
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: steps.check.outputs.exists == 'true'
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: 'trivy-${{ matrix.image.name }}-results.sarif'
-          category: 'vulnerability-scan-${{ matrix.image.name }}'
+          sarif_file: "trivy-${{ matrix.image.name }}-results.sarif"
+          category: "vulnerability-scan-${{ matrix.image.name }}"
 
       - name: Scan summary for ${{ matrix.image.name }}
         if: always()


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates our scanning jobs to use the latest `codeql-action` Actions. I noticed our jobs were producing a warning about an upcoming deprecation.

```
> Run github/codeql-action/upload-sarif@v3
Warning: CodeQL Action v3 will be deprecated in December 2026. Please update all occurrences of the CodeQL Action in your workflow files to v4. For more information, see https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/
```


## 🧪 How to test

You can see the jobs are still working [here](https://github.com/CDCgov/dibbs-ecr-refiner/actions/runs/20140025562/job/57813205768?pr=681).

