### PR TITLE
feat: Create generic Risk Assessment template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ client/e2e/downloads/
 
 # Structurizr
 .structurizr/
+
+# Risk Assessments
+docs/risk-assessments/
+!docs/risk-assessments/.template

--- a/.justscripts/just/risk-assessments.just
+++ b/.justscripts/just/risk-assessments.just
@@ -1,0 +1,24 @@
+alias help := default
+
+[private]
+@default:
+    just --list risk-assessments
+
+# @variable type
+# @type string
+# @description A string representing the singular name to use when outputting
+# messages from the main _new recipe defined at the root `justfile`.
+
+type := "risk assessment"
+
+# @variable folder
+# @type string
+# @description A string representing the file path relative to the root of the
+# repository which contains the .template.md and where the files are being
+# created.
+
+folder := "docs/risk-assessments"
+
+[doc('Create a new risk assessment from the template found in docs/risk-assessments/.template')]
+@new title:
+    just --justfile {{ justfile() }} _new "{{ title }}" "{{ type }}" "{{ folder }}"

--- a/docs/risk-assessments/.template
+++ b/docs/risk-assessments/.template
@@ -1,5 +1,9 @@
 # eCR Refiner Risk Assessment
 
+## ${nextNumber}. ${title}
+
+Date: ${today}
+
 <!--
 This template is for any Risk Assessment needs that the eCR Refiner team
 needs when working with the APHL AIMS platform. This needs to be done when we

--- a/docs/risk-assessments/_template.md
+++ b/docs/risk-assessments/_template.md
@@ -1,0 +1,50 @@
+# eCR Refiner Risk Assessment
+
+<!--
+This template is for any Risk Assessment needs that the eCR Refiner team
+needs when working with the APHL AIMS platform. This needs to be done when we
+have high or medium vulnerabilities which will cause our application or
+containers to not be able to be deployed in their APHL Production environment.
+-->
+
+## Identity of Origin of Deficiency
+
+<!-- [AUTHOR: Briefly state where and how the deficiency was discovered. Fill in
+here.] -->
+
+## Overall Risk Score of Deficiency
+
+<!-- [AUTHOR: Provide the overall risk score (e.g., High, Medium, Low, or
+numeric rating). Cite your scoring system if needed. Fill in here.] -->
+
+## Identified Deficiency, Vulnerability, or Exception
+
+<!-- [AUTHOR: List the specific identified deficiency, vulnerability, or
+exception, using any official identifier or finding label. Fill in here.] -->
+
+## Description of Deficiency, Vulnerability, or Exception
+
+<!-- [AUTHOR: Summarize the deficiency, including how it impacts the system or
+business. One to two concise paragraphs. Fill in here.] -->
+
+## Justification for Risk Acceptance
+
+<!-- [AUTHOR: If you recommend accepting this risk, explain the rationale, such
+as business case, operational need, or risk trade-off. Up to two paragraphs. Fill
+in here.] -->
+
+## Compensating Control or Remediation Plan
+
+<!-- [AUTHOR: Describe the compensating control in place, or detail the planned
+remediation steps and timeline to address the deficiency. Up to two paragraphs.
+Fill in here.] -->
+
+## Additional Remarks / Scan Results / Release Version
+
+<!--
+[AUTHOR: Pin exceptions to the relevant application or container version as
+necessary. Paste a direct link to the relevant row from the GitHub Code Scanning
+results:
+https://github.com/CDCgov/dibbs-ecr-refiner/security/code-scanning
+(fill in here with the direct finding's URL)]
+-->

--- a/justfile
+++ b/justfile
@@ -100,15 +100,18 @@ _new title type folder:
     #!/usr/bin/env node
     const fs = require('node:fs');
     const path = require('node:path');
+    const os = require('os');
 
     const today = new Date().toISOString().split('T')[0];
     const title = "{{ title }}";
     const fileTitle = "{{ kebabcase(title) }}";
+    const isCve = "{{ type }}" === "risk assessment"
 
     console.info(`📝 Creating a new {{ type }} on ${today}`);
 
     console.info(`🔍 Found {{ type }} title: ${title}`);
 
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'new-'));
     const runningFromDir = path.join("{{ replace(justfile_directory(), '\', '/') }}");
     const folderPath = '{{ folder }}';
 
@@ -124,37 +127,47 @@ _new title type folder:
       return fs.lstatSync(fileName).isFile() && fileName.match(re);
     };
 
