### PR TITLE
fix: Remove lazy load optimization

### DIFF
--- a/client/src/components/Diff/index.tsx
+++ b/client/src/components/Diff/index.tsx
@@ -153,15 +153,6 @@ export function Diff({
         compareMethod={DiffMethod.WORDS_WITH_SPACE}
         leftTitle="Original eICR"
         rightTitle="Refined eICR"
-        infiniteLoading={{
-          pageSize: 20,
-          containerHeight: '80vh',
-        }}
-        loadingElement={() => (
-          <div style={{ padding: '20px', textAlign: 'center' }}>
-            Computing diff...
-          </div>
-        )}
         styles={{
           titleBlock: {
             fontFamily: 'Public Sans, sans-serif',


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This was asked for by @kplaneaux in Slack due to the fact that enabling this was
causing the inability for users to be able to use their browser's Find in Page
functionality.

Revert "fix: Lazy load diffs to improve performance (#1090)"

This reverts commit 395a84788be5a16bb3cbcd0e66bc6a296d918e95.

## 🔗 Related Issue

- #1060

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

- Ensure that Find in Page functionality still works on the Diff page.
