### PR TITLE
fix: inline and independent test configurations use the same serialization/deserialization process as Lambda

### DIFF
--- a/refiner/app/api/v1/configurations/testing.py
+++ b/refiner/app/api/v1/configurations/testing.py
@@ -163,6 +163,7 @@ async def run_configuration_test(
             all_conditions=all_conditions_for_configuration,
             jurisdiction_id=user.jurisdiction_id,
             logger=logger,
+            db=db,
         )
     except XMLValidationError:
         raise HTTPException(

--- a/refiner/app/services/testing.py
+++ b/refiner/app/services/testing.py
@@ -305,23 +305,8 @@ async def independent_testing(
 
         trace.all_conditions_for_configuration = all_conditions_for_configuration
 
-        # Serialize
-        serialized_configuration = await convert_config_to_storage_payload(
-            configuration=configuration, db=db
-        )
-
-        if not serialized_configuration:
-            logger.error(
-                "Converting configuration to storage payload failed.",
-                extra={configuration},
-            )
-            raise ValueError(
-                f"Configurated could not be converted to a storage payload: {configuration.id}"
-            )
-
-        # Deserialize
-        processed_configuration = ProcessedConfiguration.from_dict(
-            serialized_configuration.to_dict()
+        processed_configuration = await _convert_to_processed_config(
+            configuration=configuration, logger=logger, db=db
         )
 
         trace.refine_object = processed_configuration
@@ -392,6 +377,41 @@ async def independent_testing(
             xml_files=xml_files,
         ),
     )
+
+
+async def _convert_to_processed_config(
+    configuration: DbConfiguration, logger: Logger, db: AsyncDatabaseConnection
+):
+    """
+    Helper function to simulate the serialization/deserialization process Lambda uses.
+
+    Args:
+        configuration (DbConfiguration): The configuration
+        logger (Logger): The logger
+        db (AsyncDatabaseConnection): The database connection
+
+    Raises:
+        ValueError: Unable to convert the config to a storage payload
+
+    Returns:
+        ProcessedConfiguration: A ProcessedConfiguration created from a storage payload object
+    """
+    # Convert the config to a storage payload
+    serialized_configuration = await convert_config_to_storage_payload(
+        configuration=configuration, db=db
+    )
+
+    if not serialized_configuration:
+        logger.error(
+            "Converting configuration to storage payload failed.",
+            extra={"configuration": asdict(configuration)},
+        )
+        raise ValueError(
+            f"Configuration could not be converted to a storage payload: {configuration.id}"
+        )
+
+    # Convert to a ProcessedConfiguration from the serialized configuration
+    return ProcessedConfiguration.from_dict(serialized_configuration.to_dict())
 
 
 def _generate_shadow_rr(
@@ -517,24 +537,8 @@ async def inline_testing(
 
     # STEP 4:
     # prepare and execute the refinement from payload -> processed_configuration -> shared pipeline
-
-    # Serialize
-    serialized_configuration = await convert_config_to_storage_payload(
-        configuration=configuration, db=db
-    )
-
-    if not serialized_configuration:
-        logger.error(
-            "Converting configuration to storage payload failed.",
-            extra={configuration},
-        )
-        raise ValueError(
-            f"Configurated could not be converted to a storage payload: {configuration.id}"
-        )
-
-    # Deserialize
-    processed_configuration = ProcessedConfiguration.from_dict(
-        serialized_configuration.to_dict()
+    processed_configuration = await _convert_to_processed_config(
+        configuration=configuration, logger=logger, db=db
     )
 
     pipeline_trace = RefinementTrace(

--- a/refiner/app/services/testing.py
+++ b/refiner/app/services/testing.py
@@ -19,7 +19,7 @@ from ..db.configurations.db import (
 )
 from ..db.configurations.model import DbConfiguration
 from ..db.pool import AsyncDatabaseConnection
-from ..services.terminology import ConfigurationPayload, ProcessedConfiguration
+from ..services.terminology import ProcessedConfiguration
 from .ecr.model import (
     RefinedDocument,
     ReportableCondition,
@@ -433,6 +433,7 @@ async def inline_testing(
     all_conditions: list[DbCondition],
     jurisdiction_id: str,
     logger: Logger,
+    db: AsyncDatabaseConnection,
 ) -> InlineTestingResult:
     """
     Orchestrates the full inline testing workflow for eICR refinement using an already-fetched configuration and primary condition.
@@ -455,6 +456,7 @@ async def inline_testing(
           of the primary and secondary conditions.
         jurisdiction_id: The jurisdiction code to filter reportable conditions.
         logger: we're passing the logger from the route to the service.
+        db: The database connection
 
     Returns:
         An InlineTestingResult dictionary containing either the refined document or a validation error.
@@ -515,11 +517,25 @@ async def inline_testing(
 
     # STEP 4:
     # prepare and execute the refinement from payload -> processed_configuration -> shared pipeline
-    payload = ConfigurationPayload(
-        configuration=trace.configuration,
-        conditions=trace.all_conditions_for_configuration,
+
+    # Serialize
+    serialized_configuration = await convert_config_to_storage_payload(
+        configuration=configuration, db=db
     )
-    processed_configuration = ProcessedConfiguration.from_payload(payload)
+
+    if not serialized_configuration:
+        logger.error(
+            "Converting configuration to storage payload failed.",
+            extra={configuration},
+        )
+        raise ValueError(
+            f"Configurated could not be converted to a storage payload: {configuration.id}"
+        )
+
+    # Deserialize
+    processed_configuration = ProcessedConfiguration.from_dict(
+        serialized_configuration.to_dict()
+    )
 
     pipeline_trace = RefinementTrace(
         jurisdiction_code=jurisdiction_id,

--- a/refiner/app/services/testing.py
+++ b/refiner/app/services/testing.py
@@ -6,6 +6,8 @@ from uuid import UUID
 
 from packaging.version import parse
 
+from app.services.configurations import convert_config_to_storage_payload
+
 from ..core.models.types import XMLFiles
 from ..db.conditions.db import (
     get_conditions_by_child_rsg_snomed_codes_db,
@@ -303,11 +305,25 @@ async def independent_testing(
 
         trace.all_conditions_for_configuration = all_conditions_for_configuration
 
-        payload = ConfigurationPayload(
-            configuration=configuration,
-            conditions=trace.all_conditions_for_configuration,
+        # Serialize
+        serialized_configuration = await convert_config_to_storage_payload(
+            configuration=configuration, db=db
         )
-        processed_configuration = ProcessedConfiguration.from_payload(payload)
+
+        if not serialized_configuration:
+            logger.error(
+                "Converting configuration to storage payload failed.",
+                extra={configuration},
+            )
+            raise ValueError(
+                f"Configurated could not be converted to a storage payload: {configuration.id}"
+            )
+
+        # Deserialize
+        processed_configuration = ProcessedConfiguration.from_dict(
+            serialized_configuration.to_dict()
+        )
+
         trace.refine_object = processed_configuration
 
         # Use the shared pipeline to execute refinement


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the inline and independent test flows so that the `ProcessedConfiguration` used for refinement is created by serializing to a `ConfigurationStoragePayload` and then deserializing this object.

This brings the web app's refinement process much closer to the way that refinement works in Lambda. The only main difference now is that the `ConfigurationStoragePayload` is used immediately rather than being written to a file.

## 🧪 How to test

- Both inline and independent testing should function as they did before
- All automated tests should continue to pass