### PR TITLE
fix: align git and docker tags in promotion job

### DIFF
--- a/.github/workflows/promote-release-candidate.yml
+++ b/.github/workflows/promote-release-candidate.yml
@@ -97,7 +97,7 @@ jobs:
           # Set all the variables we need
           echo "rc_version=$RC_VERSION" >> $GITHUB_OUTPUT
           echo "stable_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "git_tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "git_tag=$VERSION" >> $GITHUB_OUTPUT
 
           echo "ghcr_base=$GHCR_BASE" >> $GITHUB_OUTPUT
           echo "ecr_base=$ECR_BASE" >> $GITHUB_OUTPUT

--- a/.github/workflows/promote-release-candidate.yml
+++ b/.github/workflows/promote-release-candidate.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Check if stable tag already exists
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "Error: Tag v$VERSION already exists"
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Error: Tag $VERSION already exists"
             exit 1
           fi
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary
There was some confusion between the different output formats of the Git and Docker tags for the promotion job, so this PR aligns them.

## ✅ Acceptance Criteria
<img width="1310" height="746" alt="Screenshot 2026-05-05 at 10 07 32 AM" src="https://github.com/user-attachments/assets/ab2cb9ab-ec17-4e00-940c-028b6062de34" />

- Check [the output of the promotion job](https://github.com/CDCgov/dibbs-ecr-refiner/actions/runs/25381180183/job/74429636771) and verify the tag values are the same

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
