### PR TITLE
fix: independent testing not matching on some configurations

### DIFF
--- a/refiner/app/services/testing.py
+++ b/refiner/app/services/testing.py
@@ -142,11 +142,11 @@ async def discover_configurations_for_conditions(
         jurisdiction_id=jurisdiction_id, db=db
     )
 
-    conditions_grouped_by_url = _group_conditions_by_url(rc_to_conditions_map)
-
     configured_primary_condition_ids = {
         config.condition_id for config in all_jurisdiction_configs
     }
+
+    conditions_grouped_by_url = _group_conditions_by_url(rc_to_conditions_map)
 
     condition_sets: list[DiscoveredConfigurationSet] = []
     for all_versions in conditions_grouped_by_url.values():

--- a/refiner/app/services/testing.py
+++ b/refiner/app/services/testing.py
@@ -152,7 +152,7 @@ async def discover_configurations_for_conditions(
     for all_versions in conditions_grouped_by_url.values():
         all_condition_ids = {c.id for c in all_versions}
 
-        representative_condition = next(
+        primary_condition = next(
             (c for c in all_versions if c.id in configured_primary_condition_ids),
             None,
         ) or max(all_versions, key=lambda c: parse(c.version))
@@ -169,8 +169,8 @@ async def discover_configurations_for_conditions(
 
         condition_sets.append(
             DiscoveredConfigurationSet(
-                name=representative_condition.display_name,
-                condition_id=representative_condition.id,
+                name=primary_condition.display_name,
+                condition_id=primary_condition.id,
                 versions=[
                     DiscoveredConfigurationVersion(
                         id=c.id, version=c.version, status=c.status

--- a/refiner/app/services/testing.py
+++ b/refiner/app/services/testing.py
@@ -144,12 +144,13 @@ async def discover_configurations_for_conditions(
 
     conditions_grouped_by_url = _group_conditions_by_url(rc_to_conditions_map)
 
+    configured_primary_condition_ids = {
+        config.condition_id for config in all_jurisdiction_configs
+    }
+
     condition_sets: list[DiscoveredConfigurationSet] = []
     for all_versions in conditions_grouped_by_url.values():
         all_condition_ids = {c.id for c in all_versions}
-        configured_primary_condition_ids = {
-            config.condition_id for config in all_jurisdiction_configs
-        }
 
         representative_condition = next(
             (c for c in all_versions if c.id in configured_primary_condition_ids),

--- a/refiner/app/services/testing.py
+++ b/refiner/app/services/testing.py
@@ -142,14 +142,15 @@ async def discover_configurations_for_conditions(
         jurisdiction_id=jurisdiction_id, db=db
     )
 
-    configured_primary_condition_ids = {
-        config.condition_id for config in all_jurisdiction_configs
-    }
-
     conditions_grouped_by_url = _group_conditions_by_url(rc_to_conditions_map)
 
     condition_sets: list[DiscoveredConfigurationSet] = []
     for all_versions in conditions_grouped_by_url.values():
+        all_condition_ids = {c.id for c in all_versions}
+        configured_primary_condition_ids = {
+            config.condition_id for config in all_jurisdiction_configs
+        }
+
         representative_condition = next(
             (c for c in all_versions if c.id in configured_primary_condition_ids),
             None,
@@ -159,7 +160,7 @@ async def discover_configurations_for_conditions(
             [
                 c
                 for c in all_jurisdiction_configs
-                if c.condition_id == representative_condition.id
+                if c.condition_id in all_condition_ids
             ],
             key=lambda c: c.version,
             reverse=True,

--- a/refiner/tests/integration/test_demo.py
+++ b/refiner/tests/integration/test_demo.py
@@ -204,3 +204,61 @@ async def test_shadow_rr_is_produced(
     with ZipFile(BytesIO(zip_bytes), "r") as zf:
         names = zf.namelist()
         assert set(names) == set(expected_file_names)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_discovers_configs_across_all_tes_versions(
+    get_condition_id,
+    create_config,
+    activate_config,
+    covid_influenza_v1_1_zip_path,
+    authed_client,
+):
+    """
+    Test that the discovery feature will find all configurations for a reportable condition
+    regardless of their TES version. The app should be able to handle multiple versions at the
+    same time.
+
+    NOTE: The `condition_id` of the set will be the latest TES version's condition ID.
+    """
+    current_covid_id = await get_condition_id("COVID-19", "5.0.0")
+    current_flu_id = await get_condition_id("Influenza", "5.0.0")
+
+    old_covid_id = await get_condition_id("COVID-19", "3.0.0")
+    old_flu_id = await get_condition_id("Influenza", "4.0.0")
+
+    # create a bunch of 3.0.0 COVID configs
+    for _ in range(21):
+        config = await create_config(old_covid_id)
+        await activate_config(config["id"])
+
+    # create a 5.0.0 COVID draft
+    await create_config(current_covid_id)
+
+    # create a bunch of 4.0.0 influenza configs
+    for _ in range(27):
+        config = await create_config(old_flu_id)
+        await activate_config(config["id"])
+
+    uploaded_file = covid_influenza_v1_1_zip_path
+    with open(uploaded_file, "rb") as file_data:
+        response = await authed_client.post(
+            f"{api_route_base}/discover-configurations",
+            files={
+                "uploaded_file": (
+                    "mon_mothma_covid_influenza_1.1.zip",
+                    file_data,
+                    "application/zip",
+                )
+            },
+        )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+
+    sets_by_name = {set["name"]: set for set in data["sets"]}
+    assert len(sets_by_name["COVID-19"]["versions"]) == 22
+    assert sets_by_name["COVID-19"]["condition_id"] == str(current_covid_id)
+
+    assert len(sets_by_name["Influenza"]["versions"]) == 27
+    assert sets_by_name["Influenza"]["condition_id"] == str(current_flu_id)

--- a/refiner/tests/localstack/seed.py
+++ b/refiner/tests/localstack/seed.py
@@ -41,10 +41,16 @@ def seed_localstack(s3_client):
     """
     BUCKET = "local-config-bucket"
 
+    response = s3_client.list_objects_v2(Bucket=BUCKET)
+    for obj in response.get("Contents", []):
+        s3_client.delete_object(Bucket=BUCKET, Key=obj["Key"])
+
     try:
-        s3_client.create_bucket(Bucket=BUCKET)
-    except s3_client.exceptions.BucketAlreadyOwnedByYou:
+        s3_client.delete_bucket(Bucket=BUCKET)
+    except s3_client.exceptions.NoSuchBucket:
         pass
+
+    s3_client.create_bucket(Bucket=BUCKET)
 
     COVID_CANONICAL_URL = "https://tes.tools.aimsplatform.org/api/fhir/ValueSet/07221093-b8a1-4b1d-8678-259277bfba64"
     activation_key = get_active_file_key(


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the configuration discovery service in the independent test flow to find configurations for reportable conditions regardless of their primary condition's TES version.

This was happening because the matching was overly strict (see my comment).

Fixes #1239 

## 🧪 How to test

- Take a look at the new automated test

If you'd like to see this manually, the easiest way is this:
1. Go to the `testing.spec.ts` e2e test
2. Comment out line 10 (config deletion)
3. Replace `test` with `test.only` on line 45 (`test.only('Should be able...)`)
4. Run the test, you should have 21 COVID configs in your local environment
5. In `app/db/conditions/db.py` replace line 122 with this: `latest_version = '3.0.0'`
6. Create new COVID draft(s) in the UI. Any new drafts you create will use the TES 3.0.0 COVID-19 condition

At this point you have a mix of TES 3.0.0 and 5.0.0 COVID-19 configurations. You should see all of these configurations appear in the independent test flow dropdown when running the test file.

## ℹ️ Additional Information

- Any other testing to add?
