### PR TITLE
fix: possible duplicate key when rendering a code set's code table

### DIFF
--- a/client/src/pages/Configurations/ConfigBuild/CustomCodes/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CustomCodes/index.tsx
@@ -293,7 +293,7 @@ export function ConditionCodeTable({
               </tr>
             </thead>
             <tbody>
-              {visibleCodes.map((code) => {
+              {visibleCodes.map((code, i) => {
                 const matchingResult = results.find(
                   (r) =>
                     r.item.code === code.code &&
@@ -302,7 +302,7 @@ export function ConditionCodeTable({
 
                 return (
                   <ConditionCodeRow
-                    key={`${code.system}-${code.code}`}
+                    key={`${code.system}-${code.code}-${i}`} // TODO: swap this to an ID when possible
                     codeSystem={code.system}
                     code={code.code}
                     text={code.description}


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR fixes a React key error due to two codes in the same list sharing a system and code. We noticed this was happening with `HIV Infection or AIDS` TES version 5.0.0.

This is the code we were seeing appear twice:

`422337001 - SNOMED`

<img width="1504" height="278" alt="image" src="https://github.com/user-attachments/assets/3aad691e-4590-4402-a2af-23508d0c228c" />

## 🧪 How to test

Try loading up the `HIV Infection or AIDS` TES version 5.0.0 code set and you should not see any errors in the console.

Prior to this fix you'll see something like this:
<img width="1551" height="691" alt="image" src="https://github.com/user-attachments/assets/74f51632-cd0e-48a0-a2fc-76e1d57be982" />