### PR TITLE
refactor: Remove `ProcessedConfiguration.from_payload()`

### DIFF
--- a/refiner/app/lambda/README.md
+++ b/refiner/app/lambda/README.md
@@ -2,35 +2,6 @@
 
 This package is exclusively used to build a version of the Refiner intended to run as an AWS Lambda function.
 
-## Refinement pipeline architecture
-
-The Refiner has two entry points that both need to produce identical refinement results:
-
-- **Webapp** (`testing.py`): Interactive validation where a logged-in user tests an eICR/RR pair against a configuration resolved from the database.
-- **Lambda** (`lambda_function.py`): Production refinement where an incoming eICR/RR pair is refined against configurations resolved from S3.
-
-Both entry points share a common refinement pipeline defined in `app/services/pipeline.py`. The pipeline exposes two stages:
-
-1. **Discovery** (`discover_reportable_conditions`): Parses the RR to extract which conditions are reportable and to which jurisdictions. Both the webapp and Lambda call this identically.
-2. **Refinement** (`refine_for_condition`): Takes a `ProcessedConfiguration` and an eICR/RR pair, creates refinement plans, and executes them. The refined output is identical regardless of how the configuration was sourced.
-
-### The activation bridge
-
-The connection between the webapp and Lambda is the activation step. When a user activates a configuration in the webapp, `convert_config_to_storage_payload` in `app/services/configurations.py` serializes the configuration to S3. This includes both a flat `codes` list (for backward compatibility with the generic matching path) and a structured `code_system_sets` field (for section-aware matching). Lambda reads this file at runtime and deserializes it back into the same data structures the webapp uses.
-
-The S3 file structure for a jurisdiction's configuration:
-
-- `configurations/<jurisdiction_id>/rsg_cg_mapping.json` — maps RSG SNOMED codes to condition grouper names and canonical URLs
-- `configurations/<jurisdiction_id>/<canonical_url_uuid>/current.json` — points to the active version number (supports rollback)
-- `configurations/<jurisdiction_id>/<canonical_url_uuid>/<version>/active.json` — the serialized configuration used for refinement
-
-### Unrefined conditions RR
-
-When the RR contains reportable conditions for a jurisdiction but only some have active configurations, conditions that go through full refinement get their own refined eICR and RR. The remaining conditions (those without active configurations) still need their reportability information preserved. The `create_unrefined_conditions_rr` function in `app/services/ecr/refine.py` produces a filtered RR containing only those unrefined conditions. This prevents downstream systems from seeing duplicate condition information when they receive the full output package.
-
-### Observability
-
-Both entry points use `RefinementTrace` objects (defined in `pipeline.py`) to track what happened during refinement. Each trace captures the jurisdiction, condition code, whether a configuration was resolved, the refinement outcome (refined, skipped, or error), and the skip reason if applicable. Lambda logs a summary of all traces at the end of each invocation.
 
 ## Running the eCR Refiner Lambda in production
 
@@ -100,3 +71,33 @@ Sample SQS Event to trigger Lambda:
   ]
 }
 ```
+
+## Refinement pipeline architecture
+
+The Refiner has two entry points that both need to produce identical refinement results:
+
+- **Webapp** (`testing.py`): Interactive validation where a logged-in user tests an eICR/RR pair against a configuration resolved from the database.
+- **Lambda** (`lambda_function.py`): Production refinement where an incoming eICR/RR pair is refined against configurations resolved from S3.
+
+Both entry points share a common refinement pipeline defined in `app/services/pipeline.py`. The pipeline exposes two stages:
+
+1. **Discovery** (`discover_reportable_conditions`): Parses the RR to extract which conditions are reportable and to which jurisdictions. Both the webapp and Lambda call this identically.
+2. **Refinement** (`refine_for_condition`): Takes a `ProcessedConfiguration` and an eICR/RR pair, creates refinement plans, and executes them. The refined output is identical regardless of how the configuration was sourced.
+
+### The activation bridge
+
+The connection between the webapp and Lambda is the activation step. When a user activates a configuration in the webapp, `convert_config_to_storage_payload` in `app/services/configurations.py` serializes the configuration to S3. This includes both a flat `codes` list (for backward compatibility with the generic matching path) and a structured `code_system_sets` field (for section-aware matching). Lambda reads this file at runtime and deserializes it back into the same data structures the webapp uses.
+
+The S3 file structure for a jurisdiction's configuration:
+
+- `configurations/<jurisdiction_id>/rsg_cg_mapping.json` — maps RSG SNOMED codes to condition grouper names and canonical URLs
+- `configurations/<jurisdiction_id>/<canonical_url_uuid>/current.json` — points to the active version number (supports rollback)
+- `configurations/<jurisdiction_id>/<canonical_url_uuid>/<version>/active.json` — the serialized configuration used for refinement
+
+### Unrefined conditions RR
+
+When the RR contains reportable conditions for a jurisdiction but only some have active configurations, conditions that go through full refinement get their own refined eICR and RR. The remaining conditions (those without active configurations) still need their reportability information preserved. The `create_unrefined_conditions_rr` function in `app/services/ecr/refine.py` produces a filtered RR containing only those unrefined conditions. This prevents downstream systems from seeing duplicate condition information when they receive the full output package.
+
+### Observability
+
+Both entry points use `RefinementTrace` objects (defined in `pipeline.py`) to track what happened during refinement. Each trace captures the jurisdiction, condition code, whether a configuration was resolved, the refinement outcome (refined, skipped, or error), and the skip reason if applicable. Lambda logs a summary of all traces at the end of each invocation.

--- a/refiner/app/lambda/README.md
+++ b/refiner/app/lambda/README.md
@@ -14,13 +14,6 @@ Both entry points share a common refinement pipeline defined in `app/services/pi
 1. **Discovery** (`discover_reportable_conditions`): Parses the RR to extract which conditions are reportable and to which jurisdictions. Both the webapp and Lambda call this identically.
 2. **Refinement** (`refine_for_condition`): Takes a `ProcessedConfiguration` and an eICR/RR pair, creates refinement plans, and executes them. The refined output is identical regardless of how the configuration was sourced.
 
-The only difference between the two paths is how they resolve a `ProcessedConfiguration`:
-
-- The **webapp** queries the database, builds a `ConfigurationPayload` with full `DbCondition` objects, and calls `ProcessedConfiguration.from_payload()`. This produces a `CodeSystemSets` with codes organized by system (SNOMED, LOINC, ICD-10, RxNorm, CVX) and enriched with display names.
-- **Lambda** reads an `active.json` file from S3 and calls `ProcessedConfiguration.from_dict()`. The `active.json` file contains a `code_system_sets` field that was serialized at activation time, so `from_dict` produces the same `CodeSystemSets` with the same per-system routing and display names.
-
-This design ensures that once a `ProcessedConfiguration` is built, the downstream behavior is byte-for-byte identical in both environments.
-
 ### The activation bridge
 
 The connection between the webapp and Lambda is the activation step. When a user activates a configuration in the webapp, `convert_config_to_storage_payload` in `app/services/configurations.py` serializes the configuration to S3. This includes both a flat `codes` list (for backward compatibility with the generic matching path) and a structured `code_system_sets` field (for section-aware matching). Lambda reads this file at runtime and deserializes it back into the same data structures the webapp uses.

--- a/refiner/app/services/terminology.py
+++ b/refiner/app/services/terminology.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 # This file establishes a consistent pattern for handling terminology data:
 # 1. A `Payload` class (e.g., ConfigurationPayload) holds raw DB models.
 # 2. A `Processed` class (e.g., ProcessedConfiguration) holds the final, ready-to-use data.
