### PR TITLE
chore: update actions to use node 24

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -31,12 +31,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into GitHub Container Registry
         uses: docker/login-action@v3
@@ -128,7 +128,7 @@ jobs:
           fi
 
       - name: Build/push Refiner App RC image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.app
@@ -140,7 +140,7 @@ jobs:
             VERSION=${{ steps.vars.outputs.version_tag }}
 
       - name: Build/push Refiner Lambda RC image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           provenance: false
@@ -152,7 +152,7 @@ jobs:
             VERSION=${{ steps.vars.outputs.version_tag }}
 
       - name: Build/push Refiner Ops RC image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.ops

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Test Refiner app build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.app
@@ -32,13 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Test Refiner Lambda build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.lambda
@@ -50,13 +50,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Test Refiner Ops build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.ops

--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -39,12 +39,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into GitHub Container Registry
         uses: docker/login-action@v3
@@ -123,7 +123,7 @@ jobs:
           echo "OPS_TAGS: ${{ steps.vars.outputs.ops_tags }}"
 
       - name: Build and push Refiner app image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.app
@@ -135,7 +135,7 @@ jobs:
             VERSION=${{ steps.vars.outputs.version_tag }}
 
       - name: Build and push Refiner Lambda image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           provenance: false
@@ -147,7 +147,7 @@ jobs:
             VERSION=${{ steps.vars.outputs.version_tag }}
 
       - name: Build and push Refiner Ops image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.ops

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup python ${{env.PYTHON_RUNNER_VERSION}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{env.PYTHON_RUNNER_VERSION}}
           cache: pip
@@ -34,7 +34,7 @@ jobs:
   run-ts-linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         working-directory: ./client
         run: |

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -37,13 +37,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image locally (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.image.dockerfile }}
@@ -86,7 +86,7 @@ jobs:
           category: "pr-scan-${{ matrix.image.name }}"
 
       - name: Upload JSON results as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: trivy-results-${{ matrix.image.name }}
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download scan results
         uses: actions/download-artifact@v4

--- a/.github/workflows/promote-release-candidate.yml
+++ b/.github/workflows/promote-release-candidate.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log into GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/save-rendered-diagrams.yaml
+++ b/.github/workflows/save-rendered-diagrams.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Cache Docker pull of structurizr/lite:2025.05.28 image
         id: image-cache
-        uses: actions/cache@v7
+        uses: actions/cache@v5
         with:
           path: ~/image-cache
           # The SHA256 here is copied from the index digest for the 2025.05.28
@@ -66,14 +66,14 @@ jobs:
 
       - name: Cache dependencies
         id: node-cache
-        uses: actions/cache@v7
+        uses: actions/cache@v5
         with:
           path: ./docs/node_modules
           key: modules-${{ hashFiles('docs/package-lock.json') }}-v1
 
       - name: Cache Puppeteer
         id: puppeteer-cache
-        uses: actions/cache@v7
+        uses: actions/cache@v5
         with:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ hashFiles('docs/package-lock.json') }}-v1

--- a/.github/workflows/save-rendered-diagrams.yaml
+++ b/.github/workflows/save-rendered-diagrams.yaml
@@ -36,7 +36,7 @@ jobs:
       #     private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Cache Docker pull of structurizr/lite:2025.05.28 image
         id: image-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v7
         with:
           path: ~/image-cache
           # The SHA256 here is copied from the index digest for the 2025.05.28
@@ -60,20 +60,20 @@ jobs:
         run: docker load -i ~/image-cache/structurizr.tar
 
       - name: Setup Node v24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
       - name: Cache dependencies
         id: node-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v7
         with:
           path: ./docs/node_modules
           key: modules-${{ hashFiles('docs/package-lock.json') }}-v1
 
       - name: Cache Puppeteer
         id: puppeteer-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v7
         with:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ hashFiles('docs/package-lock.json') }}-v1

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Make repo owner lowercase
         id: repo
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload JSON results as artifact
         if: steps.check.outputs.exists == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: trivy-results-${{ matrix.image.name }}
           path: trivy-${{ matrix.image.name }}-results.json
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download scan results
         uses: actions/download-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup python ${{env.PYTHON_RUNNER_VERSION}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{env.PYTHON_RUNNER_VERSION}}
           cache: pip
@@ -37,9 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup python ${{env.PYTHON_RUNNER_VERSION}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{env.PYTHON_RUNNER_VERSION}}
           cache: pip
@@ -54,9 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{env.NODE_VERSION}}
       - name: Install dependencies
@@ -76,10 +76,10 @@ jobs:
       VERSION: ${{ github.sha }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{env.NODE_VERSION}}
 
@@ -88,7 +88,7 @@ jobs:
         working-directory: client
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v7
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-browsers-${{ hashFiles('client/package-lock.json') }}
@@ -119,7 +119,7 @@ jobs:
         working-directory: client
 
       - name: Upload HTML Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
         working-directory: client
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v7
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-browsers-${{ hashFiles('client/package-lock.json') }}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup python ${{env.PYTHON_RUNNER_VERSION}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{env.PYTHON_RUNNER_VERSION}}
           cache: pip


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary
In the review of #1249, realized our GitHub actions that use versions defaulting to Node 20 will start to be deprecated soon. This upgrades the actions to ones that support 24 by default.

## ✅ Acceptance Criteria
- CI passes without deprecation warnings
     - Have a run of the pipeline [here](https://github.com/CDCgov/dibbs-ecr-refiner/actions/runs/26451305673) that passed w/o deprecation warnings
     - Have a run of the release candidate build pipeline [here](https://github.com/CDCgov/dibbs-ecr-refiner/actions/runs/26451598677/job/77873681983) that completed w/o warnings as well

## ℹ️ Additional Information
Double check any other jobs that I might have missed