### PR TITLE
fix: Add the versions to the update response

### DIFF
--- a/refiner/app/db/configurations/model.py
+++ b/refiner/app/db/configurations/model.py
@@ -143,7 +143,7 @@ class ConfigurationStoragePayload:
     """
 
     codes: set[str]
-    sections: list[dict[str, str]]
+    sections: list[dict[str, Any]]
     included_condition_rsg_codes: set[str]
 
     def to_dict(self) -> dict:

--- a/refiner/app/services/configurations.py
+++ b/refiner/app/services/configurations.py
@@ -1,4 +1,5 @@
 from logging import Logger
+from typing import Any
 
 from app.db.conditions.db import get_condition_by_id_db, get_included_conditions_db
 from app.db.configurations.model import (
@@ -61,7 +62,7 @@ async def convert_config_to_storage_payload(
         ConfigurationStoragePayload | None: A configuration that can be written to a file system, or None if operation can't be completed.
     """
     codes: set[str] = set()
-    sections: list[dict[str, str]] = []
+    sections: list[dict[str, Any]] = []
     included_condition_rsg_codes: set[str] = set()
 
     # custom codes

--- a/refiner/app/services/terminology.py
+++ b/refiner/app/services/terminology.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -138,7 +139,7 @@ class ProcessedConfiguration:
         # STEP 3:
         # convert the list of DbConfigurationSectionProcessing objects into
         # a simple list of dictionaries
-        section_processing_as_dicts: list[dict[str, str]] = [
+        section_processing_as_dicts: list[dict[str, Any]] = [
             {
                 "code": section_process.code,
                 "name": section_process.name,


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

1. 💬 fix: Add the versions to the update response 🏷️ 9ba73b0

## 🔗 Related Issue

Addresses some issues found in the implementation of #759 and testing of #238.
This bug was reported in Slack showing that the version numbers were being
removed when an action was selected under section processing in a configuration.

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

Load up a configuration, navigate to the Sections item on the left. Once there,
select different actions for each section name and note that the version
information remains.
