### PR TITLE
fix: set modal backdrop z-index

### DIFF
--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -68,7 +68,6 @@ function Modal({
             'items-start': position === 'top',
           })}
         >
-
           <DialogPanel
             className={classNames(
               'border-base-lighter relative z-60 w-full max-w-lg rounded-sm border bg-white p-6 shadow-lg',

--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -60,7 +60,7 @@ function Modal({
   return (
     <ModalContext.Provider value={{ onClose }}>
       <Dialog open={open} onClose={onClose} unmount>
-        <DialogBackdrop className="fixed inset-0 bg-black/60" />
+        <DialogBackdrop className="fixed inset-0 z-50 bg-black/60" />
 
         <div
           className={classNames('fixed inset-0 z-50 flex justify-center p-4', {
@@ -68,11 +68,10 @@ function Modal({
             'items-start': position === 'top',
           })}
         >
-          <div className="bg-base-dark/70 fixed inset-0" aria-hidden="true" />
 
           <DialogPanel
             className={classNames(
-              'border-base-lighter relative z-50 w-full max-w-lg rounded-sm border bg-white p-6 shadow-lg',
+              'border-base-lighter relative z-60 w-full max-w-lg rounded-sm border bg-white p-6 shadow-lg',
               className
             )}
           >


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR addresses an issue where elements on the page using a non-zero z-index would clip through the modal backdrop when the modal is displayed due to it lacking its own z-index.

Before:
<img width="1598" height="1181" alt="image" src="https://github.com/user-attachments/assets/5a2756f3-ecb0-4a8b-861e-89ab7e38f682" />


After:
<img width="1598" height="1180" alt="image" src="https://github.com/user-attachments/assets/63565166-2828-4fb9-b005-ea70bcbd5f6c" />

## 🧪 How to test

- I think this only applies to the example above currently. I'm not noticing any other areas with this issue