### PR TITLE
fix: copy `app/db` module into Lambda build

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -16,6 +16,7 @@ COPY ./refiner/assets ./assets
 # Copy refiner modules
 COPY ./refiner/app/core app/core
 COPY ./refiner/app/services app/services
+COPY ./refiner/app/db app/db
 
 # Handler entrypoint
 CMD [ "app.lambda.lambda_function.lambda_handler" ]


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This was removed from `Dockerfile.lambda` in #750 however this causes the Lambda to crash when running in a container because the refining process references code from the `db` module. This PR addresses the issue by adding this line back to `Dockerfile.lambda`.