### PR TITLE
feat: produce shadow RR for conditions with no configuration

### DIFF
--- a/refiner/app/services/testing.py
+++ b/refiner/app/services/testing.py
@@ -370,6 +370,7 @@ async def independent_testing(
         no_matching_configuration_for_conditions=no_matching_configurations,
         no_active_configuration_for_conditions=no_active_configurations,
         shadow_rr=_generate_shadow_rr(
+            no_matching_configuration_for_conditions=no_matching_configurations,
             no_active_configuration_for_conditions=no_active_configurations,
             xml_files=xml_files,
         ),
@@ -377,28 +378,34 @@ async def independent_testing(
 
 
 def _generate_shadow_rr(
-    no_active_configuration_for_conditions: list[NoMatchEntry], xml_files: XMLFiles
+    no_matching_configuration_for_conditions: list[NoMatchEntry],
+    no_active_configuration_for_conditions: list[NoMatchEntry],
+    xml_files: XMLFiles,
 ) -> str | None:
     """
-    Given a list of condition codes with no active configuration, return the generated shadow RR or None.
+    Generates a shadow RR based on conditions with no active configuration.
 
     Args:
-        no_active_configuration_for_conditions (list[NoMatchEntry]): list of no match entries
+        no_matching_configuration_for_conditions (list[NoMatchEntry]): list of conditions without a configuration
+        no_active_configuration_for_conditions (list[NoMatchEntry]): list of conditions without an active configuration
         xml_files (XMLFiles): the original XML eCR files
 
     Returns:
         str | None: RR content, or None if a shadow RR isn't generated
     """
-    if not no_active_configuration_for_conditions:
+    no_match_found_conditions = (
+        no_matching_configuration_for_conditions
+        + no_active_configuration_for_conditions
+    )
+    if not no_match_found_conditions:
         return None
 
-    non_active_codes = {
-        code
-        for entry in no_active_configuration_for_conditions
-        for code in entry["rc_snomed_codes"]
+    no_match_codes = {
+        code for entry in no_match_found_conditions for code in entry["rc_snomed_codes"]
     }
+
     return refine_rr_for_unconfigured_conditions(
-        xml_files=xml_files, condition_codes=non_active_codes
+        xml_files=xml_files, condition_codes=no_match_codes
     )
 
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the independent test flow to produce a shadow RR for conditions that:
1. Don't have a configuration created at all
2. Have a configuration created but it is not active

Previously we were only creating shadow RRs for conditions that had a configuration created.

## 🔗 Related Issue

Fixes #1058

## 🧪 How to test

Start with a fresh DB state (`just db refresh`)
1. Create a COVID-19 configuration and activate it
2. Run the independent test flow
3. Download the results, check that `CDA_RR_unrefined_rr.xml` is in the package (because no Influenza config exists)
4. Create an Influenza configuration draft
5. Run the independent test flow
6. Download the results, check that `CDA_RR_unrefined_rr.xml` is in the package (because no Influenza config is active)
7. Activate the Influenza config
8. Run the independent test flow
9. Download the results, check that `CDA_RR_unrefined_rr.xml` is **NOT** in the package (because the Influenza config is now active)

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
