### PR TITLE
[FIX] 'Computing diff...' spinner displays inside of diff viewer header

### DIFF
--- a/client/src/components/Diff/index.tsx
+++ b/client/src/components/Diff/index.tsx
@@ -106,36 +106,39 @@ export function Diff({
       </div>
 
       {renderDiff ? (
-        <ReactDiffViewer
-          oldValue={unrefined_eicr}
-          newValue={condition.refined_eicr}
-          splitView={splitView}
-          showDiffOnly={showDiffOnly}
-          compareMethod={DiffMethod.WORDS_WITH_SPACE}
-          leftTitle="Original eICR"
-          rightTitle="Refined eICR"
-          loadingElement={() => {
-            return (
-              <div className="m-auto flex w-50 items-center justify-center">
-                <Spinner className="m-2" /> Computing diff...
+        <div className="relative">
+          <ReactDiffViewer
+            oldValue={unrefined_eicr}
+            newValue={condition.refined_eicr}
+            splitView={splitView}
+            showDiffOnly={showDiffOnly}
+            compareMethod={DiffMethod.WORDS_WITH_SPACE}
+            leftTitle="Original eICR"
+            rightTitle="Refined eICR"
+            loadingElement={() => (
+              <div className="absolute inset-x-0 top-16 z-10 flex justify-center">
+                <div className="flex items-center rounded-md bg-white px-4 py-2 shadow">
+                  <Spinner className="mr-2" />
+                  <span>Computing diff...</span>
+                </div>
               </div>
-            );
-          }}
-          styles={{
-            titleBlock: {
-              fontFamily: 'Public Sans, sans-serif',
-              fontSize: '16px',
-            },
-            diffContainer: {
-              borderRadius: '1px',
-              borderStyle: '',
-            },
-            lineNumber: {
-              color: 'black !important',
-              opacity: '100 !important',
-            },
-          }}
-        />
+            )}
+            styles={{
+              titleBlock: {
+                fontFamily: 'Public Sans, sans-serif',
+                fontSize: '16px',
+              },
+              diffContainer: {
+                borderRadius: '1px',
+                borderStyle: '',
+              },
+              lineNumber: {
+                color: 'black !important',
+                opacity: '100 !important',
+              },
+            }}
+          />
+        </div>
       ) : (
         <DiffViewWarning />
       )}


### PR DESCRIPTION
# 🔀 PULL REQUEST

<img width="1723" height="900" alt="Screenshot 2026-05-28 at 10 05 03 AM" src="https://github.com/user-attachments/assets/09e0435b-471e-492c-89c8-4d6062a92057" />


<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

- Wrap the diff viewer in a relative container and show a centered overlay

<!--
What changes are being proposed?
-->

## 🔗 Related Issue

<!--
add the issue number in both places:
Fixes #3
- #3
-->

Fixes #1225 
- #1225 

## ✅ Acceptance Criteria

<!--
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
-->

- [ ] "Computing diff..." spinner should show up below the diff view header

## 🧪 How to test

<!--
Unit tests

1. From the project root make sure you're in the `refiner/` directory
2. Activate a virtual environment using your tool of choice
3. Make sure that both `requirements.txt` and `dev-requirements.txt` are installed
4. Run the unit tests with `pytest -vv tests/`
5. Additionally you can check coverage with `pytest --cov=app tests`

or

Testing the application:

1. Run `docker compose up`
2. Check that both services are up and running with `docker ps`
3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
4. You should be able to [insert goal you want to accomplish!]
-->

Easiest way to test is to replace the Diff function with this one with a timeout to make it easier to see locally. Even when using Chrome networking throttling it was hard to take a good look 

[diff_slowed_func.tsx](https://github.com/user-attachments/files/28350157/diff_slowed_func.tsx)


## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