-# 3. The `Processed` class has a `.from_payload()` factory method that contains all
+# 3. The `Processed` class has a `.from_dict()` factory method that contains all
 #    the logic to transform the raw payload into the processed version.
 # This separates data fetching, data processing, and data usage into clean, testable steps.
 # =============================================================================

--- a/refiner/app/services/terminology.py
+++ b/refiner/app/services/terminology.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Iterator
-from dataclasses import asdict, dataclass, field, fields
+from dataclasses import dataclass, field, fields
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -419,80 +419,4 @@ class ProcessedConfiguration:
             code_system_sets=code_system_sets,
             section_processing=[s.model_dump() for s in validated.sections],
             included_condition_rsg_codes=validated.included_condition_rsg_codes,
-        )
-
-    @classmethod
-    def from_payload(cls, payload: ConfigurationPayload) -> "ProcessedConfiguration":
-        """
-        Create ProcessedConfiguration from a ConfigurationPayload object.
-
-        This method aggregates codes from both the configuration's associated conditions and
-        any custom codes defined on the configuration itself. Codes are organized by code
-        system for section-aware matching, and a flat set is maintained for sections with no
-        entry matching rules.
-
-        Args:
-            payload: The ConfigurationPayload containing the DbConfiguration and its
-                     related DbConditions.
-
-        Returns:
-            ProcessedConfiguration: An object containing both flat and structured code sets.
-        """
-
-        # STEP 1: build per-system dicts from condition codes
-        # each condition has snomed_codes, loinc_codes, icd10_codes, rxnorm_codes
-        # each code object in those lists has .code and .display
-        coding_by_code_system: dict[str, list[dict]] = defaultdict(list)
-        for condition in payload.conditions:
-            # map each db code list to its target dict + OID
-            code_system_map: dict[CodeSystem, list] = (
-                index_condition_code_list_by_system(condition)
-            )
-
-            for code_system, code_list in code_system_map.items():
-                coding_by_code_system[
-                    CodeSystem(code_system).format_system_string()
-                ].extend(
-                    [
-                        asdict(
-                            Coding(
-                                code=c.code, display=c.display, system=code_system.oid
-                            )
-                        )
-                        for c in code_list
-                    ]
-                )
-
-        # STEP 2: add custom codes, routing by their system label
-        for custom_code in payload.configuration.custom_codes:
-            cur_code_system = CodeSystem(custom_code.system).format_system_string()
-            code_val = custom_code.code
-            display_val = custom_code.name
-
-            # route to the correct dict based on system label
-            coding_by_code_system[cur_code_system].append(
-                asdict(
-                    Coding(
-                        code=code_val,
-                        display=display_val,
-                        system=CodeSystem(cur_code_system).oid,
-                    )
-                )
-            )
-
-        # STEP 3: build the CodeSystemSets
-        code_system_sets = CodeSystemSets.from_dict(data=coding_by_code_system)
-
-        # STEP 4: build included_condition_rsg_codes
-        included_condition_rsg_codes = set()
-        for c in payload.conditions:
-            included_condition_rsg_codes.update(c.child_rsg_snomed_codes)
-
-        return cls(
-            codes=code_system_sets.all_codes,
-            code_system_sets=code_system_sets,
-            section_processing=[
-                asdict(section) for section in payload.configuration.section_processing
-            ],
-            included_condition_rsg_codes=included_condition_rsg_codes,
         )

--- a/refiner/app/services/terminology.py
+++ b/refiner/app/services/terminology.py
@@ -2,20 +2,15 @@ from collections import defaultdict
 from collections.abc import Iterator
 from dataclasses import dataclass, field, fields
 from enum import StrEnum
-from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
 from ..db.conditions.model import DbCondition, DbConditionCoding
 
-if TYPE_CHECKING:
-    from ..db.configurations.model import DbConfiguration
-
 # NOTE:
 # This file establishes a consistent pattern for handling terminology data:
-# 1. A `Payload` class (e.g., ConfigurationPayload) holds raw DB models.
-# 2. A `Processed` class (e.g., ProcessedConfiguration) holds the final, ready-to-use data.
-# 3. The `Processed` class has a `.from_dict()` factory method that contains all
+# 1. A `Processed` class (e.g., ProcessedConfiguration) holds the final, ready-to-use data.
+# 2. The `Processed` class has a `.from_dict()` factory method that contains all
 #    the logic to transform the raw payload into the processed version.
 # This separates data fetching, data processing, and data usage into clean, testable steps.
 # =============================================================================
@@ -312,29 +307,6 @@ class CodeSystemSets:
 # NOTE:
 # CONFIGURATION PROCESSING
 # =============================================================================
-
-
-@dataclass(frozen=True)
-class ConfigurationPayload:
-    """
-    Model representing the raw configuration data needed for refinement.
-
-    This model is intentionally minimal to support both inline testing (from configuration building)
-    and independent testing (from demo.py processing) patterns. The model focuses on just the
-    essential data needed for refinement:
-
-    - conditions: A list of all DbCondition objects to be considered.
-    - configuration: The specific DbConfiguration object, which may contain custom codes.
-
-    Note on Testing Patterns:
-    - Independent testing: Uses RC SNOMED codes from the RR's coded information organizer to find
-      the matching configuration. The RC SNOMED code comes from the RR, not the configuration itself.
-    - Inline testing: Directly uses a configuration to test against input data, focusing only on
-      the codes defined in that configuration.
-    """
-
-    configuration: "DbConfiguration"
-    conditions: list[DbCondition]
 
 
 class Section(BaseModel):

--- a/refiner/tests/unit/helpers/configuration.py
+++ b/refiner/tests/unit/helpers/configuration.py
@@ -1,0 +1,24 @@
+import unittest
+
+from app.db.conditions.model import DbCondition
+from app.db.configurations.model import DbConfiguration
+from app.services.configurations import convert_config_to_storage_payload
+from app.services.terminology import ProcessedConfiguration
+
+
+async def create_processed_config(
+    config: DbConfiguration, conditions: list[DbCondition]
+):
+    with unittest.mock.patch(
+        "app.services.configurations.get_included_conditions_db",
+        return_value=conditions,
+    ):
+        storage_payload = await convert_config_to_storage_payload(
+            configuration=config,
+            db=unittest.mock.AsyncMock(),
+        )
+
+    if storage_payload is None:
+        raise ValueError("convert_config_to_storage_payload returned None unexpectedly")
+
+    return ProcessedConfiguration.from_dict(storage_payload.to_dict())

--- a/refiner/tests/unit/test_service_refine.py
+++ b/refiner/tests/unit/test_service_refine.py
@@ -1,3 +1,6 @@
+import unittest
+
+import pytest
 from lxml import etree
 
 from app.db.conditions.model import DbCondition, DbConditionCoding
@@ -5,10 +8,11 @@ from app.db.configurations.model import (
     DbConfiguration,
     DbConfigurationSectionInstructions,
 )
+from app.services.configurations import convert_config_to_storage_payload
 from app.services.ecr.model import HL7_NS, EICRRefinementPlan
 from app.services.ecr.refine import create_rr_refinement_plan, refine_eicr, refine_rr
 from app.services.ecr.specification import load_spec
-from app.services.terminology import ConfigurationPayload, ProcessedConfiguration
+from app.services.terminology import ProcessedConfiguration
 
 # NOTE:
 # TEST CONSTANTS
@@ -132,7 +136,7 @@ def _make_db_configuration_v3_1_1(**kwargs) -> DbConfiguration:
 # =============================================================================
 
 
