### PR TITLE
feat(ui): Convert Narrative `<Switch/>` to `<Dropdown/>`

### DIFF
--- a/client/e2e/configuration.spec.ts
+++ b/client/e2e/configuration.spec.ts
@@ -378,10 +378,10 @@ test.describe('Configuration detail flow', () => {
       await page.getByLabel('LOINC code').fill(customSectionCode);
       await page.getByRole('button', { name: 'Add section' }).click();
       await expect(
-        page.getByRole('switch', {
-          name: `Toggle to refine or retain the narrative block in the ${customSectionName} section`,
+        page.getByRole('combobox', {
+          name: `Narrative data handling for ${customSectionName} section`,
         })
-      ).not.toBeChecked();
+      ).toHaveValue('remove');
     });
 
     await test.step('Run inline test', async () => {

--- a/client/src/pages/Configurations/ConfigBuild/Sections/NarrativeSelect.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/Sections/NarrativeSelect.tsx
@@ -30,7 +30,7 @@ export function NarrativeSelect({
           });
         }}
         aria-label={`Narrative data handling for ${currentSection.name} section`}
-        className="min-w-52"
+        className="min-w-38"
       >
         <option value="retain">Keep original</option>
         <option value="remove">Remove</option>

--- a/client/src/pages/Configurations/ConfigBuild/Sections/NarrativeSelect.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/Sections/NarrativeSelect.tsx
@@ -1,0 +1,40 @@
+import { Select } from '@components/Select';
+import { Field } from '@components/Field';
+import { DbConfigurationSectionProcessing } from '../../../../api/schemas/dbConfigurationSectionProcessing';
+import { useSectionUpdater } from './useSectionUpdater';
+
+// TODO: Add "Reconstruct" option once backend `narrative` field supports 3-value enum
+// (retain | remove | refine). Currently limited to boolean (true = retain, false = remove).
+
+interface NarrativeSelectProps {
+  configurationId: string;
+  currentSection: DbConfigurationSectionProcessing;
+  disabled: boolean;
+}
+
+export function NarrativeSelect({
+  configurationId,
+  currentSection,
+  disabled,
+}: NarrativeSelectProps) {
+  const updateSection = useSectionUpdater(configurationId);
+
+  return (
+    <Field className="flex items-center gap-3">
+      <Select
+        disabled={disabled}
+        value={currentSection.narrative ? 'retain' : 'remove'}
+        onChange={(e) => {
+          updateSection(currentSection, {
+            narrative: e.target.value === 'retain',
+          });
+        }}
+        aria-label={`Narrative data handling for ${currentSection.name} section`}
+        className="min-w-52"
+      >
+        <option value="retain">Keep original</option>
+        <option value="remove">Remove</option>
+      </Select>
+    </Field>
+  );
+}

--- a/client/src/pages/Configurations/ConfigBuild/Sections/Sections.test.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/Sections/Sections.test.tsx
@@ -158,12 +158,7 @@ describe('Configuration sections', () => {
     const disabledSectionName = screen.getByText('Disabled section');
     const row = disabledSectionName.closest('tr');
     expect(row).not.toBeNull();
-
-    if (!row) {
-      throw new Error('Could not find table row for "Disabled section"');
-    }
-
-    const select = within(row).queryByRole('combobox');
+    const select = row && within(row).queryByRole('combobox');
     expect(select).toBeInTheDocument();
     expect(select).toBeDisabled();
   });

--- a/client/src/pages/Configurations/ConfigBuild/Sections/Sections.test.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/Sections/Sections.test.tsx
@@ -45,6 +45,19 @@ const sections: DbConfigurationSectionProcessing[] = [
   },
 ];
 
