### PR TITLE
chore: build Lambda image specifically for `linux/amd64`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,5 +43,6 @@ jobs:
           context: .
           file: Dockerfile.lambda
           push: false
+          platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -105,4 +105,5 @@ jobs:
           context: .
           file: Dockerfile.lambda
           push: true
+          platforms: linux/amd64
           tags: ${{ steps.vars.outputs.lambda_tags }}


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the build pipeline to specifically build the Lambda image for `linux/amd64`. This PR is attempting to address an error we're seeing when deploying the Lambda container to AWS, which we believe stems from Lambda needing to be built for a single platform architecture.

## 🧪 How to test

Pipeline builds should be working.
