### PR TITLE
fix(server): Add Vital Signs entry matching rules similar to Results

### DIFF
--- a/refiner/app/services/ecr/specification.py
+++ b/refiner/app/services/ecr/specification.py
@@ -31,6 +31,8 @@ SECTION_PROCESSING_SKIP: Final[set[str]] = {
     "88085-6",  # reportability response information section
 }
 
+# these OIDs are stable, HL7-registered identifiers that have not changed
+# across any version of C-CDA or eICR
 LOINC_OID = "2.16.840.1.113883.6.1"
 ICD10_OID = "2.16.840.1.113883.6.90"
 RXNORM_OID = "2.16.840.1.113883.6.88"
@@ -80,7 +82,7 @@ _ADMISSION_DIAGNOSIS_MATCH_RULES: Final[list[EntryMatchRule]] = [
 _ADMISSION_MEDICATIONS_MATCH_RULES: Final[list[EntryMatchRule]] = [
     EntryMatchRule(
         code_xpath=".//hl7:manufacturedMaterial/hl7:code",
-        code_system_oid=RXNORM_OID,  # RxNorm
+        code_system_oid=RXNORM_OID,
         translation_xpath=".//hl7:manufacturedMaterial/hl7:code/hl7:translation",
     ),
 ]
@@ -140,9 +142,9 @@ _ENCOUNTERS_MATCH_RULES: Final[list[EntryMatchRule]] = [
 _IMMUNIZATIONS_MATCH_RULES: Final[list[EntryMatchRule]] = [
     EntryMatchRule(
         code_xpath=".//hl7:manufacturedMaterial/hl7:code",
-        code_system_oid=CVX_OID,  # CVX
+        code_system_oid=CVX_OID,
         translation_xpath=".//hl7:manufacturedMaterial/hl7:code/hl7:translation",
-        translation_code_system_oid=RXNORM_OID,  # RxNorm
+        translation_code_system_oid=RXNORM_OID,
     ),
 ]
 
@@ -153,7 +155,7 @@ _IMMUNIZATIONS_MATCH_RULES: Final[list[EntryMatchRule]] = [
 _MEDICATIONS_MATCH_RULES: Final[list[EntryMatchRule]] = [
     EntryMatchRule(
         code_xpath=".//hl7:manufacturedMaterial/hl7:code",
-        code_system_oid=RXNORM_OID,  # RxNorm
+        code_system_oid=RXNORM_OID,
         translation_xpath=".//hl7:manufacturedMaterial/hl7:code/hl7:translation",
     ),
 ]
@@ -165,7 +167,7 @@ _MEDICATIONS_MATCH_RULES: Final[list[EntryMatchRule]] = [
 _MEDICATIONS_HOME_MATCH_RULES: Final[list[EntryMatchRule]] = [
     EntryMatchRule(
         code_xpath=".//hl7:manufacturedMaterial/hl7:code",
-        code_system_oid=RXNORM_OID,  # RxNorm
+        code_system_oid=RXNORM_OID,
         translation_xpath=".//hl7:manufacturedMaterial/hl7:code/hl7:translation",
     ),
 ]
@@ -237,7 +239,7 @@ _PLAN_OF_TREATMENT_MATCH_RULES: Final[list[EntryMatchRule]] = [
             "[hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.44']]"
             "/hl7:code"
         ),
-        code_system_oid=LOINC_OID,  # LOINC
+        code_system_oid=LOINC_OID,
     ),
     # rule 2 — medication activity (scoped to base Medication Activity template)
     EntryMatchRule(
@@ -246,7 +248,7 @@ _PLAN_OF_TREATMENT_MATCH_RULES: Final[list[EntryMatchRule]] = [
             "[hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.16']]"
             "//hl7:manufacturedMaterial/hl7:code"
         ),
-        code_system_oid=RXNORM_OID,  # RxNorm
+        code_system_oid=RXNORM_OID,
         translation_xpath=(
             ".//hl7:substanceAdministration"
             "[hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.16']]"
@@ -260,13 +262,13 @@ _PLAN_OF_TREATMENT_MATCH_RULES: Final[list[EntryMatchRule]] = [
             "[hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.52']]"
             "//hl7:manufacturedMaterial/hl7:code"
         ),
-        code_system_oid=CVX_OID,  # CVX
+        code_system_oid=CVX_OID,
         translation_xpath=(
             ".//hl7:substanceAdministration"
             "[hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.52']]"
             "//hl7:manufacturedMaterial/hl7:code/hl7:translation"
         ),
-        translation_code_system_oid=RXNORM_OID,  # RxNorm
+        translation_code_system_oid=RXNORM_OID,
     ),
     # rule 4 — indication value (reason for medication/procedure) — SNOMED fallback
     EntryMatchRule(
@@ -275,7 +277,7 @@ _PLAN_OF_TREATMENT_MATCH_RULES: Final[list[EntryMatchRule]] = [
             "[hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.19']]"
             "/hl7:value"
         ),
-        code_system_oid=SNOMED_OID,  # SNOMED
+        code_system_oid=SNOMED_OID,
     ),
 ]
 
@@ -319,7 +321,7 @@ _RESULTS_MATCH_RULES: Final[list[EntryMatchRule]] = [
             "[hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.2']]"
             "/hl7:code"
         ),
-        code_system_oid=LOINC_OID,  # LOINC
+        code_system_oid=LOINC_OID,
         prune_container_xpath="hl7:organizer/hl7:component",
     ),
     EntryMatchRule(
@@ -328,7 +330,7 @@ _RESULTS_MATCH_RULES: Final[list[EntryMatchRule]] = [
             "[hl7:templateId[@root='2.16.840.1.113883.10.20.22.4.2']]"
             "/hl7:value[@xsi:type='CD']"
         ),
-        code_system_oid=SNOMED_OID,  # SNOMED
+        code_system_oid=SNOMED_OID,
         prune_container_xpath="hl7:organizer/hl7:component",
     ),
 ]


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

<!--
What changes are being proposed?
-->
Add entry matching rules for Vital Signs that prunes things in a similar way to Results. This will make sure that if you add a custom code (or if another code in the TES) matches in Vital signs that the organizer level will be the pruning point where things that don't match are removed.

## 🔗 Related Issue

<!--
add the issue number in both places:
Fixes #3
- #3
-->

Fixes #997 
- #997 

## ✅ Acceptance Criteria

<!--
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
-->

## 🧪 How to test

<!--
Unit tests

1. From the project root make sure you're in the `refiner/` directory
2. Activate a virtual environment using your tool of choice
3. Make sure that both `requirements.txt` and `requirements-dev.txt` are installed
4. Run the unit tests with `pytest -vv tests/`
5. Additionally you can check coverage with `pytest --cov=app tests`

or

Testing the application:

1. Run `docker compose up`
2. Check that both services are up and running with `docker ps`
3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
4. You should be able to [insert goal you want to accomplish!]
-->

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
### What the IGs Say About Vital Signs Structure

The Vital Signs section (LOINC 8716-3) has a three-level nesting that's structurally analogous to Results but with its own quirks. Per the STU3.1.1 Vol2:

- Section → entry → Vital Signs Organizer (V3) (2.16.840.1.113883.10.20.22.4.26:2015-08-01) → component → Vital Sign Observation (V2) (2.16.840.1.113883.10.20.22.4.27:2014-06-09)
- The matchable clinical code lives at the observation level — each Vital Sign Observation (V2) SHALL have a code drawn from the Vital Sign Result Type value set (urn:oid:2.16.840.1.113883.3.88.12.80.62), which is all LOINC codes (CONF:1098-7301). The code system OID is 2.16.840.1.113883.6.1. The observations produce value[[@xsi](https://github.com/xsi):type='PQ'] (physical quantities), not coded values, so the matchable code is observation/code, not observation/value.
- The Organizer itself has a fixed code — SNOMED 46680005 "Vital Signs" (CONF:1198-32741) with a required LOINC translation of 74728-7 (CONF:1198-32743/32744). So the organizer code is not clinically discriminating for matching purposes; it's the same on every organizer.