### PR TITLE
fix: Refactor the app-shell container

### DIFF
--- a/client/src/tailwind.css
+++ b/client/src/tailwind.css
@@ -10,8 +10,25 @@
 }
 
 @layer base {
+  /* To lock the document height to the viewport and prevent unwanted
+   * page-level scrolling, the html and body elements have been switched from
+   * h-full to a fixed height: 100dvh. We applied overflow: hidden to the
+   * html element to ensure the outer document remains static, while setting
+   * overflow-y: auto on the body to handle internal content scrolling. This
+   * configuration uses modern Dynamic Viewport Units to provide a consistent
+   * full-screen layout across both desktop and mobile browsers.
+   */
   html,
   body {
+    @apply h-dvh;
+  }
+  html {
+    @apply overflow-hidden;
+  }
+  body {
+    @apply m-0 overflow-y-auto;
+  }
+  #root {
     @apply h-full;
   }
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This patch fixes the app-shell container to prevent any element of a large
height to cause the body to have a scroll beyond the footer of the page.

## 🔗 Related Issue

Closes #933

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

Navigate to the custom codes section and add more than 200 custom codes. There
should be no empty space under the application shell. The scrolling should be
contained to the custom code table.
