### PR TITLE
chore: add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,28 @@ updates:
     directory: "/client"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
 
   - package-ecosystem: "pip"
-    directory: "/refiner"
+    directories:
+      - "/refiner"
+      - "/refiner/app/lambda"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
 
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the dependabot config to add a [cooldown period](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-). Dependabot won't attempt to open a dependency update PR unless the version it's trying to update is > 5 days old.

The main goal of this is to limit the possibility of merging vulnerable or unstable dependency versions. 