-    console.info(`🔦 Checking for existing {{ type }}s in ${fullWritePath}`);
+    if (isCve) {
+      console.info(`🕵️ This is a {{ type }} and will be saved to a temporary directory`)
+    } else {
+      console.info(`🔦 Checking for existing {{ type }}s in ${fullWritePath}`);
+      const resolvedPath = path.resolve(fullWritePath);
 
-    const resolvedPath = path.resolve(fullWritePath);
+      const files = fs.readdirSync(resolvedPath)
+        .map(fileName => {
+          return path.join(fullWritePath, fileName);
+          })
+        .filter(isFile);
 
-    const template = fs.readFileSync(`${fullWritePath}/.template`)
+      console.info(`🔍 Found ${(files.length + "").padStart(4, '0')} {{ type }}(s)`);
 
-    const files = fs.readdirSync(resolvedPath)
-      .map(fileName => {
-        return path.join(fullWritePath, fileName);
-      })
-      .filter(isFile);
+      const nextNumber = files.length + 1;
+      const nextNumberString = (nextNumber + "").padStart(4, '0');
 
-    console.info(`🔍 Found ${(files.length + "").padStart(4, '0')} {{ type }}(s)`);
-
-    const nextNumber = files.length + 1;
-    const nextNumberString = (nextNumber + "").padStart(4, '0');
-
-    console.info(`🖊️ Setting your new {{ type }} to #${nextNumberString}`);
+      console.info(`🖊️ Setting your new {{ type }} to #${nextNumberString}`);
+    }
 
     const nextFilePath = path.join(
-        resolvedPath,
-        `${nextNumberString}_${today}_${fileTitle}.md`
+        (isCve ? tmpDir : resolvedPath),
+        (isCve ? `${today}_${fileTitle}.md` : `${nextNumberString}_${today}_${fileTitle}.md`)
     );
 
-    console.info(`📊 Attempting to save {{ type }} #${nextNumberString} to ${nextFilePath}`);
+    if (isCve) {
+      console.info(`📊 Attempting to save {{ type }} to ${nextFilePath}`)
+    } else {
+      console.info(`📊 Attempting to save {{ type }} #${nextNumberString} to ${nextFilePath}`);
+    }
 
+    const template = fs.readFileSync(`${fullWritePath}/.template`)
     const content = eval(`\`${template}\``);
 
     try {
       fs.writeFileSync(nextFilePath, content);
-      console.log(`✅ Successfully created {{ type }} #${nextNumberString} for ${title} at ${nextFilePath}`);
+      if (isCve) {
+        console.log(`✅ Successfully created {{ type }} for ${title} at ${nextFilePath}`);
+      } else {
+        console.log(`✅ Successfully created {{ type }} #${nextNumberString} for ${title} at ${nextFilePath}`);
+      }
     } catch (e) {
       console.error(`❌ ${e}`);
     }

--- a/justfile
+++ b/justfile
@@ -13,6 +13,10 @@ mod c './.justscripts/just/client.just'
 mod db './.justscripts/just/database.just'
 
 [group('alias')]
+[doc('Alias for `risk-assessments`')]
+mod cve './.justscripts/just/risk-assessments.just'
+
+[group('alias')]
 [doc('Alias for `decisions`')]
 mod rfc './.justscripts/just/decisions.just'
 
@@ -65,6 +69,10 @@ mod cloud './.justscripts/just/cloud.just'
 mod structurizr './.justscripts/just/structurizr.just'
 
 [group('sub-command')]
+[doc('Run risk assessments commands')]
+mod risk-assessments './.justscripts/just/risk-assessments.just'
+
+[group('sub-command')]
 [doc('Run decision records commands')]
 mod decisions './.justscripts/just/decisions.just'
 
@@ -85,7 +93,7 @@ test:
 
 # NOTE: The recipe below named `_new` is **only** called from other Justfiles
 # that create files from .template files found next to them. Currently it's
-# used for managing and authoring `docs/decisions`.
+# used for managing and authoring `docs/decisions` and `docs/risk-assessments`
 
 [private]
 _new title type folder:


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This new template and recipe can be used by eCR Refiner engineers to help assess
risks (CVEs) introduced by dependencies on our project that we would like to
accept or need a plan to mitigate it. If the dependency to the project is
updated, these kinds of risk assessments are unnecessary, but if we would like
to continue to release based on our schedule APHL will require us to produce one
for each vulnerability, deficiency, or exception.

> [!IMPORTANT]
> This template is okay to share publicly but the actual created documents
> **must** never be added to this repository. There are measurements in place
> with the automation and our configuration of the repo to prevent this but
> please be mindful of committing anything after running either of the new
> `just` recipes.

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

You should be able to run any of the new recipes below to create a new CVE
locally on your machine.

```sh
# the shortcut
just cve new "CVE-2026-123456"

# or the long version
just risk-assessments new "CVE-2026-123456"
```

This file location will not be created within your local repository but rather
in a temporary directory. Make note of this directory as it will be displayed on
the screen for you to be able to find it after the automation runs. Please be
responsible with the file and prevent accidentally committing any risk
assessments that have been filled out.
