### PR TITLE
chore: use new default Postgres 18 volume mount point

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -41,7 +41,7 @@ services:
   db:
     volumes:
       - ./.justscripts/sql/drop-all.sql:/drop-all.sql
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
 
   migrate:
     image: ghcr.io/amacneil/dbmate:main


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR modifies the `docker-compose.override.yml`'s `db` volume to use the [new default mount point in Postgres 18](https://hub.docker.com/_/postgres#pgdata).

I started seeing pipeline failures before making this change.
```sh
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names).  This better reflects how
       PostgreSQL itself works, and how upgrades are to be performed.
       See also https://github.com/docker-library/postgres/pull/1259
       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)
       This is usually the result of upgrading the Docker image without
       upgrading the underlying database using "pg_upgrade" (which requires both
       versions).
       The suggested container configuration for 18+ is to place a single mount
       at /var/lib/postgresql which will then place PostgreSQL data in a
       subdirectory, allowing usage of "pg_upgrade --link" without mount point
       boundary issues.
```

## 🧪 How to test

- Fully stop your dev environment and restart it. Everything should work as expected
- GH Action pipeline should be successful