### PR TITLE
chore: server test improvements

### DIFF
--- a/.justscripts/just/server.just
+++ b/.justscripts/just/server.just
@@ -19,7 +19,7 @@ _venv:
 [doc('Run pytest suite')]
 [group('test')]
 test: _venv
-    .venv/bin/pytest tests
+    {{ if env("CI", "") != "" { ".venv/bin/pytest tests" } else { ".venv/bin/pytest -vvv tests" } }}
 
 [doc('Run Ruff checker, fix things, and formatter')]
 fix: _venv

--- a/refiner/app/services/file_io.py
+++ b/refiner/app/services/file_io.py
@@ -1,4 +1,5 @@
 import io
+import time
 from dataclasses import dataclass
 from io import BytesIO
 from zipfile import BadZipFile, ZipFile, ZipInfo
@@ -164,6 +165,25 @@ def create_refined_ecr_zip_in_memory(
         - If content is str, it is encoded as UTF-8 before writing.
         - Skips any empty files; robust against partial failures (e.g., missing HTML).
     """
+    # Compute entry mtimes ourselves from current UTC time. We deliberately
+    # bypass CPython's default ZipInfo construction path
+    # (ZipInfo._for_archive), because it honors `SOURCE_DATE_EPOCH` via
+    # time.localtime() – which produces invalid pre-1980 DOS dates in any
+    # timezone west of UTC. That path crashes with: `struct.error: 'H' format
+    # requires 0 <= number <= 65535`.
+    #
+    # Using gmtime() makes the timestamp timezone-agnostic and ensures DOS-date
+    # math (year - 1980) is always non-negative for any sane "now".
+    now_utc = time.gmtime()
+    entry_date_time = (
+        now_utc.tm_year,
+        now_utc.tm_mon,
+        now_utc.tm_mday,
+        now_utc.tm_hour,
+        now_utc.tm_min,
+        now_utc.tm_sec,
+    )
+
     zip_buffer = io.BytesIO()
 
     with ZipFile(zip_buffer, "w") as zf:
@@ -174,7 +194,9 @@ def create_refined_ecr_zip_in_memory(
             if not content:
                 continue
             data = content if isinstance(content, bytes) else content.encode("utf-8")
-            zf.writestr(filename, data)
+            zinfo = ZipInfo(filename=filename, date_time=entry_date_time)
+            zinfo.compress_type = zf.compression
+            zf.writestr(zinfo, data)
 
     zip_buffer.seek(0)
     return zip_package.get_name(), zip_buffer

--- a/refiner/tests/unit/test_demo.py
+++ b/refiner/tests/unit/test_demo.py
@@ -1,4 +1,5 @@
 import io
+import time
 import zipfile
 from pathlib import Path
 
@@ -140,9 +141,13 @@ def create_mock_upload_file(
 
 def create_zip_file(file_dict: dict[str, bytes]) -> bytes:
     buf = io.BytesIO()
+    now = time.gmtime()
+    dt = (now.tm_year, now.tm_mon, now.tm_mday, now.tm_hour, now.tm_min, now.tm_sec)
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
         for name, content in file_dict.items():
-            z.writestr(name, content)
+            zinfo = zipfile.ZipInfo(filename=name, date_time=dt)
+            zinfo.compress_type = z.compression
+            z.writestr(zinfo, content)
     return buf.getvalue()
 
 

--- a/refiner/tests/unit/test_service_file_io.py
+++ b/refiner/tests/unit/test_service_file_io.py
@@ -1,6 +1,7 @@
+import time
 import zipfile
 from pathlib import Path
-from zipfile import ZipFile
+from zipfile import ZipFile, ZipInfo
 
 import pytest
 from lxml import etree
@@ -107,8 +108,12 @@ async def test_uncompressed_zip_size_too_large(create_test_zip, fixtures_path: P
     )
 
     # Add the large file to the existing zip
+    now = time.gmtime()
+    dt = (now.tm_year, now.tm_mon, now.tm_mday, now.tm_hour, now.tm_min, now.tm_sec)
     with ZipFile(zip_path, "a") as zf:
-        zf.writestr("large.xml", big_content)
+        zinfo = ZipInfo(filename="large.xml", date_time=dt)
+        zinfo.compress_type = zf.compression
+        zf.writestr(zinfo, big_content)
 
     with open(zip_path, "rb") as f:
         zip_bytes = f.read()


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

1. 💬 feat: Conditional verbosity for server tests 🏷️ 1af4a96
1. 💬 fix(test): Compute mtime locally & bypass ZipInfo; 🏷️ 22c92f0
   - 📝 This was something that was only affecting my local environment due to
     having the `SOURCE_DATE_EPOCH` variable set in my environment. I decided
     fixing the source rather than my environment as this variable may be set
     in a way that can cause our `file_io` service to fail in the future. So
     this fix bypasses ZipInfo's `_for_archive` method and constructs the
     `date_time` from `UTC` now.

## 🔗 Related Issue

- ZipFile related tests were failing locally under specific environment conditions.

## ✅ Acceptance Criteria

- [ ] Tests pass locally for all environments and members of the team.

## 🧪 How to test

Running `just server test` locally on this branch should have all tests passing
and also produce `-vvv` verbose output when running without the `CI` environment
variable set.

To reproduce the error that I was seeing locally, run the following command on
any other branch that doesn't include these changes (e.g. `main`).

```sh
# from within the `refiner/` directory
SOURCE_DATE_EPOCH=315532800 TZ=America/Los_Angeles .venv/bin/pytest tests
```

Without the changes in this patch, you will see the 8 failures with the error
message: `struct.error: 'H' format requires 0 <= number <= 66535`.

You can verify that this patch fixes things by running command from above on
this branch and seeing no errors reported with all 200 tests passing.

## ℹ️ Additional Information

As far as I know, this was only affecting my system due to having
`SOURCE_DATE_EPOCH` set in my environment. On further research, rather than
eliminating this variable from my system I found that fixing things in the
source code was a better approach as it would protect the application code from
this sort of error in the future in case the `SOURCE_DATE_EPOCH` variable is
ever set in our production containers or environment.

> [!NOTE]
> `SOURCE_DATE_EPOCH` is a [cross-tool convention][ctc-link] for reproducible
> builds: when set, build tools should embed this Unix timestamp into outputs
> (timestamps in archives, generated files, etc.) instead of "now". This makes a
> tarball / zip / binary byte-identical regardless of when it was built.
>
> [ctc-link]: https://reproducible-builds.org/docs/source-date-epoch/

> [!IMPORTANT]
> Nix and home-manager export `SOURCE_DATE_EPOCH=315532800` into developer
> shells by default. That value (`315532800`) is `1980-01-01T00:00:00 UTC`,
> deliberately chosen as the **lowest value that ZIP and tar can represent**.
> The DOS file format that ZIP inherits cannot encode dates before 1980.
