### PR TITLE
chore: include `MEDIUM` and `LOW` severity in security scans by default

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  TRIVY_SEVERITY: "CRITICAL,HIGH,MEDIUM,LOW"
+
 jobs:
   build-and-scan:
     runs-on: ubuntu-latest
@@ -55,7 +58,7 @@ jobs:
           image-ref: local-scan/${{ matrix.image.name }}:${{ github.sha }}
           format: "sarif"
           output: "trivy-${{ matrix.image.name }}-results.sarif"
-          severity: "CRITICAL,HIGH,MEDIUM"
+          severity: ${{ env.TRIVY_SEVERITY }}
           ignore-unfixed: true
           timeout: "10m"
 
@@ -65,7 +68,7 @@ jobs:
           image-ref: local-scan/${{ matrix.image.name }}:${{ github.sha }}
           format: "json"
           output: "trivy-${{ matrix.image.name }}-results.json"
-          severity: "CRITICAL,HIGH,MEDIUM"
+          severity: ${{ env.TRIVY_SEVERITY }}
           ignore-unfixed: true
           timeout: "10m"
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -10,12 +10,13 @@ on:
       severity_level:
         description: "Vulnerability severity threshold"
         required: false
-        default: "CRITICAL,HIGH"
+        default: "CRITICAL,HIGH,MEDIUM,LOW"
         type: choice
         options:
-          - "CRITICAL"
-          - "CRITICAL,HIGH"
+          - "CRITICAL,HIGH,MEDIUM,LOW"
           - "CRITICAL,HIGH,MEDIUM"
+          - "CRITICAL,HIGH"
+          - "CRITICAL"
       send_slack_notification:
         description: "Send Slack notification"
         required: false


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

While we know that `CRITICAL` and `HIGH` severity vulnerabilities take priority, I think it makes sense that we also scan for `MEDIUM` and `LOW` by default since

1. AWS Inspector is scanning for these
2. They are less important to address immediately but do still have remediation timelines

Getting a full picture of where each package stands ASAP will likely only help us in the long run.

This PR updates both the PR scans and the daily scans.

## 🧪 How to test

- You'll notice mediums and lows are now being reported in my [PR comment](https://github.com/CDCgov/dibbs-ecr-refiner/pull/894#issuecomment-3973615761)
- You'll see medium and lows reported in the [daily scan against `latest`](https://skylight-hq.slack.com/archives/C08QQ1SCDLY/p1772206999808529)