### PR TITLE
fix: pin FastAPI to 0.129.0

### DIFF
--- a/refiner/requirements.txt
+++ b/refiner/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.42.54
 Authlib==1.6.8
 chardet
-fastapi>=0.109.1
+fastapi==0.129.0
 fhir.resources
 httpx
 itsdangerous


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

FastAPI put out a [release](https://github.com/fastapi/fastapi/releases/tag/0.129.1) with a breaking change that impacts refiner. I noticed that this generated type
```typescript
export interface BodyUploadEcr {
  uploaded_file?: Blob | null;
}
```
was suddenly being generated as
```typescript
export interface BodyUploadEcr {
  uploaded_file?: string | null;
}
```
which was breaking the client build. After some investigation I realized I had the most recent version of FastAPI installed and that's what was causing this to happen.

This PR simply pins FastAPI to the release prior to the breaking change. We should plan to implement the updates required to use a newer version of FastAPI in a different PR.

## 🧪 How to test

Make sure your local environment is running the pinned version of FastAPI. There should be no changes to generated TypeScript files.


