### PR TITLE
fix: Removes `platform:` stanza and updates documentation around VM resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ For more detailed information about the relationship between the eICR and RR doc
 
 ## Running the project locally
 
+> [!TIP]
+> When running containers locally on macOS or Windows, please ensure your host
+> VM's defaults are increased. _Specifically, CPU cores must be set to 2 cores
+> or above, Memory must be set at least 4 GiB, and Disk should be at least 100
+> GiB_. These changes will ensure that all scripting and application code run
+> correctly without issues.
+
 The Refiner is a containerized application and can be easily run using [Docker](https://www.docker.com/). With Docker installed, run the following command from the top-level directory containing the `.docker-compose.yaml` file:
 
 ```sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,6 @@ services:
       - refiner-service
   refiner-service:
     image: python:3.14-slim
-    platform: linux/amd64
     command: sh -c "pip install -r requirements.txt -r requirements-dev.txt && uvicorn app.asgi:app --host 0.0.0.0 --port 8080 --reload"
     working_dir: /app
     volumes:


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

During the review of #1079, it was brought up that we don't need to define the
`platform:` stanza for the `refiner-service`. This patch removes that stanza and
also adds some documentation to ensure that developers use a host VM with enough
resources for our scripts and applications to run.

## 🔗 Related Issue

Supersedes #1079

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

Everything should run as expected across different architectures without issues.
