### PR TITLE
test: Pydantic warnings are errors when running the app locally

### DIFF
--- a/refiner/app/main.py
+++ b/refiner/app/main.py
@@ -31,6 +31,7 @@ from .core.config import ENVIRONMENT
 from .db.pool import AsyncDatabaseConnection, get_db
 from .services.logger import get_logger, set_request_id
 
+# Pydantic warnings will be reported as errors in local dev / testing
 if ENVIRONMENT["ENV"] == "local":
     warnings.filterwarnings("error", category=UserWarning, module="pydantic")
 

--- a/refiner/app/main.py
+++ b/refiner/app/main.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import time
 import uuid
+import warnings
 from collections.abc import Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from datetime import UTC
@@ -29,6 +30,9 @@ from .core.app.openapi import create_custom_openapi
 from .core.config import ENVIRONMENT
 from .db.pool import AsyncDatabaseConnection, get_db
 from .services.logger import get_logger, set_request_id
+
+if ENVIRONMENT["ENV"] == "local":
+    warnings.filterwarnings("error", category=UserWarning, module="pydantic")
 
 
 class CharsetStaticFiles(StaticFiles):


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the app to throw errors (local only) whenever Pydantic `UserWarning`s are reported, which in our case typically amount to `PydanticSerializationUnexpectedValue` warnings. There is no real reason we'd ever want these warnings to slip through during local dev / when testing. These should be much more obvious now since they'll break the app 😅 

## 🧪 How to test

A simple way to see this in action is to update [this line](https://github.com/CDCgov/dibbs-ecr-refiner/blob/main/refiner/app/api/auth/handlers.py#L270) to be:
```python
to_render={"most_recent_app_update": should_show_app_update}
```

We're using the string representation of the enum here, which Pydantic will warn about. This should cause an error on this branch.