### PR TITLE
fix(security): pin trivy-action to SHA to mitigate supply chain attack

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -53,7 +53,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner (SARIF)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: local-scan/${{ matrix.image.name }}:${{ github.sha }}
           format: "sarif"
@@ -63,7 +63,7 @@ jobs:
           timeout: "10m"
 
       - name: Run Trivy vulnerability scanner (JSON for PR comment)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: local-scan/${{ matrix.image.name }}:${{ github.sha }}
           format: "json"
@@ -73,7 +73,7 @@ jobs:
           timeout: "10m"
 
       - name: Display Trivy results as table
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: local-scan/${{ matrix.image.name }}:${{ github.sha }}
           format: "table"

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (SARIF)
         if: steps.check.outputs.exists == 'true'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.check.outputs.image }}
           format: "sarif"
@@ -94,7 +94,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (JSON)
         if: steps.check.outputs.exists == 'true'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.check.outputs.image }}
           format: "json"
@@ -104,7 +104,7 @@ jobs:
           timeout: "10m"
 
       - name: Display Trivy results as table
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.check.outputs.image }}
           format: "table"


### PR DESCRIPTION
## Summary

- Pin `aquasecurity/trivy-action` to a full commit SHA instead of a mutable tag/branch reference
- This mitigates the [Trivy GitHub Action supply chain attack](https://thehackernews.com/2026/03/trivy-security-scanner-github-actions.html) where 75 of 76 version tags were force-pushed with an infostealer payload

## What happened

An attacker compromised credentials for the `aquasecurity/trivy-action` repository and force-pushed malicious code to 75 out of 76 version tags. Any workflow referencing these tags (or `master`) would pull the compromised code, which exfiltrates CI secrets (SSH keys, cloud credentials, tokens) to an attacker-controlled domain.

## What this PR does

Pins the action to the known-safe commit SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0) so that even if tags are manipulated again in the future, the workflow will continue to use the verified safe code.

## Test plan

- [ ] Verify the trivy scan workflow runs successfully with the SHA-pinned action
