### PR TITLE
fix: error should display MB instead of bytes

### DIFF
--- a/refiner/app/api/validation/file_validation.py
+++ b/refiner/app/api/validation/file_validation.py
@@ -186,7 +186,7 @@ async def _validate_ecr_zip_pair(file: UploadFile) -> UploadFile:
     if file.size > UNCOMPRESSED_MAX_BYTES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Uncompressed file must be less than {UNCOMPRESSED_MAX_BYTES}MB in size.",
+            detail=f"Uncompressed file must be less than {UNCOMPRESSED_MAX_MB}MB in size.",
         )
 
     return file

--- a/refiner/tests/unit/test_demo.py
+++ b/refiner/tests/unit/test_demo.py
@@ -103,7 +103,7 @@ async def test_file_too_large():
     file = create_mock_upload_file("big.zip", content)
     with pytest.raises(HTTPException) as exc:
         await _validate_ecr_zip_pair(file)
-    assert f"must be less than {UNCOMPRESSED_MAX_BYTES}" in exc.value.detail
+    assert "must be less than 15MB" in exc.value.detail
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

I noticed that this error message was displaying incorrectly while doing some manual testing.

Before:
<img width="613" height="356" alt="image" src="https://github.com/user-attachments/assets/3800dcc5-18e9-47c3-a352-b6d50f9dcafa" />

After:
<img width="590" height="348" alt="image" src="https://github.com/user-attachments/assets/e196a3cd-be55-4f4a-bdc0-308d966ad6bb" />

## 🧪 How to test

- Try uploading a file in the independent test flow that is larger than the max uncompressed size