### PR TITLE
fix: remove saving/saved from test and activate configuration pages

### DIFF
--- a/client/src/pages/Configurations/ConfigurationTitleBar.tsx
+++ b/client/src/pages/Configurations/ConfigurationTitleBar.tsx
@@ -81,27 +81,29 @@ export function ConfigurationTitleBar({
           <h2 className="text-gray-cool-90 mr-4 text-[1.75rem] font-bold">
             {CONFIGURATION_TITLE_CONTENTS[step].title}
           </h2>
-          <div className="text-gray-cool-60 h-4 items-center italic">
-            <div className="flex items-center">
-              {shouldShowSpinner ? (
-                <>
-                  <Icon.Autorenew
-                    role="presentation"
-                    className="text-blue-cool-50 h-6! w-6! animate-spin"
-                  ></Icon.Autorenew>
-                  Saving
-                </>
-              ) : (
-                <>
-                  <Icon.Check
-                    role="presentation"
-                    className="text-state-success h-6! w-6!"
-                  ></Icon.Check>{' '}
-                  Saved
-                </>
-              )}
+          {step === 'build' && (
+            <div className="text-gray-cool-60 h-4 items-center italic">
+              <div className="flex items-center">
+                {shouldShowSpinner ? (
+                  <>
+                    <Icon.Autorenew
+                      role="presentation"
+                      className="text-blue-cool-50 h-6! w-6! animate-spin"
+                    />
+                    Saving
+                  </>
+                ) : (
+                  <>
+                    <Icon.Check
+                      role="presentation"
+                      className="text-state-success h-6! w-6!"
+                    />{' '}
+                    Saved
+                  </>
+                )}
+              </div>
             </div>
-          </div>
+          )}
         </div>
         {CONFIGURATION_TITLE_CONTENTS[step].subtitle}
       </div>


### PR DESCRIPTION
# 🔀 PULL REQUEST

<img width="1278" height="1235" alt="Screenshot 2026-01-20 at 1 45 07 PM" src="https://github.com/user-attachments/assets/ece1daa2-497f-4581-b946-a465c94252b2" />
<img width="1276" height="1233" alt="Screenshot 2026-01-20 at 1 45 17 PM" src="https://github.com/user-attachments/assets/002e7da4-9182-4ec7-8268-635eb0c453e6" />
<img width="1274" height="1233" alt="Screenshot 2026-01-20 at 1 45 28 PM" src="https://github.com/user-attachments/assets/29435d81-8ef7-4a1e-8625-3c35c600c234" />


<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

<!--
What changes are being proposed?
-->

## 🔗 Related Issue

<!--
add the issue number in both places:
Fixes #3
- #3
-->

Fixes #739 
- #739 

## ✅ Acceptance Criteria


<!--
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
-->

## 🧪 How to test

<!--
Unit tests

1. From the project root make sure you're in the `refiner/` directory
2. Activate a virtual environment using your tool of choice
3. Make sure that both `requirements.txt` and `requirements-dev.txt` are installed
4. Run the unit tests with `pytest -vv tests/`
5. Additionally you can check coverage with `pytest --cov=app tests`

or

Testing the application:

1. Run `docker compose up`
2. Check that both services are up and running with `docker ps`
3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
4. You should be able to [insert goal you want to accomplish!]
-->

1. Run `docker compose up`
2. Check that both services are up and running with `docker ps`
3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
4. Create a configuration 
5. View saving/saved on build, but not test or activate pages

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
