### PR TITLE
fix: Refactor the validation around NO sections

### DIFF
--- a/refiner/app/api/v1/configurations/sections.py
+++ b/refiner/app/api/v1/configurations/sections.py
@@ -175,7 +175,6 @@ async def update_section(
         all_sections=config.section_processing,
         desired_name=section_input.name,
         desired_code=section_input.new_code,
-        desired_action=section_input.action,
     )
 
     section_update = _build_section_update(
@@ -268,7 +267,6 @@ def _raise_if_invalid_section_update(
     all_sections: list[DbConfigurationSectionProcessing],
     desired_name: str | None,
     desired_code: str | None,
-    desired_action: str | None,
 ) -> None:
     """
     Raises an exception if any properties of an update are not valid.
@@ -278,15 +276,7 @@ def _raise_if_invalid_section_update(
         all_sections (list[DbConfigurationSectionProcessing]): All sections associated with a config
         desired_name (str | None): The desired name to update to
         desired_code (str | None): the desired code to update to
-        desired_action (str | None): The desired action to update to
     """
-    # Validation for narrative-only sections
-    if desired_action == "refine" and existing_section.code in NARRATIVE_ONLY_SECTIONS:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"The section {existing_section.name} is narrative-only and cannot be refined.",
-        )
-
     other_sections = [s for s in all_sections if s.code != existing_section.code]
 
     _raise_if_invalid_section_fields(
@@ -331,6 +321,8 @@ def _build_section_update(
         code = prev_section.code
         name = prev_section.name
         section_type = "standard"
+        if code in NARRATIVE_ONLY_SECTIONS:
+            action = "retain"
 
     return DbConfigurationSectionProcessing(
         code=code,

--- a/refiner/tests/unit/test_service_configurations.py
+++ b/refiner/tests/unit/test_service_configurations.py
@@ -1,3 +1,5 @@
+from app.api.v1.configurations.model import SectionUpdateInput
+from app.api.v1.configurations.sections import _build_section_update
 from app.db.configurations.model import DbConfigurationSectionProcessing
 from app.services.configurations import (
     clone_section_processing_instructions,
@@ -243,3 +245,94 @@ class TestCloneSectionProcessingInstructions:
         assert result_map[refinable_code].action == "refine"
         assert result_map[refinable_code].include is False
         assert result_map[custom_code].section_type == "custom"
+
+
+class TestBuildSectionUpdateNormalization:
+    def test_narrative_only_standard_section_normalized_to_retain(self):
+        """
+        Tests that standard sections with narrative-only codes are normalized to action="retain"
+        even when action="refine" is requested (handles legacy DB rows).
+        """
+        narrative_code = NARRATIVE_ONLY_SECTIONS[0]
+
+        prev_section = DbConfigurationSectionProcessing(
+            code=narrative_code,
+            name="Chief Complaint",
+            action="refine",  # Legacy value from before narrative refinement PR
+            include=True,
+            narrative=True,
+            versions=["1.1"],
+            section_type="standard",
+        )
+
+        section_input = SectionUpdateInput(
+            current_code=narrative_code,
+            action="refine",  # Attempting to set to refine
+        )
+
+        result = _build_section_update(prev_section, section_input)
+
+        assert result.code == narrative_code
+        assert result.action == "retain", (
+            f"Narrative-only standard section should be normalized to 'retain', got '{result.action}'"
+        )
+        assert result.section_type == "standard"
+
+    def test_narrative_only_custom_section_not_normalized(self):
+        """
+        Tests that custom sections with narrative-only codes are NOT normalized,
+        allowing them to keep their requested action.
+        """
+        narrative_code = NARRATIVE_ONLY_SECTIONS[0]
+
+        prev_section = DbConfigurationSectionProcessing(
+            code=narrative_code,
+            name="Custom Narrative Section",
+            action="refine",
+            include=True,
+            narrative=True,
+            versions=[],
+            section_type="custom",
+        )
+
+        section_input = SectionUpdateInput(
+            current_code=narrative_code,
+            action="refine",
+        )
+
+        result = _build_section_update(prev_section, section_input)
+
+        assert result.code == narrative_code
+        assert result.action == "refine", (
+            f"Custom section should keep 'refine' action, got '{result.action}'"
+        )
+        assert result.section_type == "custom"
+
+    def test_refinable_standard_section_keeps_refine_action(self):
+        """
+        Tests that standard sections with match rules keep action="refine" when requested.
+        """
+        refinable_code = "11450-4"  # Problem Section
+
+        prev_section = DbConfigurationSectionProcessing(
+            code=refinable_code,
+            name="Problem Section",
+            action="retain",
+            include=True,
+            narrative=False,
+            versions=["1.1"],
+            section_type="standard",
+        )
+
+        section_input = SectionUpdateInput(
+            current_code=refinable_code,
+            action="refine",
+        )
+
+        result = _build_section_update(prev_section, section_input)
+
+        assert result.code == refinable_code
+        assert result.action == "refine", (
+            f"Refinable standard section should keep 'refine' action, got '{result.action}'"
+        )
+        assert result.section_type == "standard"


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

After my last PR landed, we now had the API blocking any attempt to edit legacy
configurations because it saw the old settings as invalid. I've got fix locally
I'm pushing up that will normalize the narrative-only ones to make things work
for legacy configurations.

## 🔗 Related Issue

- #1182

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

> [!NOTE]
> Unsure how to test this locally for now...
