### PR TITLE
chore: improve e2e testing login helper reliability

### DIFF
--- a/client/e2e/utils.ts
+++ b/client/e2e/utils.ts
@@ -53,23 +53,19 @@ export async function login({
   const username = typeof user === 'string' ? user : 'refiner';
   const password = typeof user === 'string' ? user : 'refiner';
 
-  await page.goto(baseUrl, { waitUntil: 'networkidle', timeout: 60000 });
+  await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+
   await page.getByText('Log in').click();
-  await page.getByRole('textbox', { name: 'Username or email' }).click();
   await page.getByRole('textbox', { name: 'Username or email' }).fill(username);
-  await page.getByRole('textbox', { name: 'Username or email' }).press('Tab');
   await page.getByRole('textbox', { name: 'Password' }).fill(password);
 
   // wait for navigation after clicking sign in button
   await Promise.all([
-    page.waitForURL((url) => !url.hostname.includes('localhost:8082'), {
+    page.waitForURL('http://localhost:8081/configurations', {
       timeout: 30000,
     }),
     page.getByRole('button', { name: 'Sign In' }).click(),
   ]);
-
-  // wait for network to be idle after login
-  await page.waitForLoadState('networkidle');
 
   // check that we are on the logged-in home screen
   await expect(


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR attempts to resolve some of the flakiness with the `login` helper function used in the e2e tests. This fails on a fairly regular basis due to timing issues.

## 🧪 How to test

Feel free to try running the [tests job](https://github.com/CDCgov/dibbs-ecr-refiner/actions/workflows/tests.yml) using this branch.

It's always hard to say for sure but the results from jobs I ran look promising.

<img width="1200" height="616" alt="image" src="https://github.com/user-attachments/assets/74df881b-dcc2-4cc5-9e58-3fe8848255a8" />

