### PR TITLE
fix: inline testing zip doesn't include a refined eICR XML file

### DIFF
--- a/refiner/app/api/v1/configurations.py
+++ b/refiner/app/api/v1/configurations.py
@@ -1434,6 +1434,7 @@ async def run_configuration_test(
         condition_code=condition_obj.code,
     )
 
+    s3_file_package.append((eicr_filename, refined_document.refined_eicr))
     s3_file_package.append((rr_filename, refined_document.refined_rr))
     # Generate HTML from refined XML
     try:


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

I noticed the refined eICR XML file is missing from the inline testing zip package. This PR adds it in.

## 🧪 How to test

Run an inline test and download the zip package. You should see the refined eICR is included.