### PR TITLE
feat: add `s3_url` column to `configurations` table

### DIFF
--- a/refiner/migrations/000007_add_s3_url_to_config.down.sql
+++ b/refiner/migrations/000007_add_s3_url_to_config.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE configurations
+DROP COLUMN IF EXISTS s3_url;

--- a/refiner/migrations/000007_add_s3_url_to_config.up.sql
+++ b/refiner/migrations/000007_add_s3_url_to_config.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE configurations
+ADD COLUMN s3_url TEXT;


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds the migration to add the `s3_url` column to the `configurations` table. This column will be used to store the resulting S3 URL that comes from activating a configuration. The URL will point to the currently active configuration file.

## 🔗 Related Issue

Fixes #697 

## 🧪 How to test

1. Run `just migrate local` to add the column
2. Check your `configurations` table to ensure the column is present and has a `null` value
3. Run `just migrate local down 1` and check that the column is no longer present on the config table