### PR TITLE
chore: Set Lambda build/push job to use `provenance: false`

### DIFF
--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -103,6 +103,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          provenance: false
           file: Dockerfile.lambda
           push: true
           platforms: linux/amd64


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR further attempts to address an issue where Lambda cannot pull in the image Refiner image due to the build process using the OCI image format. It appears that Lambda doesn't like this, so we'll use the Docker Image Manifest V2 Schema instead.

## 🧪 How to test

Here is a comparison of the manifest data produced using `docker manifest inspect ghcr.io/cdcgov/dibbs-ecr-refiner/lambda:main` vs. `docker manifest inspect ghcr.io/cdcgov/dibbs-ecr-refiner/lambda:jw-lambda-build-manifest`.

Manifest before:
```sh
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 3140,
         "digest": "sha256:98eb0c278a157c743bffde5d8f8cfae0df4b3758a4d0ae46272fb580ca3abda8",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 567,
         "digest": "sha256:aab2782247675369ec351e34f0e05ae84e09f39a20634bc515bd7e852b4dbd00",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}
```

Manifest after:
```sh
{
        "schemaVersion": 2,
        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
        "config": {
                "mediaType": "application/vnd.docker.container.image.v1+json",
                "digest": "sha256:ff0ffe6c5ee1cfa63c4bec84eec8401fb208aa5ae37b5fb6709a780b37559082",
                "size": 5662
        },
        "layers": [
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:0b221e659edd51e4a7fbae52854e9b836195e38a3ae643fd148409d8eb0aef81",
                        "size": 36909623
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:4f75fe7eac8a1c7aa78535cd6e756c57323072cae843d734fdc887e34af754df",
                        "size": 88123
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:66b3c0d6b7faa6e14ae95de6c4c75e89b7e4731e0f39cc8037c20e7c0ddcb3ce",
                        "size": 417
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:72e2a8fdec91dd2034b5d36602f86fa8c31af471285b24634b8b0a1884c4a1b8",
                        "size": 3681043
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:d26f9d72b846520e7095d6738545f1da40615be3711112dd27680789890fd3f6",
                        "size": 155411960
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:b6f63d1bd824fe62982f559aa553f2c883e54880ff35b01314b922d8c20cab42",
                        "size": 14190
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
                        "size": 32
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:e39bc23227cba48ba1a3ea7b6abb43c72bcc889130fe69bed455bf80a2e33043",
                        "size": 321
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:48fc9351d786166c7ad9a90e8068299a124f0e0a79a954b0e2788ef970034391",
                        "size": 197
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:8e0af5a840b4698b07ab51544694c1832150fcaa61ceccd398ef7a21ff0c6e08",
                        "size": 46658753
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:0b55a0da94928cf857ffad0936a3d028bd89ddd53a0aadf4931562e99c877bd3",
                        "size": 3789
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:7935d93ef52a5d833cd790fff1465c13c0a121b8f37419501adf286a52e96b03",
                        "size": 98103
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:33fbea90994b79cf5e73989b398e6ec1393ea691900f37aab2b2204f29839e49",
                        "size": 4849
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:7bcad4519f5c780abe553cb0af2b03231c20a1f63fa066ca4486e6223bfb41b8",
                        "size": 31178
                },
                {
                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                        "digest": "sha256:fa5691a75e0b6f7a3427f265788dc152e4369574c8be2c56db1d8c933ea68b6b",
                        "size": 12492
                }
        ]
}
```
