### PR TITLE
chore: use `ruff` version defined in `dev-requirements.txt` in the pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,10 @@ jobs:
           python-version: ${{env.PYTHON_RUNNER_VERSION}}
           cache: pip
       - name: Install dependencies
+        working-directory: ./refiner
         run: |
           pip install -U pip
-          pip install ruff==0.15.13
+          pip install $(grep "^ruff==" dev-requirements.txt)
       - name: Run linter (ruff)
         run: |
           ruff check --output-format=github .


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the `lint.yml` file to use the version of `ruff` defined in `dev-requirements.txt` instead of hard-coding a version directly in the workflow file.

## 🧪 How to test

Pipeline should work as it did before.


