### PR TITLE
chore: Vite shouldn't hot reload when e2e files change

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -30,6 +30,9 @@ export default defineConfig({
     },
   },
   server: {
+    watch: {
+      ignored: ['**/e2e/**'],
+    },
     host: true,
     strictPort: true,
     port: 8081,


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the Vite config to prevent files in `e2e/` from causing a hot reload. The current config can make working on e2e tests really difficult if you're simultaneously inspecting elements in your browser while also making modifications to the test in your editor.

## 🧪 How to test

Try modifying files in the `e2e/` directory and you should see that your client is no longer hot reloading.
