### PR TITLE
fix: activation and deactivation buttons displaying incorrect cursor

### DIFF
--- a/client/src/pages/Configurations/ConfigActivate/buttonDisplays/TurnOffButtons.tsx
+++ b/client/src/pages/Configurations/ConfigActivate/buttonDisplays/TurnOffButtons.tsx
@@ -22,11 +22,9 @@ export function TurnOffButtons({
       <ModalToggleButton
         modalRef={deactivateRef}
         opener
-        className={classNames(
-          'self-start',
-          SECONDARY_BUTTON_STYLES,
-          DISABLED_BUTTON_STYLES
-        )}
+        className={classNames('self-start', SECONDARY_BUTTON_STYLES, {
+          disabled: DISABLED_BUTTON_STYLES,
+        })}
         disabled={disabled}
       >
         Turn off current version

--- a/client/src/pages/Configurations/ConfigActivate/buttonDisplays/TurnOnButtons.tsx
+++ b/client/src/pages/Configurations/ConfigActivate/buttonDisplays/TurnOnButtons.tsx
@@ -22,11 +22,9 @@ export function TurnOnButtons({
       <ModalToggleButton
         modalRef={activateRef}
         opener
-        className={classNames(
-          'self-start',
-          SECONDARY_BUTTON_STYLES,
-          DISABLED_BUTTON_STYLES
-        )}
+        className={classNames('self-start', SECONDARY_BUTTON_STYLES, {
+          disabled: DISABLED_BUTTON_STYLES,
+        })}
         disabled={disabled}
       >
         Turn on configuration


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

I noticed a bug that was introduced with #646  where the activation and deactivation buttons were showing the incorrect cursor. The cursor made it appear like the buttons were disabled when they were not. This is because we were missing some logic around showing the disabled styling.

Before:
![Kapture 2026-01-08 at 13 05 35](https://github.com/user-attachments/assets/9261768e-218f-4745-8e69-7ece7db3a83f)

After:
![Kapture 2026-01-08 at 13 06 25](https://github.com/user-attachments/assets/8a560d41-460f-4c38-ac99-6005e6c1cb41)

