### PR TITLE
chore(test): navigate e2e auth flow only once

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# e2e testing
+e2e/.auth

--- a/client/e2e/04 - homepage.spec.ts
+++ b/client/e2e/04 - homepage.spec.ts
@@ -17,23 +17,16 @@ test.describe('Viewing the application sign in content', () => {
     ).toBeVisible();
     await expect(makeAxeBuilder).toHaveNoAxeViolations();
 
-    const refinerButton = page.locator('button', {
-      hasText: 'refiner (SDDH)',
+    const menuButton = page.getByRole('button', {
+      name: 'Open settings menu',
     });
-    await expect(refinerButton).toBeVisible();
-    await refinerButton.click();
+    await expect(menuButton).toBeVisible();
+    await menuButton.click();
 
-    // 2️⃣ Assert the logout link is visible
-    const logoutLink = page.locator('a[href="/api/logout"]', {
-      hasText: 'Log out',
-    });
-    await expect(logoutLink).toBeVisible();
-
-    // 3️⃣ Click the logout link
-    await logoutLink.click();
-
-    // homepage should have the relevant content
-    await expect(page).toHaveTitle(/DIBBs eCR Refiner/);
-    await expect(page.getByRole('link', { name: 'Log in' })).toBeVisible();
+    await expect(
+      page.getByRole('menuitem', {
+        name: 'Log out',
+      })
+    ).toBeVisible();
   });
 });

--- a/client/e2e/auth.setup.ts
+++ b/client/e2e/auth.setup.ts
@@ -1,0 +1,11 @@
+import { test as setup } from '@playwright/test';
+import fs from 'fs';
+import { login } from './utils';
+
+const authFile = 'e2e/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  if (fs.existsSync(authFile)) fs.unlinkSync(authFile);
+  await login({ page });
+  await page.context().storageState({ path: authFile });
+});

--- a/client/e2e/fixtures/setup.ts
+++ b/client/e2e/fixtures/setup.ts
@@ -1,5 +1,5 @@
 import { test as baseTest, expect, Page, WorkerInfo } from '@playwright/test';
-import { deleteConfigurationArtifacts, login } from '../utils';
+import { deleteConfigurationArtifacts } from '../utils';
 class ConfigurationPage {
   private readonly conditionIndex: number;
   private conditionName: string = '';
@@ -45,12 +45,12 @@ const defaultFixturesTest = baseTest.extend<object>({
   page: async ({ page }, use) => {
     // start in the logged in homepage
     await page.goto('/configurations');
-    const returnToHomepageButton = page.getByRole('button', {
-      name: 'Return to homepage',
-    });
-    if (returnToHomepageButton) {
-      await login({ page, baseUrl: 'http://localhost:8081' });
-    }
+    await expect(
+      page.getByRole('heading', { name: 'Configurations', level: 1 })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Set up new configuration' })
+    ).toBeVisible();
     await use(page);
   },
 });

--- a/client/e2e/utils.ts
+++ b/client/e2e/utils.ts
@@ -73,13 +73,6 @@ export async function login({
   ).toBeVisible();
 }
 
-export async function logout(page: Page) {
-  await page.goto('/');
-  await page.getByRole('button', { name: 'refiner' }).click();
-  await page.getByRole('menuitem', { name: 'Log out' }).click();
-  await expect(page.getByRole('link', { name: 'Log in' })).toBeVisible();
-}
-
 export async function createNewConfiguration(
   conditionName: string,
   page: Page

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -18,8 +18,18 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'Chromium',
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
       use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'e2e',
+      testMatch: /.*\.spec\.ts/,
+      dependencies: ['setup'],
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'e2e/.auth/user.json',
+      },
     },
   ],
 });


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR modifies the e2e tests so that they acquire a single Refiner session through Keycloak and then reuse it across all tests. This prevents the tests from needing to re-authenticate over and over as they run. This should help to make the test suite a little more reliable when running in the pipeline since the Keycloak service can be flaky at times in this environment.

## 🔗 Related Issue

Part of the app testing ticket.

## 🧪 How to test

If you want to try this locally:

1. Run `npm run e2e:dev`
2. Try running a single test or all tests via the testing UI
3. You should see `auth.test.ts` will always run first, which authenticates and then stores the session to `e2e/.auth/user.json`
4. Test(s) should pass as normal