-def _make_empty_processed_config() -> ProcessedConfiguration:
+async def _make_empty_processed_config() -> ProcessedConfiguration:
     """
     Creates a ProcessedConfiguration with no codes.
 
@@ -142,11 +146,28 @@ def _make_empty_processed_config() -> ProcessedConfiguration:
 
     condition = _make_condition_v1_1()
     config = _make_db_configuration_v1_1()
-    payload = ConfigurationPayload(conditions=[condition], configuration=config)
-    return ProcessedConfiguration.from_payload(payload)
+    return await create_processed_config(config=config, conditions=[condition])
 
 
-def _make_processed_config_v1_1(**condition_kwargs) -> ProcessedConfiguration:
+async def create_processed_config(
+    config: DbConfiguration, conditions: list[DbCondition]
+):
+    with unittest.mock.patch(
+        "app.services.configurations.get_included_conditions_db",
+        return_value=conditions,
+    ):
+        storage_payload = await convert_config_to_storage_payload(
+            configuration=config,
+            db=unittest.mock.AsyncMock(),
+        )
+
+    if storage_payload is None:
+        raise ValueError("convert_config_to_storage_payload returned None unexpectedly")
+
+    return ProcessedConfiguration.from_dict(storage_payload.to_dict())
+
+
+async def _make_processed_config_v1_1(**condition_kwargs) -> ProcessedConfiguration:
     """
     Creates a ProcessedConfiguration from a v1.1 condition with the given codes.
 
@@ -156,8 +177,8 @@ def _make_processed_config_v1_1(**condition_kwargs) -> ProcessedConfiguration:
 
     condition = _make_condition_v1_1(**condition_kwargs)
     config = _make_db_configuration_v1_1()
