### PR TITLE
fix: Configuration version menu should scroll when list is large

### DIFF
--- a/client/src/pages/Configurations/ConfigBuild/VersionMenu.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/VersionMenu.tsx
@@ -34,7 +34,7 @@ export function VersionMenu({
             <Icon.ArrowDropDown aria-hidden />
           </div>
         </MenuButton>
-        <MenuItems className="absolute mt-1 ml-4 flex flex-col rounded-lg bg-white px-4 py-2 shadow-lg max-h-100 overflow-y-auto">
+        <MenuItems className="absolute mt-1 ml-4 flex max-h-100 flex-col overflow-y-auto rounded-lg bg-white px-4 py-2 shadow-lg">
           {versions.map((config, i) => (
             <Fragment key={config.id}>
               <MenuItem>

--- a/client/src/pages/Configurations/ConfigBuild/VersionMenu.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/VersionMenu.tsx
@@ -34,7 +34,7 @@ export function VersionMenu({
             <Icon.ArrowDropDown aria-hidden />
           </div>
         </MenuButton>
-        <MenuItems className="absolute mt-1 ml-4 flex flex-col rounded-lg bg-white px-4 py-2 shadow-lg">
+        <MenuItems className="absolute mt-1 ml-4 flex flex-col rounded-lg bg-white px-4 py-2 shadow-lg max-h-100 overflow-y-auto">
           {versions.map((config, i) => (
             <Fragment key={config.id}>
               <MenuItem>


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR fixes an issue with the configuration version list where it can go off screen if the list becomes too large. The list now has a max height and will scroll when the number of menu items exceed that height.

Before:
<img width="1599" height="1180" alt="image" src="https://github.com/user-attachments/assets/5bc9e36f-3df2-4ae1-9114-7b15b8bec461" />

After:
<img width="1028" height="761" alt="Kapture 2026-05-20 at 11 05 45" src="https://github.com/user-attachments/assets/5a1b260c-95b5-4fb8-b32a-bbd2e2eed131" />

## 🧪 How to test

- Tests and app otherwise function as they did previously