### PR TITLE
chore: revert "chore(deps): bump node from 24-alpine3.23 to 26-alpine3.23"

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,7 +5,7 @@
 
 services:
   client:
-    image: node:26-alpine3.23
+    image: node:24-alpine3.23
     working_dir: /app
     volumes:
       - ./client:/app


### PR DESCRIPTION
Reverts CDCgov/dibbs-ecr-refiner#1205

We want to stick with the LTS version of Node for the time being.