### PR TITLE
fix: reset session cookie when session is extended

### DIFF
--- a/refiner/app/api/auth/handlers.py
+++ b/refiner/app/api/auth/handlers.py
@@ -21,10 +21,10 @@ from ...db.users.model import DbUser
 from ...services.logger import get_logger
 from .config import ENVIRONMENT, get_oauth_provider
 from .session import (
-    SESSION_EXPIRY_SECONDS,
     create_session,
     delete_session,
     get_user_from_session,
+    set_session_cookie,
 )
 
 auth_router = APIRouter()
@@ -201,14 +201,7 @@ async def auth_callback(
             secure=env != "local",
         )
 
-        response.set_cookie(
-            key="refiner-session",
-            value=session_token,
-            httponly=True,
-            max_age=SESSION_EXPIRY_SECONDS,
-            samesite="lax",
-            secure=env != "local",  # We'll be serving over https in live envs
-        )
+        set_session_cookie(response=response, session_token=session_token)
         return response
 
     except Exception:

--- a/refiner/app/api/auth/middleware.py
+++ b/refiner/app/api/auth/middleware.py
@@ -89,7 +89,7 @@ async def get_logged_in_user(
     user = DbUserWithSessionExpiryTime(**db_user)
 
     # Renew session if it's close to expiring
-    await update_session_expiry_time(
+    await _update_session_expiry_time(
         expires_at=user.expires_at,
         token_hash=token_hash,
         logger=logger,
@@ -119,7 +119,7 @@ async def _fetch_session_user(
             return await cur.fetchone()
 
 
-async def update_session_expiry_time(
+async def _update_session_expiry_time(
     response: Response,
     session_token: str,
     expires_at: datetime,

--- a/refiner/app/api/auth/middleware.py
+++ b/refiner/app/api/auth/middleware.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 from datetime import datetime as dt
 from logging import Logger
 
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, Request, Response, status
 from psycopg.rows import dict_row
 
 from app.db.pool import AsyncDatabaseConnection, get_db
@@ -11,7 +11,7 @@ from app.db.pool import AsyncDatabaseConnection, get_db
 from ...core.exceptions import DatabaseConnectionError, DatabaseQueryError
 from ...db.users.model import DbUser
 from ...services.logger import get_logger
-from .session import SESSION_TTL, get_hashed_token
+from .session import SESSION_TTL, get_hashed_token, set_session_cookie
 
 RENEW_THRESHOLD = timedelta(minutes=15)
 
@@ -39,6 +39,7 @@ class DbUserWithSessionExpiryTime(DbUser):
 # This function can be used as an auth check for handlers or routers
 async def get_logged_in_user(
     request: Request,
+    response: Response,
     logger: Logger = Depends(get_logger),
     db: AsyncDatabaseConnection = Depends(get_db),
 ) -> DbUser:
@@ -47,6 +48,7 @@ async def get_logged_in_user(
 
     Args:
         request (Request): Request to check for user info
+        response (Response): The response object
         logger (Logger): The standard logger
         db (AsyncDatabaseConnection): The database connection
 
@@ -67,19 +69,7 @@ async def get_logged_in_user(
     token_hash = get_hashed_token(session_token)
     db_user = None
     try:
-        async with db.get_connection() as conn:
-            async with conn.cursor(row_factory=dict_row) as cur:
-                now = dt.now(UTC)
-                await cur.execute(
-                    """
-                    SELECT users.*, sessions.expires_at
-                    FROM sessions
-                    JOIN users ON sessions.user_id = users.id
-                    WHERE sessions.token_hash = %s AND sessions.expires_at > %s
-                    """,
-                    (token_hash, now),
-                )
-                db_user = await cur.fetchone()
+        db_user = await _fetch_session_user(token_hash=token_hash, db=db)
     except (DatabaseConnectionError, DatabaseQueryError) as db_err:
         logger.error(
             "Database error occurred while getting user information",
@@ -97,24 +87,52 @@ async def get_logged_in_user(
         )
 
     user = DbUserWithSessionExpiryTime(**db_user)
-    expires_at = user.expires_at
 
     # Renew session if it's close to expiring
     await update_session_expiry_time(
-        expires_at=expires_at, token_hash=token_hash, logger=logger, db=db
+        expires_at=user.expires_at,
+        token_hash=token_hash,
+        logger=logger,
+        response=response,
+        session_token=session_token,
+        db=db,
     )
 
     # Create a DbUser from the DbUserWithSessionExpiryTime to return
     return user.to_db_user()
 
 
+async def _fetch_session_user(
+    token_hash: str, db: AsyncDatabaseConnection
+) -> dict | None:
+    async with db.get_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT users.*, sessions.expires_at
+                FROM sessions
+                JOIN users ON sessions.user_id = users.id
+                WHERE sessions.token_hash = %s AND sessions.expires_at > %s
+                """,
+                (token_hash, dt.now(UTC)),
+            )
+            return await cur.fetchone()
+
+
 async def update_session_expiry_time(
-    expires_at: datetime, token_hash: str, logger: Logger, db: AsyncDatabaseConnection
+    response: Response,
+    session_token: str,
+    expires_at: datetime,
+    token_hash: str,
+    logger: Logger,
+    db: AsyncDatabaseConnection,
 ) -> None:
     """
     Updates a user's session expiration if it is set to expire soon.
 
     Args:
+        response (Response): The response object
+        session_token: The user's session token
         expires_at (datetime): Current expiration time
         token_hash (str): Hashed session token
         logger (Logger): Standard logger
@@ -133,6 +151,7 @@ async def update_session_expiry_time(
                         "UPDATE sessions SET expires_at = %s WHERE token_hash = %s",
                         (new_expiration, token_hash),
                     )
+            set_session_cookie(response=response, session_token=session_token)
 
         except (DatabaseConnectionError, DatabaseQueryError) as db_err:
             logger.error(

--- a/refiner/app/api/auth/middleware.py
+++ b/refiner/app/api/auth/middleware.py
@@ -132,7 +132,7 @@ async def update_session_expiry_time(
 
     Args:
         response (Response): The response object
-        session_token: The user's session token
+        session_token (str): The user's session token
         expires_at (datetime): Current expiration time
         token_hash (str): Hashed session token
         logger (Logger): Standard logger

--- a/refiner/app/api/auth/session.py
+++ b/refiner/app/api/auth/session.py
@@ -6,6 +6,7 @@ from datetime import UTC, timedelta
 from datetime import datetime as dt
 from logging import Logger
 
+from fastapi import Response
 from psycopg.rows import dict_row
 
 from app.db.pool import AsyncDatabaseConnection
@@ -31,6 +32,26 @@ def get_hashed_token(token: str) -> str:
     return hmac.new(
         SESSION_SECRET_KEY, token.encode("utf-8"), hashlib.sha256
     ).hexdigest()
+
+
+def set_session_cookie(response: Response, session_token: str) -> None:
+    """
+    Sets the user's session cookie.
+
+    Args:
+        response (Response): The response object
+        session_token (str): The user's session token
+    """
+    env = ENVIRONMENT["ENV"]
+
+    response.set_cookie(
+        key="refiner-session",
+        value=session_token,
+        httponly=True,
+        max_age=SESSION_EXPIRY_SECONDS,
+        samesite="lax",
+        secure=env != "local",  # We'll be serving over https in live envs
+    )
 
 
 async def create_session(user_id: str, db: AsyncDatabaseConnection) -> str:


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR addresses an issue that can cause users to be logged out of the app when they shouldn't be. When the user's session is about to expire (~15 mins away) the app will see this and will give the user another hour of session time. This works as expected for the DB session record but I noticed that the user's cookie was not being updated.

Here is what a user might encounter currently:

1. User's DB session record's `expires_at` is updated one hour into the future
2. User's cookie MaxAge expires
3. User makes an API request
4. User gets booted from the app ("your session has expired" screen)
5. User logs back in
6. New cookie is given by the server, DB creates a new session record (user may have a couple valid sessions in the DB)

This change will reset the cookie immediately after the DB updates the session record. This will prevent users from being booted out of the app when they are still actively using it.

## 🧪 How to test

**Log out first if you're already logged in**

We mainly just need to be sure both the DB record and cookie update as expected. A quick way to do this is by running this query in your local DB:
```sql
UPDATE sessions
SET expires_at = NOW() + INTERVAL '10 minutes'
WHERE token_hash = '<your_token_hash>';
```

This will set your session to expire in 10 minutes from now. Click anything in the app that makes an API request and you should see your `expires_at` in the DB record update by +1 hour.

If you check your `refiner-session` cookie, you'll see `Expires / MaxAge` should now be in sync with the time in the DB.

## ℹ️ Additional Information

This is how it was always supposed to work 🙃 
