### PR TITLE
fix: independent test flow producing duplicate refined eICR files

### DIFF
--- a/refiner/app/api/v1/demo.py
+++ b/refiner/app/api/v1/demo.py
@@ -211,13 +211,14 @@ async def demo_upload(
             )
             # Continue with XML only; do not include HTML file for this condition
 
-        normalized_refined_eicr = format.normalize_xml(refined_document.refined_eicr)
-        refined_files_to_zip.append((eicr_filename_xml, normalized_refined_eicr))
+        refined_files_to_zip.append((eicr_filename_xml, condition_refined_eicr))
         refined_files_to_zip.append((rr_filename_xml, condition_refined_rr))
 
         formatted_unrefined_eicr = format.strip_comments(
             format.normalize_xml(original_xml_files.eicr)
         )
+
+        normalized_refined_eicr = format.normalize_xml(refined_document.refined_eicr)
         formatted_refined_eicr = format.strip_comments(normalized_refined_eicr)
         formatted_refined_rr = format.strip_comments(
             format.normalize_xml(original_xml_files.rr)


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR fixes an issue where a refined eICR document would be produced twice during the independent test flow's zip packaging step.

## 🧪 How to test

- Create COVID and/ or Influenza configs, activate them
- Run the independent test
- Download the file package and ensure the contents look correct