### PR TITLE
fix: Removes unused variable from template

### DIFF
--- a/docs/risk-assessments/.template
+++ b/docs/risk-assessments/.template
@@ -1,6 +1,6 @@
 # eCR Refiner Risk Assessment
 
-## ${nextNumber}. ${title}
+## ${title}
 
 Date: ${today}
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

Fixes an issue with creating local CVE documents due to an unused variable that
existed in the template, `nextNumber`.

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

Run `just cve new "CVE-2026-12345"` and it should create a new risk assessment
document in a temporary directory without issue.