-    payload = ConfigurationPayload(conditions=[condition], configuration=config)
-    return ProcessedConfiguration.from_payload(payload)
+
+    return await create_processed_config(config=config, conditions=[condition])
 
 
 def _make_plan(
@@ -198,429 +219,449 @@ def _make_plan(
 # =============================================================================
 
 
-def test_retain_action_v1_1(
-    eicr_root_v1_1: etree._Element, original_eicr_root_v1_1: etree._Element
-):
-    """
-    Tests the 'retain' action, which should not modify the section.
-    """
-
-    empty_config = _make_empty_processed_config()
-
-    plan = EICRRefinementPlan(
-        codes_to_check=set(),
-        code_system_sets=empty_config.code_system_sets,
-        section_instructions={
-            "29762-2": DbConfigurationSectionInstructions(
-                action="retain", include=True, narrative=True
-            )
-        },
-        section_provenance={},
-        specification=load_spec("1.1"),
-        augmentation_timestamp=_PLACEHOLDER_AUGMENTATION_TIMESTAMP,
-    )
-
-    refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
-
-    section_refined = eicr_root_v1_1.xpath(
-        './/hl7:section[hl7:code[@code="29762-2"]]', namespaces=HL7_NS
-    )[0]
-
-    section_original = original_eicr_root_v1_1.xpath(
-        './/hl7:section[hl7:code[@code="29762-2"]]', namespaces=HL7_NS
-    )[0]
-
-    assert etree.tostring(section_refined) == etree.tostring(section_original)
-
-
-def test_refine_action_with_no_matches_v1_1(eicr_root_v1_1: etree._Element):
-    """
-    Tests 'refine' with a non-matching code, which should create a minimal section.
-    """
-
-    empty_config = _make_empty_processed_config()
-
-    plan = EICRRefinementPlan(
-        codes_to_check={"NON_EXISTENT_CODE"},
-        code_system_sets=empty_config.code_system_sets,
-        section_instructions={
-            "11450-4": DbConfigurationSectionInstructions(
-                action="refine", include=True, narrative=False
-            )
-        },
-        section_provenance={},
-        specification=load_spec("1.1"),
-        augmentation_timestamp=_PLACEHOLDER_AUGMENTATION_TIMESTAMP,
-    )
-
-    refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
-
-    problems_section = eicr_root_v1_1.xpath(
-        './/hl7:section[hl7:code[@code="11450-4"]]', namespaces=HL7_NS
-    )[0]
-    assert problems_section.get("nullFlavor") == "NI"
-
-
-def test_refine_action_with_matches_v1_1(eicr_root_v1_1: etree._Element):
-    """
-    Tests the 'refine' action for v1.1, ensuring it correctly uses the
-    terminology pipeline to build codes and filter a section.
-    """
-
-    processed_config = _make_processed_config_v1_1(
-        loinc_codes=[DbConditionCoding(code="94533-7", display="")]
-    )
-
-    plan = EICRRefinementPlan(
-        codes_to_check=processed_config.codes,
-        code_system_sets=processed_config.code_system_sets,
-        section_instructions={
-            "30954-2": DbConfigurationSectionInstructions(
-                action="refine", include=True, narrative=False
-            )
-        },
-        section_provenance={},
-        specification=load_spec("1.1"),
-        augmentation_timestamp=_PLACEHOLDER_AUGMENTATION_TIMESTAMP,
-    )
-
-    refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
-
-    results_section = eicr_root_v1_1.xpath(
-        './/hl7:section[hl7:code[@code="30954-2"]]', namespaces=HL7_NS
-    )[0]
-    section_text = etree.tostring(results_section, encoding="unicode")
-    assert "94533-7" in section_text
-
-
-# NOTE:
-# EICR REFINEMENT TESTS — section-aware path
-# =============================================================================
-# * these tests exercise the full refine_eicr pipeline with real
-# ProcessedConfiguration objects so that the section-aware match rules,
-# component-level pruning, and displayName enrichment all fire
-# * they assert on the shape of the refined XML output rather than testing
-# internal functions, making them resilient to internal refactoring
-
-
-def test_section_aware_results_filtering_v1_1(eicr_root_v1_1: etree._Element):
-    """
-    Tests that the section-aware path correctly filters the Results section:
-    keeps entries with LOINC codes in the condition grouper and removes entries
-    with LOINC codes not in the condition grouper.
-    """
-
-    processed_config = _make_processed_config_v1_1(
-        loinc_codes=[
-            DbConditionCoding(code="94533-7", display="SARS-CoV-2 N gene"),
-            DbConditionCoding(code="94558-4", display="SARS-CoV-2 Ag Rapid"),
-        ],
-    )
-    plan = _make_plan(processed_config, {"30954-2": "refine"})
-
-    refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
-
-    results_section = eicr_root_v1_1.xpath(
-        './/hl7:section[hl7:code[@code="30954-2"]]', namespaces=HL7_NS
-    )[0]
-
-    # matching COVID tests should survive
-    organizer_codes = results_section.xpath(
-        ".//hl7:organizer/hl7:code/@code", namespaces=HL7_NS
-    )
-    assert "94533-7" in organizer_codes
-    assert "94558-4" in organizer_codes
-
-    # non-matching entries should be removed
-    section_text = etree.tostring(results_section, encoding="unicode")
-    assert "34487-9" not in section_text  # influenza
-    assert "51990-0" not in section_text  # BMP
-    assert "48065-7" not in section_text  # D-dimer
-    assert "30746-2" not in section_text  # chest X-ray
-
-
-def test_section_aware_problems_component_pruning_v1_1(eicr_root_v1_1: etree._Element):
-    """
-    Tests that the Problems section prunes individual problem observations
-    within a Problem Concern Act while keeping the act wrapper intact.
-    """
-
-    processed_config = _make_processed_config_v1_1(
-        snomed_codes=[
-            DbConditionCoding(code="840539006", display="Disease caused by SARS-CoV-2"),
-            DbConditionCoding(code="186747009", display="Coronavirus infection"),
-            DbConditionCoding(code="230145002", display="Difficulty Breathing"),
-        ],
-    )
-    plan = _make_plan(processed_config, {"11450-4": "refine"})
-
-    refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
-
-    problems_section = eicr_root_v1_1.xpath(
-        './/hl7:section[hl7:code[@code="11450-4"]]', namespaces=HL7_NS
-    )[0]
-
-    # section should NOT be NI — we have matches
-    assert problems_section.get("nullFlavor") is None
-
-    # the Problem Concern Act wrapper should still be present
-    concern_acts = problems_section.xpath(
-        ".//hl7:act[hl7:code[@code='CONC']]", namespaces=HL7_NS
-    )
-    assert len(concern_acts) == 1
-
-    # matching problem observations should survive
-    surviving_values = problems_section.xpath(
-        ".//hl7:observation/hl7:value/@code", namespaces=HL7_NS
-    )
-    assert "840539006" in surviving_values
-    assert "186747009" in surviving_values
-    assert "230145002" in surviving_values
-
-    # non-matching observations should be pruned
-    section_text = etree.tostring(problems_section, encoding="unicode")
-    assert "719865001" not in section_text  # influenza
-    assert "59621000" not in section_text  # hypertension
-    assert "44054006" not in section_text  # diabetes
-
-
-def test_display_name_enrichment_v1_1(eicr_root_v1_1: etree._Element):
-    """
-    Tests that missing displayName attributes are filled in from the condition
-    grouper, both at match time (observation code) and during the post-prune
-    enrichment pass (organizer code, result value).
-    """
-
-    processed_config = _make_processed_config_v1_1(
-        loinc_codes=[
-            DbConditionCoding(
-                code="94759-8",
-                display="SARS-CoV-2 (COVID-19) RNA [Presence] in Nasopharynx by NAA with probe detection",
-            ),
-        ],
-        snomed_codes=[
-            DbConditionCoding(code="260373001", display="Detected (qualifier value)"),
-        ],
-    )
-    plan = _make_plan(processed_config, {"30954-2": "refine"})
-
-    refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
-
-    results_section = eicr_root_v1_1.xpath(
-        './/hl7:section[hl7:code[@code="30954-2"]]', namespaces=HL7_NS
-    )[0]
-
-    # observation code should be enriched (match-time)
-    obs_codes = results_section.xpath(
-        ".//hl7:observation/hl7:code[@code='94759-8']", namespaces=HL7_NS
-    )
-    assert len(obs_codes) > 0
-    assert obs_codes[0].get("displayName") is not None
-    assert "Nasopharynx" in obs_codes[0].get("displayName", "")
-
-    # organizer code should be enriched (post-prune _enrich_surviving_entries)
-    organizer_codes = results_section.xpath(
-        ".//hl7:organizer/hl7:code[@code='94759-8']", namespaces=HL7_NS
-    )
-    assert len(organizer_codes) > 0
-    assert organizer_codes[0].get("displayName") is not None
-    assert "Nasopharynx" in organizer_codes[0].get("displayName", "")
-
-    # result value should be enriched (post-prune _enrich_surviving_entries)
-    detected_values = results_section.xpath(
-        ".//hl7:value[@code='260373001']", namespaces=HL7_NS
-    )
-    assert len(detected_values) > 0
-    assert detected_values[0].get("displayName") is not None
-    assert "Detected" in detected_values[0].get("displayName", "")
-
-
-def test_plan_of_treatment_heterogeneous_entries_v1_1(eicr_root_v1_1: etree._Element):
-    """
-    Tests that Plan of Treatment correctly handles heterogeneous entry types:
-    keeps matching lab orders (LOINC) and medications (RxNorm), removes
-    non-matching entries.
-    """
-
-    processed_config = _make_processed_config_v1_1(
-        loinc_codes=[
-            DbConditionCoding(code="94500-6", display="SARS-CoV-2 RNA panel"),
-        ],
-        rxnorm_codes=[
-            DbConditionCoding(code="2284960", display="remdesivir 100 MG Injection"),
-        ],
-    )
-    plan = _make_plan(processed_config, {"18776-5": "refine"})
-
-    refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
-
-    pot_section = eicr_root_v1_1.xpath(
-        './/hl7:section[hl7:code[@code="18776-5"]]', namespaces=HL7_NS
-    )[0]
-    section_text = etree.tostring(pot_section, encoding="unicode")
-
-    # matching lab order and medication should survive
-    assert "94500-6" in section_text
-    assert "2284960" in section_text
-
-    # non-matching entries should be removed
-    assert "25836-8" not in section_text  # influenza lab order
-    assert "261315" not in section_text  # oseltamivir
-    assert "314076" not in section_text  # lisinopril
-    assert "861007" not in section_text  # metformin
-    assert "270427003" not in section_text  # follow-up encounter
-
-
-def test_encounters_diagnosis_pruning_v1_1(eicr_root_v1_1: etree._Element):
-    """
-    Tests that the Encounters section prunes non-matching diagnoses at the
-    component level while keeping the encounter wrapper and matching diagnoses.
-    """
-
-    processed_config = _make_processed_config_v1_1(
-        snomed_codes=[
-            DbConditionCoding(code="840539006", display="Disease caused by SARS-CoV-2"),
-        ],
-    )
-    plan = _make_plan(processed_config, {"46240-8": "refine"})
-
-    refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
-
-    enc_section = eicr_root_v1_1.xpath(
-        './/hl7:section[hl7:code[@code="46240-8"]]', namespaces=HL7_NS
-    )[0]
-
-    # only encounters with matching diagnoses should survive
-    entries = enc_section.xpath(".//hl7:entry", namespaces=HL7_NS)
-    assert len(entries) == 1
-
-    # covid diagnosis should be kept
-    surviving_values = enc_section.xpath(
-        ".//hl7:observation/hl7:value/@code", namespaces=HL7_NS
-    )
-    assert "840539006" in surviving_values
-
-    # influenza diagnosis should be pruned from within the encounter
-    section_text = etree.tostring(enc_section, encoding="unicode")
-    assert "772828001" not in section_text
-
-
-def test_non_matching_section_becomes_ni_v1_1(eicr_root_v1_1: etree._Element):
-    """
-    Tests that a section with entries but no matching codes becomes nullFlavor NI
-    with all entries removed.
-    """
-
-    processed_config = _make_processed_config_v1_1(
-        snomed_codes=[
-            DbConditionCoding(code="840539006", display="Disease caused by SARS-CoV-2"),
-        ],
-    )
-    plan = _make_plan(processed_config, {"11369-6": "refine"})
-
-    refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
-
-    imm_section = eicr_root_v1_1.xpath(
-        './/hl7:section[hl7:code[@code="11369-6"]]', namespaces=HL7_NS
-    )[0]
-
-    # no matching CVX codes for covid → section should be NI
-    assert imm_section.get("nullFlavor") == "NI"
-
-    # entries should be removed
-    entries = imm_section.xpath(".//hl7:entry", namespaces=HL7_NS)
-    assert len(entries) == 0
-
-
-# NOTE:
-# RR REFINEMENT TESTS
-# =============================================================================
-
-
-def test_refine_rr_by_condition_v1_1(rr_root_v1_1: etree._Element):
-    """
-    Tests RR refinement for v1.1: keeps ONLY the observations for conditions
-    specified in the configuration.
-    """
-
-    covid_condition = _make_condition_v1_1(child_rsg_snomed_codes=["840539006"])
-    config = _make_db_configuration_v1_1()
-    payload = ConfigurationPayload(conditions=[covid_condition], configuration=config)
-
-    processed_configuration = ProcessedConfiguration.from_payload(payload)
-
-    rr_refinement_plan = create_rr_refinement_plan(
-        processed_configuration=processed_configuration
-    )
-
-    refine_rr(rr_root=rr_root_v1_1, plan=rr_refinement_plan)
-
-    doc_string = etree.tostring(rr_root_v1_1, encoding="unicode")
-
-    assert "840539006" in doc_string
-    assert "49727002" not in doc_string
-
-
-def test_refine_rr_by_jurisdiction_v1_1(rr_root_v1_1: etree._Element):
-    """
-    Tests RR refinement for v1.1: doesn't touch observations not for the given jurisdiction.
-    """
-
-    covid_condition = _make_condition_v1_1(child_rsg_snomed_codes=["840539006"])
-    config = _make_db_configuration_v1_1(jurisdiction_id="SOME-OTHER-JD")
-    payload = ConfigurationPayload(conditions=[covid_condition], configuration=config)
-
-    processed_configuration = ProcessedConfiguration.from_payload(payload)
-    rr_refinement_plan = create_rr_refinement_plan(
-        processed_configuration=processed_configuration
-    )
-
-    refine_rr(rr_root=rr_root_v1_1, plan=rr_refinement_plan)
-
-    doc_string = etree.tostring(rr_root_v1_1, encoding="unicode")
-
-    assert "840539006" in doc_string
-
-
-def test_refine_rr_by_condition_v3_1_1(rr_root_v3_1_1: etree._Element):
-    """
-    Tests RR refinement on the Zika file: confirms the Zika observation is kept
-    even if config is for another jurisdiction.
-    """
-
-    zika_condition = _make_condition_v3_1_1(child_rsg_snomed_codes=["3928002"])
-    config = _make_db_configuration_v3_1_1()
-    payload = ConfigurationPayload(conditions=[zika_condition], configuration=config)
-
-    processed_configuration = ProcessedConfiguration.from_payload(payload)
-    rr_refinement_plan = create_rr_refinement_plan(
-        processed_configuration=processed_configuration
-    )
-
-    refine_rr(rr_root=rr_root_v3_1_1, plan=rr_refinement_plan)
-
-    doc_string = etree.tostring(rr_root_v3_1_1, encoding="unicode")
-
-    assert "3928002" in doc_string
-
-
-def test_refine_rr_by_jurisdiction_v3_1_1(rr_root_v3_1_1: etree._Element):
-    """
-    Tests RR refinement on the Zika file: confirms the Zika observation is still
-    present even when jurisdiction is different.
-    """
-
-    zika_condition = _make_condition_v3_1_1(child_rsg_snomed_codes=["3928002"])
-    config = _make_db_configuration_v3_1_1(jurisdiction_id="SOME-OTHER-JD")
-    payload = ConfigurationPayload(conditions=[zika_condition], configuration=config)
-
-    processed_configuration = ProcessedConfiguration.from_payload(payload)
-    rr_refinement_plan = create_rr_refinement_plan(
-        processed_configuration=processed_configuration
-    )
-
-    refine_rr(rr_root=rr_root_v3_1_1, plan=rr_refinement_plan)
-
-    doc_string = etree.tostring(rr_root_v3_1_1, encoding="unicode")
-
-    assert "3928002" in doc_string
+@pytest.mark.asyncio
+class TestRefiningService:
+    async def test_retain_action_v1_1(
+        self, eicr_root_v1_1: etree._Element, original_eicr_root_v1_1: etree._Element
+    ):
+        """
+        Tests the 'retain' action, which should not modify the section.
+        """
+
+        empty_config = await _make_empty_processed_config()
+
+        plan = EICRRefinementPlan(
+            codes_to_check=set(),
+            code_system_sets=empty_config.code_system_sets,
+            section_instructions={
+                "29762-2": DbConfigurationSectionInstructions(
+                    action="retain", include=True, narrative=True
+                )
+            },
+            section_provenance={},
+            specification=load_spec("1.1"),
+            augmentation_timestamp=_PLACEHOLDER_AUGMENTATION_TIMESTAMP,
+        )
+
+        refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
+
+        section_refined = eicr_root_v1_1.xpath(
+            './/hl7:section[hl7:code[@code="29762-2"]]', namespaces=HL7_NS
+        )[0]
+
+        section_original = original_eicr_root_v1_1.xpath(
+            './/hl7:section[hl7:code[@code="29762-2"]]', namespaces=HL7_NS
+        )[0]
+
+        assert etree.tostring(section_refined) == etree.tostring(section_original)
+
+    async def test_refine_action_with_no_matches_v1_1(
+        self, eicr_root_v1_1: etree._Element
+    ):
+        """
+        Tests 'refine' with a non-matching code, which should create a minimal section.
+        """
+
+        empty_config = await _make_empty_processed_config()
+
+        plan = EICRRefinementPlan(
+            codes_to_check={"NON_EXISTENT_CODE"},
+            code_system_sets=empty_config.code_system_sets,
+            section_instructions={
+                "11450-4": DbConfigurationSectionInstructions(
+                    action="refine", include=True, narrative=False
+                )
+            },
+            section_provenance={},
+            specification=load_spec("1.1"),
+            augmentation_timestamp=_PLACEHOLDER_AUGMENTATION_TIMESTAMP,
+        )
+
+        refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
+
+        problems_section = eicr_root_v1_1.xpath(
+            './/hl7:section[hl7:code[@code="11450-4"]]', namespaces=HL7_NS
+        )[0]
+        assert problems_section.get("nullFlavor") == "NI"
+
+    async def test_refine_action_with_matches_v1_1(
+        self, eicr_root_v1_1: etree._Element
+    ):
+        """
+        Tests the 'refine' action for v1.1, ensuring it correctly uses the
+        terminology pipeline to build codes and filter a section.
+        """
+
+        processed_config = await _make_processed_config_v1_1(
+            loinc_codes=[DbConditionCoding(code="94533-7", display="")]
+        )
+
+        plan = EICRRefinementPlan(
+            codes_to_check=processed_config.codes,
+            code_system_sets=processed_config.code_system_sets,
+            section_instructions={
+                "30954-2": DbConfigurationSectionInstructions(
+                    action="refine", include=True, narrative=False
+                )
+            },
+            section_provenance={},
+            specification=load_spec("1.1"),
+            augmentation_timestamp=_PLACEHOLDER_AUGMENTATION_TIMESTAMP,
+        )
+
+        refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
+
+        results_section = eicr_root_v1_1.xpath(
+            './/hl7:section[hl7:code[@code="30954-2"]]', namespaces=HL7_NS
+        )[0]
+        section_text = etree.tostring(results_section, encoding="unicode")
+        assert "94533-7" in section_text
+
+    # NOTE:
+    # EICR REFINEMENT TESTS — section-aware path
+    # =============================================================================
+    # * these tests exercise the full refine_eicr pipeline with real
+    # ProcessedConfiguration objects so that the section-aware match rules,
+    # component-level pruning, and displayName enrichment all fire
+    # * they assert on the shape of the refined XML output rather than testing
+    # internal functions, making them resilient to internal refactoring
+
+    async def test_section_aware_results_filtering_v1_1(
+        self, eicr_root_v1_1: etree._Element
+    ):
+        """
+        Tests that the section-aware path correctly filters the Results section:
+        keeps entries with LOINC codes in the condition grouper and removes entries
+        with LOINC codes not in the condition grouper.
+        """
+
+        processed_config = await _make_processed_config_v1_1(
+            loinc_codes=[
+                DbConditionCoding(code="94533-7", display="SARS-CoV-2 N gene"),
+                DbConditionCoding(code="94558-4", display="SARS-CoV-2 Ag Rapid"),
+            ],
+        )
+        plan = _make_plan(processed_config, {"30954-2": "refine"})
+
+        refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
+
+        results_section = eicr_root_v1_1.xpath(
+            './/hl7:section[hl7:code[@code="30954-2"]]', namespaces=HL7_NS
+        )[0]
+
+        # matching COVID tests should survive
+        organizer_codes = results_section.xpath(
+            ".//hl7:organizer/hl7:code/@code", namespaces=HL7_NS
+        )
+        assert "94533-7" in organizer_codes
+        assert "94558-4" in organizer_codes
+
+        # non-matching entries should be removed
+        section_text = etree.tostring(results_section, encoding="unicode")
+        assert "34487-9" not in section_text  # influenza
+        assert "51990-0" not in section_text  # BMP
+        assert "48065-7" not in section_text  # D-dimer
+        assert "30746-2" not in section_text  # chest X-ray
+
+    async def test_section_aware_problems_component_pruning_v1_1(
+        self,
+        eicr_root_v1_1: etree._Element,
+    ):
+        """
+        Tests that the Problems section prunes individual problem observations
+        within a Problem Concern Act while keeping the act wrapper intact.
+        """
+
+        processed_config = await _make_processed_config_v1_1(
+            snomed_codes=[
+                DbConditionCoding(
+                    code="840539006", display="Disease caused by SARS-CoV-2"
+                ),
+                DbConditionCoding(code="186747009", display="Coronavirus infection"),
+                DbConditionCoding(code="230145002", display="Difficulty Breathing"),
+            ],
+        )
+        plan = _make_plan(processed_config, {"11450-4": "refine"})
+
+        refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
+
+        problems_section = eicr_root_v1_1.xpath(
+            './/hl7:section[hl7:code[@code="11450-4"]]', namespaces=HL7_NS
+        )[0]
+
+        # section should NOT be NI — we have matches
+        assert problems_section.get("nullFlavor") is None
+
+        # the Problem Concern Act wrapper should still be present
+        concern_acts = problems_section.xpath(
+            ".//hl7:act[hl7:code[@code='CONC']]", namespaces=HL7_NS
+        )
+        assert len(concern_acts) == 1
+
+        # matching problem observations should survive
+        surviving_values = problems_section.xpath(
+            ".//hl7:observation/hl7:value/@code", namespaces=HL7_NS
+        )
+        assert "840539006" in surviving_values
+        assert "186747009" in surviving_values
+        assert "230145002" in surviving_values
+
+        # non-matching observations should be pruned
+        section_text = etree.tostring(problems_section, encoding="unicode")
+        assert "719865001" not in section_text  # influenza
+        assert "59621000" not in section_text  # hypertension
+        assert "44054006" not in section_text  # diabetes
+
+    async def test_display_name_enrichment_v1_1(self, eicr_root_v1_1: etree._Element):
+        """
+        Tests that missing displayName attributes are filled in from the condition
+        grouper, both at match time (observation code) and during the post-prune
+        enrichment pass (organizer code, result value).
+        """
+
+        processed_config = await _make_processed_config_v1_1(
+            loinc_codes=[
+                DbConditionCoding(
+                    code="94759-8",
+                    display="SARS-CoV-2 (COVID-19) RNA [Presence] in Nasopharynx by NAA with probe detection",
+                ),
+            ],
+            snomed_codes=[
+                DbConditionCoding(
+                    code="260373001", display="Detected (qualifier value)"
+                ),
+            ],
+        )
+        plan = _make_plan(processed_config, {"30954-2": "refine"})
+
+        refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
+
+        results_section = eicr_root_v1_1.xpath(
+            './/hl7:section[hl7:code[@code="30954-2"]]', namespaces=HL7_NS
+        )[0]
+
+        # observation code should be enriched (match-time)
+        obs_codes = results_section.xpath(
+            ".//hl7:observation/hl7:code[@code='94759-8']", namespaces=HL7_NS
+        )
+        assert len(obs_codes) > 0
+        assert obs_codes[0].get("displayName") is not None
+        assert "Nasopharynx" in obs_codes[0].get("displayName", "")
+
+        # organizer code should be enriched (post-prune _enrich_surviving_entries)
+        organizer_codes = results_section.xpath(
+            ".//hl7:organizer/hl7:code[@code='94759-8']", namespaces=HL7_NS
+        )
+        assert len(organizer_codes) > 0
+        assert organizer_codes[0].get("displayName") is not None
+        assert "Nasopharynx" in organizer_codes[0].get("displayName", "")
+
+        # result value should be enriched (post-prune _enrich_surviving_entries)
+        detected_values = results_section.xpath(
+            ".//hl7:value[@code='260373001']", namespaces=HL7_NS
+        )
+        assert len(detected_values) > 0
+        assert detected_values[0].get("displayName") is not None
+        assert "Detected" in detected_values[0].get("displayName", "")
+
+    async def test_plan_of_treatment_heterogeneous_entries_v1_1(
+        self,
+        eicr_root_v1_1: etree._Element,
+    ):
+        """
+        Tests that Plan of Treatment correctly handles heterogeneous entry types:
+        keeps matching lab orders (LOINC) and medications (RxNorm), removes
+        non-matching entries.
+        """
+
+        processed_config = await _make_processed_config_v1_1(
+            loinc_codes=[
+                DbConditionCoding(code="94500-6", display="SARS-CoV-2 RNA panel"),
+            ],
+            rxnorm_codes=[
+                DbConditionCoding(
+                    code="2284960", display="remdesivir 100 MG Injection"
+                ),
+            ],
+        )
+        plan = _make_plan(processed_config, {"18776-5": "refine"})
+
+        refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
+
+        pot_section = eicr_root_v1_1.xpath(
+            './/hl7:section[hl7:code[@code="18776-5"]]', namespaces=HL7_NS
+        )[0]
+        section_text = etree.tostring(pot_section, encoding="unicode")
+
+        # matching lab order and medication should survive
+        assert "94500-6" in section_text
+        assert "2284960" in section_text
+
+        # non-matching entries should be removed
+        assert "25836-8" not in section_text  # influenza lab order
+        assert "261315" not in section_text  # oseltamivir
+        assert "314076" not in section_text  # lisinopril
+        assert "861007" not in section_text  # metformin
+        assert "270427003" not in section_text  # follow-up encounter
+
+    async def test_encounters_diagnosis_pruning_v1_1(
+        self, eicr_root_v1_1: etree._Element
+    ):
+        """
+        Tests that the Encounters section prunes non-matching diagnoses at the
+        component level while keeping the encounter wrapper and matching diagnoses.
+        """
+
+        processed_config = await _make_processed_config_v1_1(
+            snomed_codes=[
+                DbConditionCoding(
+                    code="840539006", display="Disease caused by SARS-CoV-2"
+                ),
+            ],
+        )
+        plan = _make_plan(processed_config, {"46240-8": "refine"})
+
+        refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
+
+        enc_section = eicr_root_v1_1.xpath(
+            './/hl7:section[hl7:code[@code="46240-8"]]', namespaces=HL7_NS
+        )[0]
+
+        # only encounters with matching diagnoses should survive
+        entries = enc_section.xpath(".//hl7:entry", namespaces=HL7_NS)
+        assert len(entries) == 1
+
+        # covid diagnosis should be kept
+        surviving_values = enc_section.xpath(
+            ".//hl7:observation/hl7:value/@code", namespaces=HL7_NS
+        )
+        assert "840539006" in surviving_values
+
+        # influenza diagnosis should be pruned from within the encounter
+        section_text = etree.tostring(enc_section, encoding="unicode")
+        assert "772828001" not in section_text
+
+    async def test_non_matching_section_becomes_ni_v1_1(
+        self, eicr_root_v1_1: etree._Element
+    ):
+        """
+        Tests that a section with entries but no matching codes becomes nullFlavor NI
+        with all entries removed.
+        """
+
+        processed_config = await _make_processed_config_v1_1(
+            snomed_codes=[
+                DbConditionCoding(
+                    code="840539006", display="Disease caused by SARS-CoV-2"
+                ),
+            ],
+        )
+        plan = _make_plan(processed_config, {"11369-6": "refine"})
+
+        refine_eicr(eicr_root=eicr_root_v1_1, plan=plan)
+
+        imm_section = eicr_root_v1_1.xpath(
+            './/hl7:section[hl7:code[@code="11369-6"]]', namespaces=HL7_NS
+        )[0]
+
+        # no matching CVX codes for covid → section should be NI
+        assert imm_section.get("nullFlavor") == "NI"
+
+        # entries should be removed
+        entries = imm_section.xpath(".//hl7:entry", namespaces=HL7_NS)
+        assert len(entries) == 0
+
+    # NOTE:
+    # RR REFINEMENT TESTS
+    # =============================================================================
+
+    async def test_refine_rr_by_condition_v1_1(self, rr_root_v1_1: etree._Element):
+        """
+        Tests RR refinement for v1.1: keeps ONLY the observations for conditions
+        specified in the configuration.
+        """
+
+        covid_condition = _make_condition_v1_1(child_rsg_snomed_codes=["840539006"])
+        config = _make_db_configuration_v1_1()
+
+        processed_configuration = await create_processed_config(
+            config=config, conditions=[covid_condition]
+        )
+
+        rr_refinement_plan = create_rr_refinement_plan(
+            processed_configuration=processed_configuration
+        )
+
+        refine_rr(rr_root=rr_root_v1_1, plan=rr_refinement_plan)
+
+        doc_string = etree.tostring(rr_root_v1_1, encoding="unicode")
+
+        assert "840539006" in doc_string
+        assert "49727002" not in doc_string
+
+    async def test_refine_rr_by_jurisdiction_v1_1(self, rr_root_v1_1: etree._Element):
+        """
+        Tests RR refinement for v1.1: doesn't touch observations not for the given jurisdiction.
+        """
+
+        covid_condition = _make_condition_v1_1(child_rsg_snomed_codes=["840539006"])
+        config = _make_db_configuration_v1_1(jurisdiction_id="SOME-OTHER-JD")
+
+        processed_configuration = await create_processed_config(
+            config=config, conditions=[covid_condition]
+        )
+        rr_refinement_plan = create_rr_refinement_plan(
+            processed_configuration=processed_configuration
+        )
+
+        refine_rr(rr_root=rr_root_v1_1, plan=rr_refinement_plan)
+
+        doc_string = etree.tostring(rr_root_v1_1, encoding="unicode")
+
+        assert "840539006" in doc_string
+
+    async def test_refine_rr_by_condition_v3_1_1(self, rr_root_v3_1_1: etree._Element):
+        """
+        Tests RR refinement on the Zika file: confirms the Zika observation is kept
+        even if config is for another jurisdiction.
+        """
+
+        zika_condition = _make_condition_v3_1_1(child_rsg_snomed_codes=["3928002"])
+        config = _make_db_configuration_v3_1_1()
+
+        processed_configuration = await create_processed_config(
+            config=config, conditions=[zika_condition]
+        )
+        rr_refinement_plan = create_rr_refinement_plan(
+            processed_configuration=processed_configuration
+        )
+
+        refine_rr(rr_root=rr_root_v3_1_1, plan=rr_refinement_plan)
+
+        doc_string = etree.tostring(rr_root_v3_1_1, encoding="unicode")
+
+        assert "3928002" in doc_string
+
+    async def test_refine_rr_by_jurisdiction_v3_1_1(
+        self, rr_root_v3_1_1: etree._Element
+    ):
+        """
+        Tests RR refinement on the Zika file: confirms the Zika observation is still
+        present even when jurisdiction is different.
+        """
+
+        zika_condition = _make_condition_v3_1_1(child_rsg_snomed_codes=["3928002"])
+        config = _make_db_configuration_v3_1_1(jurisdiction_id="SOME-OTHER-JD")
+
+        processed_configuration = await create_processed_config(
+            config=config, conditions=[zika_condition]
+        )
+        rr_refinement_plan = create_rr_refinement_plan(
+            processed_configuration=processed_configuration
+        )
+
+        refine_rr(rr_root=rr_root_v3_1_1, plan=rr_refinement_plan)
+
+        doc_string = etree.tostring(rr_root_v3_1_1, encoding="unicode")
+
+        assert "3928002" in doc_string

--- a/refiner/tests/unit/test_service_refine.py
+++ b/refiner/tests/unit/test_service_refine.py
@@ -1,5 +1,3 @@
-import unittest
-
 import pytest
 from lxml import etree
 
@@ -8,11 +6,11 @@ from app.db.configurations.model import (
     DbConfiguration,
     DbConfigurationSectionInstructions,
 )
-from app.services.configurations import convert_config_to_storage_payload
 from app.services.ecr.model import HL7_NS, EICRRefinementPlan
 from app.services.ecr.refine import create_rr_refinement_plan, refine_eicr, refine_rr
 from app.services.ecr.specification import load_spec
 from app.services.terminology import ProcessedConfiguration
+from tests.unit.helpers.configuration import create_processed_config
 
 # NOTE:
 # TEST CONSTANTS
@@ -147,24 +145,6 @@ async def _make_empty_processed_config() -> ProcessedConfiguration:
     condition = _make_condition_v1_1()
     config = _make_db_configuration_v1_1()
     return await create_processed_config(config=config, conditions=[condition])
-
-
-async def create_processed_config(
-    config: DbConfiguration, conditions: list[DbCondition]
-):
-    with unittest.mock.patch(
-        "app.services.configurations.get_included_conditions_db",
-        return_value=conditions,
-    ):
-        storage_payload = await convert_config_to_storage_payload(
-            configuration=config,
-            db=unittest.mock.AsyncMock(),
-        )
-
-    if storage_payload is None:
-        raise ValueError("convert_config_to_storage_payload returned None unexpectedly")
-
-    return ProcessedConfiguration.from_dict(storage_payload.to_dict())
 
 
 async def _make_processed_config_v1_1(**condition_kwargs) -> ProcessedConfiguration:

--- a/refiner/tests/unit/test_service_refine.py
+++ b/refiner/tests/unit/test_service_refine.py
@@ -26,6 +26,9 @@ from tests.unit.helpers.configuration import create_processed_config
 
 _PLACEHOLDER_AUGMENTATION_TIMESTAMP = "19700101000000+0000"
 
+# ProcessedConfiguration must contain at least one code or otherwise is considered
+# to be invalid. We are using a code that definitely will not appear in a real code set.
+_MOCK_CONDITION_CODES = [DbConditionCoding(code="fake-code-0!", display="")]
 
 # NOTE:
 # LOCAL TEST HELPER FUNCTIONS - v1.1
@@ -142,7 +145,7 @@ async def _make_empty_processed_config() -> ProcessedConfiguration:
     care about matching (e.g., retain, no-match tests).
     """
 
-    condition = _make_condition_v1_1()
+    condition = _make_condition_v1_1(cvx_codes=_MOCK_CONDITION_CODES)
     config = _make_db_configuration_v1_1()
     return await create_processed_config(config=config, conditions=[condition])
 
@@ -561,7 +564,9 @@ class TestRefiningService:
         specified in the configuration.
         """
 
-        covid_condition = _make_condition_v1_1(child_rsg_snomed_codes=["840539006"])
+        covid_condition = _make_condition_v1_1(
+            child_rsg_snomed_codes=["840539006"], rxnorm_codes=_MOCK_CONDITION_CODES
+        )
         config = _make_db_configuration_v1_1()
 
         processed_configuration = await create_processed_config(
@@ -584,7 +589,9 @@ class TestRefiningService:
         Tests RR refinement for v1.1: doesn't touch observations not for the given jurisdiction.
         """
 
-        covid_condition = _make_condition_v1_1(child_rsg_snomed_codes=["840539006"])
+        covid_condition = _make_condition_v1_1(
+            child_rsg_snomed_codes=["840539006"], snomed_codes=_MOCK_CONDITION_CODES
+        )
         config = _make_db_configuration_v1_1(jurisdiction_id="SOME-OTHER-JD")
 
         processed_configuration = await create_processed_config(
@@ -606,7 +613,9 @@ class TestRefiningService:
         even if config is for another jurisdiction.
         """
 
-        zika_condition = _make_condition_v3_1_1(child_rsg_snomed_codes=["3928002"])
+        zika_condition = _make_condition_v3_1_1(
+            child_rsg_snomed_codes=["3928002"], loinc_codes=_MOCK_CONDITION_CODES
+        )
         config = _make_db_configuration_v3_1_1()
 
         processed_configuration = await create_processed_config(
@@ -630,7 +639,9 @@ class TestRefiningService:
         present even when jurisdiction is different.
         """
 
-        zika_condition = _make_condition_v3_1_1(child_rsg_snomed_codes=["3928002"])
+        zika_condition = _make_condition_v3_1_1(
+            child_rsg_snomed_codes=["3928002"], icd10_codes=_MOCK_CONDITION_CODES
+        )
         config = _make_db_configuration_v3_1_1(jurisdiction_id="SOME-OTHER-JD")
 
         processed_configuration = await create_processed_config(

--- a/refiner/tests/unit/test_service_terminology.py
+++ b/refiner/tests/unit/test_service_terminology.py
@@ -1,5 +1,7 @@
 from uuid import uuid4
 
+import pytest
+
 from app.db.conditions.model import DbCondition, DbConditionCoding
 from app.db.configurations.model import (
     DbConfiguration,
@@ -7,9 +9,8 @@ from app.db.configurations.model import (
 )
 from app.services.terminology import (
     CodeSystem,
-    ConfigurationPayload,
-    ProcessedConfiguration,
 )
+from tests.unit.helpers.configuration import create_processed_config
 
 
 def make_db_condition_coding(code, display):
@@ -54,44 +55,37 @@ def make_dbconfiguration(**kwargs) -> DbConfiguration:
     return DbConfiguration(**defaults)
 
 
-def test_processed_configuration_from_payload_and_xpath():
-    cond1: DbCondition = make_condition(
-        snomed_codes=[make_db_condition_coding("A", "SNOMED")]
-    )
-    config: DbConfiguration = make_dbconfiguration(
-        custom_codes=[
-            DbConfigurationCustomCode(
-                code="B", system=CodeSystem.LOINC, name="Custom LOINC"
-            )
-        ]
-    )
-    payload = ConfigurationPayload(conditions=[cond1], configuration=config)
-    processed = ProcessedConfiguration.from_payload(payload)
-    assert processed.codes == {"A", "B"}
+@pytest.mark.asyncio
+class TestTerminologyService:
+    async def test_processed_configuration_from_payload_and_xpath(self):
+        cond1: DbCondition = make_condition(
+            snomed_codes=[make_db_condition_coding("A", "SNOMED")]
+        )
+        config: DbConfiguration = make_dbconfiguration(
+            custom_codes=[
+                DbConfigurationCustomCode(
+                    code="B", system=CodeSystem.LOINC, name="Custom LOINC"
+                )
+            ]
+        )
+        processed = await create_processed_config(config=config, conditions=[cond1])
+        assert processed.codes == {"A", "B"}
 
-
-def test_processed_configuration_empty_codes():
-    cond: DbCondition = make_condition()
-    config: DbConfiguration = make_dbconfiguration()
-    payload = ConfigurationPayload(conditions=[cond], configuration=config)
-    processed = ProcessedConfiguration.from_payload(payload)
-    assert processed.codes == set()
-
-
-def test_processed_configuration_duplicate_codes():
-    cond1: DbCondition = make_condition(
-        snomed_codes=[make_db_condition_coding("DUP", "SNOMED")]
-    )
-    cond2: DbCondition = make_condition(
-        loinc_codes=[make_db_condition_coding("DUP", "LOINC")]
-    )
-    config: DbConfiguration = make_dbconfiguration(
-        custom_codes=[
-            DbConfigurationCustomCode(
-                code="DUP", system=CodeSystem.LOINC, name="Custom"
-            )
-        ]
-    )
-    payload = ConfigurationPayload(conditions=[cond1, cond2], configuration=config)
-    processed = ProcessedConfiguration.from_payload(payload)
-    assert processed.codes == {"DUP"}
+    async def test_processed_configuration_duplicate_codes(self):
+        cond1: DbCondition = make_condition(
+            snomed_codes=[make_db_condition_coding("DUP", "SNOMED")]
+        )
+        cond2: DbCondition = make_condition(
+            loinc_codes=[make_db_condition_coding("DUP", "LOINC")]
+        )
+        config: DbConfiguration = make_dbconfiguration(
+            custom_codes=[
+                DbConfigurationCustomCode(
+                    code="DUP", system=CodeSystem.LOINC, name="Custom"
+                )
+            ]
+        )
+        processed = await create_processed_config(
+            config=config, conditions=[cond1, cond2]
+        )
+        assert processed.codes == {"DUP"}

--- a/refiner/tests/unit/test_service_terminology.py
+++ b/refiner/tests/unit/test_service_terminology.py
@@ -95,9 +95,3 @@ def test_processed_configuration_duplicate_codes():
     payload = ConfigurationPayload(conditions=[cond1, cond2], configuration=config)
     processed = ProcessedConfiguration.from_payload(payload)
     assert processed.codes == {"DUP"}
-
-
-def test_payload_class_existence():
-    # sanity checks for class existence
-    assert ConfigurationPayload
-    assert ProcessedConfiguration


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR removes the option to create a `ProcessedConfiguration` using the `from_payload()` method. 

Last week we noticed the refined results of Lambda differed from those of the web app due to a divergence in how `ProcessedConfiguration` objects were being created in each. We merged two PRs to address this:
- #1136 (bug fix for creation)
- #1137 (ensure web app and Lambda create `ProcessedConfiguration` the same way)

This PR goes a step further so that there is now only a single way to create a `ProcessedConfiguration`, which is by using the `from_dict()` method. 

## 🧪 How to test

- App and tests should work as expected

We stopped using `from_payload()` in #1137. This PR only deletes the option so there should be no changes to the app itself.

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
