### PR TITLE
Add `just dev show` to list all running containers for `dibbs-ecr-refiner`

### DIFF
--- a/.justscripts/just/dev.just
+++ b/.justscripts/just/dev.just
@@ -22,3 +22,10 @@ down *ARGS:
 [doc("Remove the project's core services and their volumes with docker compose.")]
 rm:
     {{ docker }} compose -f {{ absolute_path('./docker-compose.yaml') }} rm -v
+
+show_tbl := 'table {{.Names}}\t{{.Ports}}\t{{.ID}}'
+
+[group('docker')]
+[doc('Show running `dibbs-ecr-refiner` containers with helpful output')]
+show:
+    {{ docker }} container ls --filter 'name=dibbs-ecr-refiner' --format "{{ show_tbl }}"


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

1. 💬 fix: Allow for a default for `just dev` 🏷️ cce3626
1. 💬 feat: Add command to show local running containers 🏷️ 214a3ec

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

As a developer, I should be able to see what containers are running easily.

## 🧪 How to test

Run `just dev up -d` and then you can run `just dev show` to see if there are
any `dibbs-ecr-refiner` containers running in Docker.
