### PR TITLE
feat: Set non-spec section defaults from `refine` to `retain`

### DIFF
--- a/refiner/app/services/ecr/refine.py
+++ b/refiner/app/services/ecr/refine.py
@@ -209,8 +209,7 @@ def refine_eicr(
         # parse the eicr document
         eicr_root = xml_files.parse_eicr()
 
-        namespaces: NamespaceMap = {"hl7": "urn:hl7-org:v3"}
-        structured_body = eicr_root.find(".//hl7:structuredBody", namespaces)
+        structured_body = eicr_root.find(".//hl7:structuredBody", HL7_NS)
 
         # if we don't have a structuredBody this is a major problem
         if structured_body is None:
@@ -229,7 +228,7 @@ def refine_eicr(
             section = get_section_by_code(
                 structured_body=structured_body,
                 loinc_code=section_code,
-                namespaces=namespaces,
+                namespaces=HL7_NS,
             )
 
             if section is None:
@@ -248,7 +247,7 @@ def refine_eicr(
             process_section(
                 section=section,
                 codes_to_match=plan.codes_to_check,
-                namespaces=namespaces,
+                namespaces=HL7_NS,
                 section_specification=section_specification,
                 version=version,
             )


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR makes it so that any sections found in an eICR not offered by Refiner will be automatically included and retained. This is essentially the same functionality as "skipping" a section.

I've tried to refactor this code a bit to be easier to read.

## 🔗 Related Issue

Fixes #955 


## 🧪 How to test

- App should work as it did previously
- All automated tests should continue to pass

## ℹ️ Additional Information

Does this look good? Anything else to consider?