+const sectionsWithDisabled: DbConfigurationSectionProcessing[] = [
+  ...sections,
+  {
+    name: 'Disabled section',
+    action: 'retain',
+    include: true,
+    code: '83910-0',
+    narrative: true,
+    versions: ['3.1'],
+    section_type: 'standard',
+  },
+];
+
 const testId = 'test-id';
 
 function renderWithClient(ui: React.ReactElement) {
@@ -57,7 +70,6 @@ describe('Configuration sections', () => {
       <Sections configurationId={testId} disabled={false} sections={sections} />
     );
 
-    // all table rows (including header)
     const rows = screen.getAllByRole('row');
     expect(rows).toHaveLength(5);
 
@@ -66,43 +78,94 @@ describe('Configuration sections', () => {
       return {
         checkbox: within(row).getByRole('checkbox'),
         nameCell: within(row).getAllByRole('cell')[1],
-        switches: within(row).queryAllByRole('switch'), // [0] = coded data, [1] = narrative data
+        codedDataSwitch: within(row).queryByRole('switch'),
+        narrativeSelect: within(row).queryByRole('combobox'),
       };
     };
 
-    // skip header
     const history = getRow(1);
     const med = getRow(2);
     const imm = getRow(3);
-    const narrative = getRow(4);
+    const custom = getRow(4);
 
-    // History
     expect(history.checkbox).toBeChecked();
     expect(history.nameCell).toHaveTextContent('History section');
-    expect(history.switches).toHaveLength(2);
-    expect(history.switches[0]).toBeChecked();
-    expect(history.switches[1]).not.toBeChecked();
+    expect(history.codedDataSwitch).toBeInTheDocument();
+    expect(history.codedDataSwitch).toBeChecked();
+    expect(history.narrativeSelect).toBeInTheDocument();
+    expect(history.narrativeSelect).toHaveValue('remove');
 
-    // Med
     expect(med.checkbox).not.toBeChecked();
     expect(med.nameCell).toHaveTextContent('Med section');
-    expect(med.switches).toHaveLength(0);
+    expect(med.codedDataSwitch).not.toBeInTheDocument();
+    expect(med.narrativeSelect).not.toBeInTheDocument();
 
-    // Immunizations
     expect(imm.checkbox).toBeChecked();
     expect(imm.nameCell).toHaveTextContent('Immunizations section');
-    expect(imm.switches).toHaveLength(2);
-    expect(imm.switches[0]).not.toBeChecked();
-    expect(imm.switches[1]).not.toBeChecked();
+    expect(imm.codedDataSwitch).toBeInTheDocument();
+    expect(imm.codedDataSwitch).not.toBeChecked();
+    expect(imm.narrativeSelect).toBeInTheDocument();
+    expect(imm.narrativeSelect).toHaveValue('remove');
 
-    // Custom section
-    expect(narrative.checkbox).toBeChecked();
-    expect(narrative.nameCell).toHaveTextContent(
+    expect(custom.checkbox).toBeChecked();
+    expect(custom.nameCell).toHaveTextContent(
       'Mock custom sectionCustommock-custom-sectionEdit|Delete'
     );
-    expect(narrative.switches).toHaveLength(2);
-    expect(narrative.switches[0]).toBeChecked();
-    expect(narrative.switches[1]).toBeChecked();
+    expect(custom.codedDataSwitch).toBeInTheDocument();
+    expect(custom.codedDataSwitch).toBeChecked();
+    expect(custom.narrativeSelect).toBeInTheDocument();
+    expect(custom.narrativeSelect).toHaveValue('retain');
+  });
+
+  it('should render narrative dropdown with correct options', () => {
+    renderWithClient(
+      <Sections configurationId={testId} disabled={false} sections={sections} />
+    );
+
+    const selects = screen.getAllByRole('combobox');
+    expect(selects.length).toBeGreaterThanOrEqual(1);
+
+    const firstSelect = selects[0];
+    const options = within(firstSelect).getAllByRole('option');
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent('Keep original');
+    expect(options[0]).toHaveValue('retain');
+    expect(options[1]).toHaveTextContent('Remove');
+    expect(options[1]).toHaveValue('remove');
+  });
+
+  it('should blank out narrative controls for excluded rows', () => {
+    renderWithClient(
+      <Sections configurationId={testId} disabled={false} sections={sections} />
+    );
+
+    const rows = screen.getAllByRole('row');
+    const medRow = rows[2];
+
+    expect(within(medRow).queryByRole('switch')).not.toBeInTheDocument();
+    expect(within(medRow).queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('should disable narrative dropdown for disabled section LOINC codes', () => {
+    renderWithClient(
+      <Sections
+        configurationId={testId}
+        disabled={false}
+        sections={sectionsWithDisabled}
+      />
+    );
+
+    const disabledSectionName = screen.getByText('Disabled section');
+    const row = disabledSectionName.closest('tr');
+    expect(row).not.toBeNull();
+
+    if (!row) {
+      throw new Error('Could not find table row for "Disabled section"');
+    }
+
+    const select = within(row).queryByRole('combobox');
+    expect(select).toBeInTheDocument();
+    expect(select).toBeDisabled();
   });
 
   it('should allow custom section additions', async () => {

--- a/client/src/pages/Configurations/ConfigBuild/Sections/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/Sections/index.tsx
@@ -172,7 +172,6 @@ export function Sections({
                     </div>
                   ) : null}
                 </td>
-
                 <td className="w-[17%]">
                   {section.include ? (
                     <div className="flex justify-center">

--- a/client/src/pages/Configurations/ConfigBuild/Sections/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/Sections/index.tsx
@@ -1,6 +1,5 @@
 import { DbConfigurationSectionProcessing } from '../../../../api/schemas/dbConfigurationSectionProcessing';
 import { useToast } from '../../../../hooks/useToast';
-import { useApiErrorFormatter } from '../../../../hooks/useErrorFormatter';
 import {
   DbSectionAction,
   DisabledSection,
@@ -8,7 +7,6 @@ import {
 } from '../../../../api/schemas';
 import {
   getGetConfigurationQueryKey,
-  useUpdateSection,
   useDeleteCustomSection,
 } from '../../../../api/configurations/configurations';
 import { useQueryClient } from '@tanstack/react-query';
@@ -18,6 +16,8 @@ import { CustomSectionModal } from './CustomSectionModal';
 import { CustomSectionBadge } from './CustomSectionBadge';
 import { Checkbox } from '@components/Checkbox';
 import { Switch } from './Switch';
+import { NarrativeSelect } from './NarrativeSelect';
+import { useSectionUpdater } from './useSectionUpdater';
 import classNames from 'classnames';
 import { Field } from '@components/Field';
 import { Label } from '@components/Label';
@@ -154,31 +154,22 @@ export function Sections({
                 <td className="w-[33%]">
                   {section.include ? (
                     <div className="flex justify-center">
-                      {isNarrativeSection(section.code) ? (
-                        <span
-                          className="text-gray-cool-50 text-center italic lg:text-right"
-                          aria-hidden
-                        >
-                          Not applicable for this section
-                        </span>
-                      ) : (
-                        <RefineSwitch
-                          configurationId={configurationId}
-                          currentSection={section}
-                          sections={sectionProcessing}
-                          disabled={disabled || isDisabledSection(section.code)}
-                        />
-                      )}
+                      <RefineSwitch
+                        configurationId={configurationId}
+                        currentSection={section}
+                        sections={sectionProcessing}
+                        disabled={disabled || isDisabledSection(section.code)}
+                        isNarrativeOnly={isNarrativeSection(section.code)}
+                      />
                     </div>
                   ) : null}
                 </td>
                 <td className="w-[17%]">
                   {section.include ? (
                     <div className="flex justify-center">
-                      <NarrativeSwitch
+                      <NarrativeSelect
                         configurationId={configurationId}
                         currentSection={section}
-                        sections={sectionProcessing}
                         disabled={disabled || isDisabledSection(section.code)}
                       />
                     </div>
@@ -343,59 +334,27 @@ function IncludeCheckbox({
   );
 }
 
-type SectionPatch = Partial<
-  Pick<
-    DbConfigurationSectionProcessing,
-    'action' | 'include' | 'narrative' | 'code'
-  >
->;
-
-function useSectionUpdater(configurationId: string) {
-  const { mutate: updateSection } = useUpdateSection();
-  const queryClient = useQueryClient();
-  const formatError = useApiErrorFormatter();
-  const showToast = useToast();
-
-  return (
-    currentSection: DbConfigurationSectionProcessing,
-    patch: SectionPatch
-  ) => {
-    updateSection(
-      {
-        configurationId,
-        data: {
-          action: patch.action ?? currentSection.action,
-          current_code: patch.code ?? currentSection.code,
-          include: patch.include ?? currentSection.include,
-          narrative: patch.narrative ?? currentSection.narrative,
-        },
-      },
-      {
-        onSuccess: async () => {
-          await queryClient.invalidateQueries({
-            queryKey: getGetConfigurationQueryKey(configurationId),
-          });
-        },
-        onError: (error) => {
-          const errorDetail =
-            formatError(error) || error.message || 'Unknown error';
-          showToast({
-            heading: 'Section failed to update',
-            body: errorDetail,
-            variant: 'error',
-          });
-        },
-      }
-    );
-  };
-}
-
 function RefineSwitch({
   currentSection,
   configurationId,
   disabled,
-}: SelectionToggleProps) {
+  isNarrativeOnly,
+}: SelectionToggleProps & { isNarrativeOnly: boolean }) {
   const updateSection = useSectionUpdater(configurationId);
+
+  if (isNarrativeOnly) {
+    return (
+      <Field className="flex -translate-x-4 flex-row items-center">
+        <Label
+          className="text-gray-cool-40 mr-2 w-72 text-right italic"
+          aria-hidden
+        >
+          Not applicable for this section
+        </Label>
+        <div className="w-12" />
+      </Field>
+    );
+  }
 
   const isRefineToggled = currentSection.action === DbSectionAction.refine;
   const refineLabelText = 'Refine';
@@ -427,29 +386,6 @@ function RefineSwitch({
             action: checked ? DbSectionAction.refine : DbSectionAction.retain,
           });
         }}
-      />
-    </Field>
-  );
-}
-
-function NarrativeSwitch({
-  currentSection,
-  configurationId,
-  disabled,
-}: SelectionToggleProps) {
-  const updateSection = useSectionUpdater(configurationId);
-
-  return (
-    <Field className="flex items-center gap-3">
-      <Switch
-        disabled={disabled}
-        checked={currentSection.narrative}
-        onChange={(checked) => {
-          updateSection(currentSection, {
-            narrative: checked,
-          });
-        }}
-        aria-label={`Toggle to refine or retain the narrative block in the ${currentSection.name} section`}
       />
     </Field>
   );

--- a/client/src/pages/Configurations/ConfigBuild/Sections/useSectionUpdater.ts
+++ b/client/src/pages/Configurations/ConfigBuild/Sections/useSectionUpdater.ts
@@ -1,0 +1,55 @@
+import { DbConfigurationSectionProcessing } from '../../../../api/schemas/dbConfigurationSectionProcessing';
+import { useToast } from '../../../../hooks/useToast';
+import { useApiErrorFormatter } from '../../../../hooks/useErrorFormatter';
+import {
+  getGetConfigurationQueryKey,
+  useUpdateSection,
+} from '../../../../api/configurations/configurations';
+import { useQueryClient } from '@tanstack/react-query';
+
+export type SectionPatch = Partial<
+  Pick<
+    DbConfigurationSectionProcessing,
+    'action' | 'include' | 'narrative' | 'code'
+  >
+>;
+
+export function useSectionUpdater(configurationId: string) {
+  const { mutate: updateSection } = useUpdateSection();
+  const queryClient = useQueryClient();
+  const formatError = useApiErrorFormatter();
+  const showToast = useToast();
+
+  return (
+    currentSection: DbConfigurationSectionProcessing,
+    patch: SectionPatch
+  ) => {
+    updateSection(
+      {
+        configurationId,
+        data: {
+          action: patch.action ?? currentSection.action,
+          current_code: patch.code ?? currentSection.code,
+          include: patch.include ?? currentSection.include,
+          narrative: patch.narrative ?? currentSection.narrative,
+        },
+      },
+      {
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({
+            queryKey: getGetConfigurationQueryKey(configurationId),
+          });
+        },
+        onError: (error) => {
+          const errorDetail =
+            formatError(error) || error.message || 'Unknown error';
+          showToast({
+            heading: 'Section failed to update',
+            body: errorDetail,
+            variant: 'error',
+          });
+        },
+      }
+    );
+  };
+}


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This patch updates the narrative data toggle switch to a dropdown select
component with two options ("Keep original" and "Remove"). This only addresses
the first part of the narrative reconstruction dropdown feature. The change
replaces the `<NarrativeSwitch/>` component with a new `<NarrativeSelect/>`
component that uses the existing `<Select/>` component. I'm also preserving the
blanking pattern for excluded rows; if `include: false` then no controls are shown.

> ❗ **Important**
>
> This patch is only starting the narrative reconstruction dropdown feature. It
> does not include the new "Reconstruct" option, cross-field validation logic,
> nor backend enum migration. Those will be addressed in subsequent patches.

## 🔗 Related Issue

- #1016
- #1195

## ✅ Acceptance Criteria

- [x] Convert narrative data options to a drop-down
- [ ] ~~Reconstruct option appears in the drop-down when available for that
      section~~
- [ ] ~~Reconstruction option grayed out unless "refine" is selected for coded
      data~~
- [x] ~~Updated table column names (coded data, narrative data)~~
- [x] ~~Updated coded data options copy (keep original, refine)~~
- [x] ~~Updated tooltip copy~~
- [ ] ~~If user has "reconstruct" for the narrative and tries to change coded
      data to "keep original", error appears under the toggle~~
- [x] Default settings are "refine" for coded data and "keep original" for
      narrative
- [x] Should retain pattern of blanking out excluded rows (not showing options
      for coded data or refined data)

## 🧪 How to test

1. Run `just dev up` to bring up the application locally
1. Navigate to the configuration's Build step and inspect the Sections table.
   Confirm that the narrative column now displays a dropdown instead of a toggle
   switch.
1. Verify that "Keep original" and "Remove" are both working as expected.
1. Run automated checks with `just client run lint fmt check test e2e`

## ℹ️ Additional Information

> [!NOTE]
> The work related to #1195 will be applied in four different patches/PRs
> continuing with this one. Each patch will be as independent as possible and rely
> only on prior patches as strictly necessary. This patch relies on the changes
> introduced in #1317.
