### PR TITLE
test: make integration tests start more quickly when containers are already running

### DIFF
--- a/refiner/tests/integration/conftest.py
+++ b/refiner/tests/integration/conftest.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from dataclasses import asdict
 from pathlib import Path
 from uuid import UUID
@@ -317,6 +318,21 @@ def base_url() -> str:
     return "http://0.0.0.0:8080/"
 
 
+def _restart_server(compose_path: str) -> None:
+    """
+    Restarts the Refiner server running in Docker.
+
+    This is used during setup to prevent Postgres cache plans from occasionally failing. This
+    often happens if you run a DB refresh while containers are already running and then try
+    to run the tests right after.
+
+    We use subprocess because DockerCompose does not provide an API to restart a single container.
+    """
+    subprocess.run(
+        ["docker", "compose", "restart", "server"], cwd=compose_path, check=True
+    )
+
+
 @pytest.fixture(scope="session")
 def setup(request):
     """
@@ -339,10 +355,10 @@ def setup(request):
         compose_file_name=["docker-compose.yml", "docker-compose.override.yml"],
     )
 
-    # restart the environment if it's already running
-    # this will clear the DB volume and prevent caching issues
-    refiner_service.stop()
     refiner_service.start()
+
+    print("⚙️ Restarting refiner server")
+    _restart_server(compose_path=path)
 
     refiner_service.wait_for("http://0.0.0.0:8080/api/healthcheck")
     print("✨ Message refiner services ready to test!")


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR fixes an issue where it would take a long time for the integration tests to begin running, even if your containers have already started.

We were previously stopping/starting the entire Docker Compose environment but was too slow. Now we just restart the `server` container before tests start executing, which should still prevent the caching issue while also being much faster.

## 🧪 How to test

1. Have your docker compose environment up and running already
2. Run `just db refresh`
3. Run `pytest tests`
4. Ensure tests beginning running reasonably quickly and that you aren't getting random test failures due to caching issues (you will see logs coming from the db container if this happens)