### PR TITLE
chore: update jobs to Python 3.14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,17 +2,10 @@ name: Run linter
 
 on:
   workflow_call:
-    inputs:
-      python_runner_version:
-        default: 3.13
-        required: true
-        type: number
   workflow_dispatch:
-    inputs:
-      python_runner_version:
-        default: 3.13
-        required: true
-        type: number
+
+env:
+  PYTHON_RUNNER_VERSION: "3.14"
 
 permissions:
   contents: read
@@ -23,10 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup python ${{inputs.python_runner_version}}
+      - name: Setup python ${{env.PYTHON_RUNNER_VERSION}}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{inputs.python_runner_version}}
+          python-version: ${{env.PYTHON_RUNNER_VERSION}}
           cache: pip
       - name: Install dependencies
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -22,15 +22,9 @@ concurrency:
 jobs:
   run-linter:
     uses: ./.github/workflows/lint.yml
-    with:
-      python_runner_version: 3.13
   run-tests:
     uses: ./.github/workflows/tests.yml
-    with:
-      python_runner_version: 3.13
   run-type-checking:
     uses: ./.github/workflows/typecheck.yml
-    with:
-      python_runner_version: 3.13
   run-build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,23 +2,14 @@ name: Run tests
 
 on:
   workflow_call:
-    inputs:
-      python_runner_version:
-        default: 3.13
-        required: true
-        type: number
   workflow_dispatch:
-    inputs:
-      python_runner_version:
-        default: 3.13
-        required: true
-        type: number
 
 permissions:
   contents: read
 
 env:
   NODE_VERSION: 22
+  PYTHON_RUNNER_VERSION: "3.14"
 
 defaults:
   run:
@@ -30,10 +21,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup python ${{inputs.python_runner_version}}
+      - name: Setup python ${{env.PYTHON_RUNNER_VERSION}}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{inputs.python_runner_version}}
+          python-version: ${{env.PYTHON_RUNNER_VERSION}}
           cache: pip
       - name: Install dependencies
         run: |
@@ -47,10 +38,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup python ${{inputs.python_runner_version}}
+      - name: Setup python ${{env.PYTHON_RUNNER_VERSION}}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{inputs.python_runner_version}}
+          python-version: ${{env.PYTHON_RUNNER_VERSION}}
           cache: pip
       - name: Install dependencies
         run: |

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -2,17 +2,10 @@ name: Run type checking
 
 on:
   workflow_call:
-    inputs:
-      python_runner_version:
-        default: 3.13
-        required: true
-        type: number
   workflow_dispatch:
-    inputs:
-      python_runner_version:
-        default: 3.13
-        required: true
-        type: number
+
+env:
+  PYTHON_RUNNER_VERSION: "3.14"
 
 permissions:
   contents: read
@@ -27,10 +20,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup python ${{inputs.python_runner_version}}
+      - name: Setup python ${{env.PYTHON_RUNNER_VERSION}}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{inputs.python_runner_version}}
+          python-version: ${{env.PYTHON_RUNNER_VERSION}}
           cache: pip
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # pre-commit configuration
 default_language_version:
-    python: python3.13
+    python: python3.14
 
 repos:
 # core formatting and check hooks


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR

- Updates all jobs from Python 3.13 to 3.14
- Removes the default job input that we don't use and replaces it with an environment variable
- Updates pre-commit config to use Python 3.14

> [!IMPORTANT]
> You may need to install Python 3.14 locally and set that as your default version for pre-commit to pick it up. I'd recommend using `pyenv` to do this: `pyenv install 3.14 && pyenv global 3.14`

## 🧪 How to test

GitHub Actions pipeline should function exactly as it did previously.