### PR TITLE
fix: show pending state in independent test upon clicking "Refine eCR" button

### DIFF
--- a/client/src/pages/Testing/index.tsx
+++ b/client/src/pages/Testing/index.tsx
@@ -74,6 +74,7 @@ export function Testing() {
   ) {
     return async () => {
       try {
+        setStatus('pending');
         await runRefinement(
           selectedFile,
           configIds,


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the independent test flow to show the `pending` state upon the user clicking the "Refine eCR" button in the UI. Refinement can take slightly longer now due to the large amount of codes in TES 6.0.0. This helps show the user that something is happening as soon as they click the button.

## 🧪 How to test

- Go through the independent test flow and click "Refine eCR". You will see the `pending` screen for a brief second before seeing the results