### PR TITLE
chore: add just helper to quickly change user jurisdiction

### DIFF
--- a/.justscripts/just/database.just
+++ b/.justscripts/just/database.just
@@ -104,3 +104,14 @@ check-code CONDITION VERSION SYSTEM CODE:
 [group('db')]
 delete-configuration CONFIGURATION_NAME:
     just db query "DELETE FROM configurations WHERE name = '{{ CONFIGURATION_NAME }}';"
+
+[doc('Set the jurisdiction for the "refiner" user. Creates the jurisdiction record if it does not exist')]
+[group('db')]
+set-jd JURISDICTION_ID:
+    just db query "\
+        INSERT INTO jurisdictions (id, name, state_code) \
+        VALUES ('{{ JURISDICTION_ID }}', '{{ JURISDICTION_ID }}', '{{ JURISDICTION_ID }}') \
+        ON CONFLICT (id) DO NOTHING; \
+        UPDATE users \
+        SET jurisdiction_id = '{{ JURISDICTION_ID }}' \
+        WHERE username = 'refiner';"


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds a new just `db` command to quickly switch the `refiner` user's jurisdiction when working locally. I find myself doing this manually while testing and figured a quick way to do this would be generally useful.

Running the command will:

1. Create the jurisdiction row if it doesn't exist already
2. `refiner`'s `jurisdiction_id` will be updated to use the desired jurisdiction ID

> [!NOTE]
> I opted to use `JURISDICTION_ID` for all inputs since the other values don't matter. This makes the command shorter and simpler as well.

## 🧪 How to test

Try running the command:

```sh
just db set-jd TEST
```

This will create a `TEST` jurisdiction and `refiner` will use this as it's jurisdiction ID.
