### PR TITLE
fix: improve configuration and conditions request performance

### DIFF
--- a/refiner/app/db/conditions/db.py
+++ b/refiner/app/db/conditions/db.py
@@ -6,13 +6,13 @@ from psycopg.rows import class_row, dict_row
 from app.db.configurations.model import DbConfigurationCondition
 
 from ..pool import AsyncDatabaseConnection
-from .model import DbCondition, DbConditionBasicInfo
+from .model import DbCondition, DbConditionBase
 
 # TES and refiner are currently using version 3.0.0 for CGs and its child RSGs
 CURRENT_VERSION = "3.0.0"
 
 
-async def get_conditions_db(db: AsyncDatabaseConnection) -> list[DbConditionBasicInfo]:
+async def get_conditions_db(db: AsyncDatabaseConnection) -> list[DbConditionBase]:
     """
     Queries the database and retrieves a list of conditions matching CURRENT_VERSION. This query does not include related code set information.
 
@@ -37,7 +37,7 @@ async def get_conditions_db(db: AsyncDatabaseConnection) -> list[DbConditionBasi
     params = (CURRENT_VERSION,)
 
     async with db.get_connection() as conn:
-        async with conn.cursor(row_factory=class_row(DbConditionBasicInfo)) as cur:
+        async with conn.cursor(row_factory=class_row(DbConditionBase)) as cur:
             await cur.execute(query, params)
             rows = await cur.fetchall()
 

--- a/refiner/app/db/conditions/model.py
+++ b/refiner/app/db/conditions/model.py
@@ -16,7 +16,7 @@ class DbConditionCoding:
 
 
 @dataclass
-class DbConditionBasicInfo:
+class DbConditionBase:
     """
     Simple information about a condition from the database. Excludes info about code sets.
     """
@@ -28,7 +28,7 @@ class DbConditionBasicInfo:
 
 
 @dataclass
-class DbCondition(DbConditionBasicInfo):
+class DbCondition(DbConditionBase):
     """
     Model to represent a complete condition row from the database (row).
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR addresses an issue where these routes: 
- `/api/v1/conditions/{condition_id}`
- `/api/v1/configurations/{configuration_id}`

were previously taking ~500+ ms for the client to resolve. The reason this was happening was due to `get_conditions_db()`  fetching the data and then needing to package that data into an object using `DbCondition.from_db_row(row)` for every row that was returned. 

This step is very expensive because `from_db_row()` needs to do this for every single code for every row that we receive back:
```python
snomed_codes=[DbConditionCoding(**c) for c in row["snomed_codes"]],
loinc_codes=[DbConditionCoding(**c) for c in row["loinc_codes"]],
icd10_codes=[DbConditionCoding(**c) for c in row["icd10_codes"]],
rxnorm_codes=[DbConditionCoding(**c) for c in row["rxnorm_codes"]],
```

This ends up being a substantial amount of data being pulled from the DB and packaged by the app that is not actually used in either of these routes.

## 📺 Demo

Here are a couple of super simple benchmarks from my local dev setup.

(before, ~900ms) Request to `/api/v1/configurations/{configuration_id}`:
<img width="599" height="384" alt="image" src="https://github.com/user-attachments/assets/f1367dc6-4fa6-41bf-b803-93dd9dca60b8" />

(after, ~66ms) Request to `/api/v1/configurations/{configuration_id}`:
<img width="601" height="387" alt="image" src="https://github.com/user-attachments/assets/e95ea1f9-038d-4026-b1e2-9890658b7f2a" />

## 🧪 How to test

The app should function exactly as it did previously.