### PR TITLE
chore: ruff won't allow `print` in app code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ extend-select = [
   "I",
   # - python code modernization
   "UP",
+  # - no `print` statements
+  "T201",
 ]
 
 # rules we explicitly disable
@@ -71,11 +73,11 @@ ignore = [
 # file-specific rule exclusions
 [tool.ruff.lint.per-file-ignores]
 # - disable docstring/type/security rules in tests
-"**/tests/*" = ["D", "S", "ANN"]
+"**/tests/*" = ["D", "S", "ANN", "T201"]
 # - disable docstring/type/security rules in lambda
 "**/lambda/*" = ["D", "S", "ANN"]
 # - disable type annotation rules in scripts
-"**/scripts/*" = ["ANN"]
+"**/scripts/*" = ["ANN", "T201"]
 # - allow missing docstrings in __init__
 "__init__.py" = ["D"]
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This ruff rule ensures `print` statements won't accidentally be left behind in app code. Note that this config still allows `print` to be used in `tests` and `scripts`.

## 🧪 How to test

1. Pull down this branch and run `ruff check`, you should see `All checks passed!`
2. Try adding a `print("testing!")` line somewhere in the app code
3. Running `ruff check` again will produce an error like this
```sh
T201 `print` found
   --> app/api/v1/configurations/testing.py:127:9
    |
125 |             msg="Running inline test using sample file", extra={"file": file.filename}
126 |         )
127 |         print("testing!")
    |         ^^^^^
128 |     try:
129 |         # STEP 2:
    |
help: Remove `print`

Found 1 error.
No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
```
