### PR TITLE
chore: update e2e tsconfig.json

### DIFF
--- a/client/e2e/tsconfig.json
+++ b/client/e2e/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "commonjs",
-    "moduleResolution": "Node",
+    "module": "es2015",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the e2e package's `tsconfig.json` to solve two issues:
1. TS should now be able to see Node's types (my editor was complaining about imports from node)
2. The `moduleResolution` value we were using is deprecated

## 🧪 How to test

- e2e tests should continue to pass
- If you were previously having issues with imports from node being flagged by TS this should resolve that (you may need to restart the language server)
- `moduleResolution` should no longer be flagged as deprecated in the tsconfig file
