### PR TITLE
fix: wait for server startup in e2e testing job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,6 +118,10 @@ jobs:
         run: |
           timeout 60 bash -c 'until curl -f http://localhost:8082 > /dev/null 2>&1; do sleep 2; done'
           echo "Auth Service is ready!"
+      - name: Wait for app server proxy to be ready
+        run: |
+          timeout 60 bash -c 'until curl -f http://localhost:8081 > /dev/null 2>&1; do sleep 2; done'
+          echo "App server proxy is ready!"
       - name: Run Playwright E2E Tests
         run: just client run e2e
       - name: Upload HTML Report


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the e2e CI job to wait for server startup. I noticed this job failing because the tests begin running before the server is ready in some cases.

## 🧪 How to test

[I've run this workflow update in CI a handful of times with promising results.](https://github.com/CDCgov/dibbs-ecr-refiner/actions/workflows/tests.yml)