### PR TITLE
chore: update Lambda image to Python 3.14

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.14
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

I noticed that the Lambda image is running Python 3.13 while both the app and ops images are using 3.14. This PR updates the Lambda to match.

## 🧪 How to test

Lambda tests should all continue to pass without issue.