### PR TITLE
chore: use localstack 4

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -99,7 +99,7 @@ services:
       - pgdata:/var/lib/postgresql/data
 
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:4
     ports:
       - "4566:4566"
     environment:


### PR DESCRIPTION
# 🔀 PULL REQUEST


## 💡 Summary

Localstack now requires an account to use. I've pinned the docker compose file to use `localstack:4` so that we can continue to use Localstack in the pipeline for now.

This should fix the other failing PRs once merged.

## 🧪 How to test

Pipeline and tests should be passing.

## ℹ️ Additional Information

I've added #977 so that we can move away from Localstack entirely.
