### PR TITLE
chore: CI specific e2e test configurations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,17 +101,17 @@ jobs:
 
       - name: Migrate Database
         run: |
-          sleep 10
+          timeout 60 bash -c 'until pg_isready -h localhost -p 5432; do sleep 2; done'
           just migrate local
       - name: Seed Database
         run: just db seed
       - name: Wait for Auth Service to be Ready
         run: |
-          timeout 60 bash -c 'until curl -f http://localhost:8082 > /dev/null 2>&1; do sleep 2; done'
+          timeout 120 bash -c 'until curl -sf http://localhost:8082/realms/refiner > /dev/null 2>&1; do sleep 2; done'
           echo "Auth Service is ready!"
       - name: Wait for app server proxy to be ready
         run: |
-          timeout 60 bash -c 'until curl -f http://localhost:8081 > /dev/null 2>&1; do sleep 2; done'
+          timeout 60 bash -c 'until curl -f http://localhost:8081/api/healthcheck > /dev/null 2>&1; do sleep 2; done'
           echo "App server proxy is ready!"
       - name: Run Playwright E2E Tests
         run: just client run e2e

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -2,12 +2,13 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
-  timeout: 30 * 1000,
+  timeout: process.env.CI ? 60 * 1000 : 30 * 1000,
   expect: {
     timeout: 10 * 1000,
   },
+  retries: process.env.CI ? 2 : 0,
   forbidOnly: !!process.env.CI,
-  workers: 2,
+  workers: process.env.CI ? 1 : 2,
   reporter: [['html', { open: 'never' }]],
   use: {
     trace: 'on-first-retry',


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

In an effort to decrease e2e tests failing in the pipeline due to constrained GH Action runners I have:
- Adjusted maximum timeout values in CI
- Improved service readiness checks
- Allowed for 2 test retries in CI
- Limited workers to 1 in CI

## 🧪 How to test

Feel free to try running the test job using this branch. Tests should continue to pass.