### PR TITLE
fix: independent test file package download validation is overly strict

### DIFF
--- a/client/src/components/Diff/index.tsx
+++ b/client/src/components/Diff/index.tsx
@@ -3,6 +3,7 @@ import ReactDiffViewer, { DiffMethod } from 'react-diff-viewer-continued';
 import { IndependentTestUploadResponse } from '../../api/schemas';
 import classNames from 'classnames';
 import { Button } from '../Button';
+import { getDownloadRefinedEcrQueryKey } from '../../api/demo/demo';
 
 type DiffProps = Pick<
   IndependentTestUploadResponse,
@@ -16,23 +17,32 @@ export function Diff({
   unrefined_eicr,
   condition,
 }: DiffProps) {
-  const [downloadError, setDownloadError] = useState<boolean>(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
   const [showDiffOnly, setShowDiffOnly] = useState(true);
   const [splitView, setSplitView] = useState(true);
 
-  function downloadFile(filename: string) {
+  async function downloadFile(filename: string) {
     try {
-      const downloadUrl = `/api/v1/demo/download/${filename}`;
+      const url = getDownloadRefinedEcrQueryKey(filename)[0];
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        const { detail } = await response.json();
+        setDownloadError(detail ?? 'An unknown error occurred.');
+        return;
+      }
+
+      const blob = await response.blob();
+      const blobUrl = URL.createObjectURL(blob);
       const link = document.createElement('a');
-      link.href = downloadUrl;
-      link.download = '';
-      document.body.appendChild(link);
+      link.href = blobUrl;
+      link.download = filename;
       link.click();
-      document.body.removeChild(link);
-      setDownloadError(false);
+      URL.revokeObjectURL(blobUrl);
+      setDownloadError(null);
     } catch (error) {
       console.error(error);
-      setDownloadError(true);
+      setDownloadError('An unknown error occurred.');
     }
   }
 
@@ -48,14 +58,18 @@ export function Diff({
             ))}
           </div>
           <div>
-            <div className="gapx-2 flex flex-col items-start py-1">
+            <div className="flex flex-col items-start gap-1 py-1">
               <Button
                 variant="tertiary"
                 onClick={() => downloadFile(refined_download_key)}
               >
                 Download results
               </Button>
-              {downloadError && <span>File download has expired.</span>}
+              {downloadError ? (
+                <span className="text-state-error-dark">
+                  Error: {downloadError}
+                </span>
+              ) : null}
             </div>
           </div>
         </div>

--- a/refiner/app/api/v1/demo.py
+++ b/refiner/app/api/v1/demo.py
@@ -1,8 +1,8 @@
 import io
+import re
 from collections.abc import Awaitable, Callable
 from logging import Logger
 from pathlib import Path
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from fastapi.concurrency import run_in_threadpool
@@ -36,6 +36,15 @@ from app.services.logger import get_logger
 from app.services.sample_file import get_sample_zip_path
 from app.services.testing import independent_testing
 from app.services.xslt import create_refined_eicr_html_file
+
+# Only allow:
+# - letters
+# - numbers
+# - hyphens
+# - underscores
+# - periods
+# - spaces
+SAFE_FILENAME_RE = re.compile(r"^[\w\-. ]+\.zip$")
 
 # create a router instance for this file
 router = APIRouter(prefix="/demo")
@@ -254,19 +263,9 @@ async def download_refined_ecr(
     server constructs the S3 object key based on the authenticated user.
     """
 
-    if "/" in filename or "\\" in filename:
+    if not SAFE_FILENAME_RE.match(filename):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid filename."
-        )
-
-    uuid_prefix = filename.removesuffix(".zip")
-
-    try:
-        UUID(uuid_prefix)
-    except ValueError:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid filename.",
         )
 
     key = get_refined_user_zip_key(


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR fixes an issue where the pertussis sample file zip package was failing to download in the independent test flow. Please see my comment for detail on exactly why this was happening.

## 🔗 Related Issue

Fixes #1059 

## 🧪 How to test

1. Create a Pertussis configuration
2. Try running the Pertussis sample files through the independent testing flow (grab from `refiner/assets/demo`)
3. Try downloading the file package using the `Download results` button. You should see that it's successful and be able to open the zip package

If you want to check that the error messaging works, try adding something like this to the route in `demo.py`:
```python
@router.get(
    "/download/{filename}",
    tags=["demo"],
    operation_id="downloadRefinedEcr",
)
async def download_refined_ecr(
    ...
) -> StreamingResponse:
    ...

    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Problem occurred.")

    if not SAFE_FILENAME_RE.match(filename):
        ...
```

When you try to download again you'll see something like this:
<img width="991" height="143" alt="image" src="https://github.com/user-attachments/assets/aca735e7-b65d-44ad-b121-2ad2047f7a43" />