### PR TITLE
feat: Code set improvements

### DIFF
--- a/client/e2e/configuration.spec.ts
+++ b/client/e2e/configuration.spec.ts
@@ -10,6 +10,23 @@ test.describe('Configuration detail flow', () => {
     await deleteAllConfigurations();
   });
 
+  test('Validate code set table appearance', async ({
+    page,
+    configurationsPage,
+    configurationPage,
+  }) => {
+    const condition = 'Anotia';
+    await configurationsPage.createConfiguration(condition);
+    await configurationPage.goToBuildTab();
+    await page.getByLabel('View TES code set information for Anotia').click();
+
+    await expect(page.getByRole('columnheader')).toHaveText([
+      'Code',
+      'Code system',
+      'Display name',
+    ]);
+  });
+
   test('Check code set status and individual grouper statuses', async ({
     page,
     configurationsPage,

--- a/client/src/pages/Configurations/ConfigBuild/CustomCodes/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CustomCodes/index.tsx
@@ -341,7 +341,7 @@ export function ConditionCodeTable({
               <div role="row" className="contents">
                 <Header>Code</Header>
                 <Header>Code system</Header>
-                <Header>Condition</Header>
+                <Header>Display name</Header>
               </div>
             </div>
 

--- a/refiner/app/api/v1/configurations/exports.py
+++ b/refiner/app/api/v1/configurations/exports.py
@@ -65,6 +65,7 @@ async def get_configuration_export(
         writer.writerow(
             [
                 "Code Type",
+                "Condition",
                 "Code System",
                 "Code",
                 "Display Name",
@@ -72,22 +73,24 @@ async def get_configuration_export(
         )
         for cond in included_conditions:
             codes = await get_condition_codes_by_condition_id_db(id=cond.id, db=db)
-            for code_obj in codes:
+            for code in codes:
                 writer.writerow(
                     [
                         "TES condition grouper code",
-                        code_obj.system or "",
-                        code_obj.code or "",
-                        code_obj.description or "",
+                        cond.display_name,
+                        code.system,
+                        code.code,
+                        code.description,
                     ]
                 )
-        for custom in config.custom_codes or []:
+        for cc in config.custom_codes or []:
             writer.writerow(
                 [
                     "Custom code",
-                    custom.system_key or "",
-                    custom.code or "",
-                    custom.name or "",
+                    "",  # Custom codes are not associated with a system
+                    cc.system_key,
+                    cc.code,
+                    cc.name,
                 ]
             )
 

--- a/refiner/app/api/v1/configurations/exports.py
+++ b/refiner/app/api/v1/configurations/exports.py
@@ -15,6 +15,7 @@ from app.db.configurations.db import get_configuration_by_id_db
 from app.db.configurations.model import DbConfiguration
 from app.db.pool import AsyncDatabaseConnection, get_db
 from app.db.users.model import DbUser
+from app.services.code_systems import get_all_code_systems_by_key
 
 router = APIRouter(prefix="/{configuration_id}/export")
 
@@ -66,6 +67,9 @@ async def _build_config_csv(
     db: AsyncDatabaseConnection,
 ) -> bytes:
     """Build the CSV export content for a configuration."""
+
+    code_systems = await get_all_code_systems_by_key(db=db)
+
     with StringIO() as csv_text:
         writer = csv.writer(csv_text)
         writer.writerow(
@@ -90,7 +94,7 @@ async def _build_config_csv(
                 [
                     "Custom code",
                     "",
-                    cc.system_key,
+                    code_systems[cc.system_key].display_name,
                     cc.code,
                     cc.name,
                 ]

--- a/refiner/app/api/v1/configurations/exports.py
+++ b/refiner/app/api/v1/configurations/exports.py
@@ -10,7 +10,9 @@ from app.db.conditions.db import (
     get_condition_codes_by_condition_id_db,
     get_included_conditions_db,
 )
+from app.db.conditions.model import DbCondition
 from app.db.configurations.db import get_configuration_by_id_db
+from app.db.configurations.model import DbConfiguration
 from app.db.pool import AsyncDatabaseConnection, get_db
 from app.db.users.model import DbUser
 
@@ -32,9 +34,8 @@ async def get_configuration_export(
     Create a CSV export of a configuration and all associated codes.
     """
 
-    jd = user.jurisdiction_id
     config = await get_configuration_by_id_db(
-        id=configuration_id, jurisdiction_id=jd, db=db
+        id=configuration_id, jurisdiction_id=user.jurisdiction_id, db=db
     )
 
     if not config:
@@ -47,18 +48,31 @@ async def get_configuration_export(
         included_conditions=config.included_conditions, db=db
     )
 
+    csv_bytes = await _build_config_csv(
+        config=config, conditions=included_conditions, db=db
+    )
+    filename = _build_export_filename(config_name=config.name)
+
+    return Response(
+        content=csv_bytes,
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+async def _build_config_csv(
+    config: DbConfiguration,
+    conditions: list[DbCondition],
+    db: AsyncDatabaseConnection,
+) -> bytes:
+    """Build the CSV export content for a configuration."""
     with StringIO() as csv_text:
         writer = csv.writer(csv_text)
         writer.writerow(
-            [
-                "Code Type",
-                "Condition",
-                "Code System",
-                "Code",
-                "Display Name",
-            ]
+            ["Code Type", "Condition", "Code System", "Code", "Display Name"]
         )
-        for cond in included_conditions:
+
+        for cond in conditions:
             codes = await get_condition_codes_by_condition_id_db(id=cond.id, db=db)
             for code in codes:
                 writer.writerow(
@@ -70,27 +84,23 @@ async def get_configuration_export(
                         code.description,
                     ]
                 )
+
         for cc in config.custom_codes or []:
             writer.writerow(
                 [
                     "Custom code",
-                    "",  # Custom codes are not associated with a system
+                    "",
                     cc.system_key,
                     cc.code,
                     cc.name,
                 ]
             )
 
-        csv_bytes = csv_text.getvalue().encode("utf-8")
+        return csv_text.getvalue().encode("utf-8")
 
-    safe_name = config.name.replace(" ", "_")
 
+def _build_export_filename(config_name: str) -> str:
+    """Build a timestamped filename for a configuration export."""
+    safe_name = config_name.replace(" ", "_")
     timestamp = datetime.now().strftime("%m%d%y_%H:%M:%S")
-
-    filename = f"{safe_name}_Code Export_{timestamp}.csv"
-
-    return Response(
-        content=csv_bytes,
-        media_type="text/csv; charset=utf-8",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-    )
+    return f"{safe_name}_Code_Export_{timestamp}.csv"

--- a/refiner/app/api/v1/configurations/exports.py
+++ b/refiner/app/api/v1/configurations/exports.py
@@ -1,5 +1,5 @@
 import csv
-from datetime import UTC, datetime
+from datetime import datetime
 from io import StringIO
 from uuid import UUID
 
@@ -13,7 +13,6 @@ from app.db.conditions.db import (
 from app.db.configurations.db import get_configuration_by_id_db
 from app.db.pool import AsyncDatabaseConnection, get_db
 from app.db.users.model import DbUser
-from app.services.configuration_locks import ConfigurationLock
 
 router = APIRouter(prefix="/{configuration_id}/export")
 
@@ -33,33 +32,21 @@ async def get_configuration_export(
     Create a CSV export of a configuration and all associated codes.
     """
 
-    # --- Validate configuration ---
     jd = user.jurisdiction_id
     config = await get_configuration_by_id_db(
         id=configuration_id, jurisdiction_id=jd, db=db
     )
+
     if not config:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Configuration not found.",
         )
 
-    lock = await ConfigurationLock.get_lock(configuration_id, db)
-    if (
-        lock
-        and str(lock.user_id) != str(user.id)
-        and lock.expires_at.timestamp() > datetime.now(UTC).timestamp()
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=f"{user.username}/{user.email} currently has this configuration open.",
-        )
-    # Determine included conditions
     included_conditions = await get_included_conditions_db(
         included_conditions=config.included_conditions, db=db
     )
 
-    # Write CSV to StringIO (text)
     with StringIO() as csv_text:
         writer = csv.writer(csv_text)
         writer.writerow(
@@ -96,13 +83,10 @@ async def get_configuration_export(
 
         csv_bytes = csv_text.getvalue().encode("utf-8")
 
-    # Replace spaces with underscores in the config name
     safe_name = config.name.replace(" ", "_")
 
-    # Format current date/time as YYMMDD HH:MM:SS
     timestamp = datetime.now().strftime("%m%d%y_%H:%M:%S")
 
-    # Build final filename
     filename = f"{safe_name}_Code Export_{timestamp}.csv"
 
     return Response(

--- a/refiner/app/api/v1/configurations/exports.py
+++ b/refiner/app/api/v1/configurations/exports.py
@@ -1,5 +1,5 @@
 import csv
-from datetime import datetime
+from datetime import UTC, datetime
 from io import StringIO
 from logging import Logger
 from uuid import UUID
@@ -119,5 +119,5 @@ async def _build_config_csv(
 def _build_export_filename(config_name: str) -> str:
     """Build a timestamped filename for a configuration export."""
     safe_name = config_name.replace(" ", "_")
-    timestamp = datetime.now().strftime("%m%d%y_%H:%M:%S")
+    timestamp = datetime.now(UTC).strftime("%m%d%y_%H_%M_%S")
     return f"{safe_name}_Code_Export_{timestamp}.csv"

--- a/refiner/app/api/v1/configurations/exports.py
+++ b/refiner/app/api/v1/configurations/exports.py
@@ -1,6 +1,7 @@
 import csv
 from datetime import datetime
 from io import StringIO
+from logging import Logger
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
@@ -16,6 +17,7 @@ from app.db.configurations.model import DbConfiguration
 from app.db.pool import AsyncDatabaseConnection, get_db
 from app.db.users.model import DbUser
 from app.services.code_systems import get_all_code_systems_by_key
+from app.services.logger import get_logger
 
 router = APIRouter(prefix="/{configuration_id}/export")
 
@@ -29,6 +31,7 @@ router = APIRouter(prefix="/{configuration_id}/export")
 async def get_configuration_export(
     configuration_id: UUID,
     user: DbUser = Depends(get_logged_in_user),
+    logger: Logger = Depends(get_logger),
     db: AsyncDatabaseConnection = Depends(get_db),
 ) -> Response:
     """
@@ -50,8 +53,9 @@ async def get_configuration_export(
     )
 
     csv_bytes = await _build_config_csv(
-        config=config, conditions=included_conditions, db=db
+        config=config, conditions=included_conditions, logger=logger, db=db
     )
+
     filename = _build_export_filename(config_name=config.name)
 
     return Response(
@@ -64,6 +68,7 @@ async def get_configuration_export(
 async def _build_config_csv(
     config: DbConfiguration,
     conditions: list[DbCondition],
+    logger: Logger,
     db: AsyncDatabaseConnection,
 ) -> bytes:
     """Build the CSV export content for a configuration."""
@@ -90,11 +95,19 @@ async def _build_config_csv(
                 )
 
         for cc in config.custom_codes or []:
+            code_system = code_systems.get(cc.system_key)
+            if code_system is None:
+                logger.warning(
+                    "Could not find code system for custom code, skipping",
+                    extra={"system_key": cc.system_key, "code": cc.code},
+                )
+                continue
+
             writer.writerow(
                 [
                     "Custom code",
                     "",
-                    code_systems[cc.system_key].display_name,
+                    code_system.display_name,
                     cc.code,
                     cc.name,
                 ]

--- a/refiner/tests/integration/test_export.py
+++ b/refiner/tests/integration/test_export.py
@@ -7,7 +7,6 @@ from fastapi import status
 
 from app.db.code_systems.db import get_all_code_systems_db
 from app.db.conditions.db import get_condition_codes_by_condition_id_db
-from app.db.configurations.model import DbConfigurationCustomCode
 
 
 @pytest.mark.integration
@@ -40,7 +39,7 @@ class TestConfigurationExport:
             cd_header,
         ), f"Unexpected Content-Disposition: {cd_header!r}"
 
-    async def test_export_with_multiple_codesets(
+    async def test_export_includes_all_codes_from_multiple_codesets(
         self,
         setup,
         authed_client,
@@ -48,10 +47,42 @@ class TestConfigurationExport:
         create_config,
         associate_codeset,
         db_pool,
-        add_custom_code,
     ):
         """
         CSV export should include all codes from primary and associated code sets.
+        """
+        amebiasis_id = await get_condition_id("Amebiasis")
+        config = await create_config(amebiasis_id)
+        config_id = config["id"]
+
+        byssinosis_id = await get_condition_id("Byssinosis")
+        await associate_codeset(config_id, byssinosis_id)
+
+        amebiasis_codes = await get_condition_codes_by_condition_id_db(
+            id=amebiasis_id, db=db_pool
+        )
+        byssinosis_codes = await get_condition_codes_by_condition_id_db(
+            id=byssinosis_id, db=db_pool
+        )
+        expected_code_rows = len(amebiasis_codes) + len(byssinosis_codes)
+
+        response = await authed_client.get(f"/api/v1/configurations/{config_id}/export")
+        assert response.status_code == status.HTTP_200_OK
+
+        content = response.text
+        lines = [line for line in content.splitlines() if line.strip()]
+        assert len(lines) == expected_code_rows + 1  # header + codes
+
+    async def test_export_csv_conditions_column_correct(
+        self,
+        setup,
+        authed_client,
+        get_condition_id,
+        create_config,
+        associate_codeset,
+    ):
+        """
+        CSV "Condition" column should only contain the associated condition names.
         """
 
         amebiasis_id = await get_condition_id("Amebiasis")
@@ -61,60 +92,43 @@ class TestConfigurationExport:
         byssinosis_id = await get_condition_id("Byssinosis")
         await associate_codeset(config_id, byssinosis_id)
 
-        # Get codes for both conditions
-        amebiasis_codes = await get_condition_codes_by_condition_id_db(
-            id=amebiasis_id, db=db_pool
-        )
-
-        byssinosis_codes = await get_condition_codes_by_condition_id_db(
-            id=byssinosis_id, db=db_pool
-        )
-
-        await add_custom_code(
-            config_id,
-            DbConfigurationCustomCode(
-                code="mock code",
-                system_key="loinc",
-                name="mock code name",
-            ),
-        )
-
-        # add 1 for custom code
-        expected_code_rows = len(amebiasis_codes) + len(byssinosis_codes) + 1
-
         response = await authed_client.get(f"/api/v1/configurations/{config_id}/export")
         assert response.status_code == status.HTTP_200_OK
 
-        content = response.text
-        lines = [line for line in content.splitlines() if line.strip()]
+        reader = csv.DictReader(StringIO(response.text))
+        column_name = "Condition"
+        conditions_in_csv = {row[column_name] for row in reader if row[column_name]}
 
-        # Header + data rows (should have header + all codes)
-        assert len(lines) == expected_code_rows + 1, (
-            f"Expected {expected_code_rows + 1} rows (header + codes), got {len(lines)}"
+        assert conditions_in_csv == {"Amebiasis", "Byssinosis"}
+
+    async def test_export_csv_code_systems_valid(
+        self,
+        setup,
+        authed_client,
+        get_condition_id,
+        create_config,
+        db_pool,
+    ):
+        """
+        CSV "Code System" column should only contain valid system names.
+        """
+        condition_id = await get_condition_id("Amebiasis")
+        config = await create_config(condition_id)
+
+        response = await authed_client.get(
+            f"/api/v1/configurations/{config['id']}/export"
         )
+        assert response.status_code == status.HTTP_200_OK
 
-        reader = csv.DictReader(StringIO(content))
-        conditions_in_csv = set()
-        code_systems_in_csv = set()
-
-        for row in reader:
-            if row["Condition"]:
-                conditions_in_csv.add(row["Condition"])
-            if row["Code System"]:
-                code_systems_in_csv.add(row["Code System"])
-
-        assert len(code_systems_in_csv) > 0
+        reader = csv.DictReader(StringIO(response.text))
+        column_name = "Code System"
+        code_systems_in_csv = {row[column_name] for row in reader if row[column_name]}
 
         code_systems = await get_all_code_systems_db(db=db_pool)
-        expected_code_systems = {cs.display_name for cs in code_systems.values()}
+        expected_systems = {cs.display_name for cs in code_systems.values()}
 
-        assert code_systems_in_csv.issubset(expected_code_systems), (
-            f"Found invalid code systems in CSV: {code_systems_in_csv - expected_code_systems}"
-        )
-
-        assert conditions_in_csv == {"Amebiasis", "Byssinosis"}, (
-            f"Expected only Amebiasis and Byssinosis, got {conditions_in_csv}"
-        )
+        # csv systems must be a subset of the expected systems set
+        assert code_systems_in_csv <= expected_systems
 
     async def test_export_csv_body_is_non_empty(
         self, setup, authed_client, get_condition_id, create_config

--- a/refiner/tests/integration/test_export.py
+++ b/refiner/tests/integration/test_export.py
@@ -38,7 +38,7 @@ class TestConfigurationExport:
 
         cd_header = response.headers.get("content-disposition", "")
         assert re.search(
-            r'filename=".+_Code_Export_\d{6}_\d{2}:\d{2}:\d{2}\.csv"',
+            r'filename=".+_Code_Export_\d{6}_\d{2}_\d{2}_\d{2}\.csv"',
             cd_header,
         ), f"Unexpected Content-Disposition: {cd_header!r}"
 

--- a/refiner/tests/integration/test_export.py
+++ b/refiner/tests/integration/test_export.py
@@ -7,13 +7,16 @@ from fastapi import status
 
 from app.db.code_systems.db import get_all_code_systems_db
 from app.db.conditions.db import get_condition_codes_by_condition_id_db
+from app.db.configurations.model import DbConfigurationCustomCode
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
 class TestConfigurationExport:
     async def test_export_returns_404_for_unknown_id(self, setup, authed_client):
-        """Endpoint must return 404 for a config ID that does not exist."""
+        """
+        Endpoint must return 404 for a config ID that does not exist.
+        """
         dummy_id = "00000000-0000-0000-0000-000000000000"
         response = await authed_client.get(f"/api/v1/configurations/{dummy_id}/export")
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -108,16 +111,25 @@ class TestConfigurationExport:
         get_condition_id,
         create_config,
         db_pool,
+        add_custom_code,
     ):
         """
         CSV "Code System" column should only contain valid system names.
         """
         condition_id = await get_condition_id("Amebiasis")
         config = await create_config(condition_id)
+        config_id = config["id"]
 
-        response = await authed_client.get(
-            f"/api/v1/configurations/{config['id']}/export"
+        await add_custom_code(
+            config_id,
+            DbConfigurationCustomCode(
+                code="MOCK-CODE-001",
+                system_key="loinc",
+                name="Mock custom code",
+            ),
         )
+
+        response = await authed_client.get(f"/api/v1/configurations/{config_id}/export")
         assert response.status_code == status.HTTP_200_OK
 
         reader = csv.DictReader(StringIO(response.text))
@@ -129,6 +141,41 @@ class TestConfigurationExport:
 
         # csv systems must be a subset of the expected systems set
         assert code_systems_in_csv <= expected_systems
+
+    async def test_export_custom_codes_have_blank_code_system(
+        self,
+        setup,
+        authed_client,
+        get_condition_id,
+        create_config,
+        add_custom_code,
+        db_pool,
+    ):
+        """
+        Custom code rows should have a blank "Condition" column.
+        """
+        condition_id = await get_condition_id("Amebiasis")
+        config = await create_config(condition_id)
+        config_id = config["id"]
+
+        await add_custom_code(
+            config_id,
+            DbConfigurationCustomCode(
+                code="MOCK-CODE-001",
+                system_key="loinc",
+                name="Mock custom code",
+            ),
+        )
+
+        response = await authed_client.get(f"/api/v1/configurations/{config_id}/export")
+        assert response.status_code == status.HTTP_200_OK
+
+        reader = csv.DictReader(StringIO(response.text))
+        for row in reader:
+            if row["Code Type"] == "Custom code":
+                assert row["Condition"] == "", (
+                    f"Expected blank Code System for custom code, got {row['Code System']!r}"
+                )
 
     async def test_export_csv_body_is_non_empty(
         self, setup, authed_client, get_condition_id, create_config

--- a/refiner/tests/integration/test_export.py
+++ b/refiner/tests/integration/test_export.py
@@ -149,7 +149,6 @@ class TestConfigurationExport:
         get_condition_id,
         create_config,
         add_custom_code,
-        db_pool,
     ):
         """
         Custom code rows should have a blank "Condition" column.

--- a/refiner/tests/integration/test_export.py
+++ b/refiner/tests/integration/test_export.py
@@ -30,7 +30,7 @@ class TestConfigurationExport:
 
         cd_header = response.headers.get("content-disposition", "")
         assert re.search(
-            r'filename=".+_Code Export_\d{6}_\d{2}:\d{2}:\d{2}\.csv"',
+            r'filename=".+_Code_Export_\d{6}_\d{2}:\d{2}:\d{2}\.csv"',
             cd_header,
         ), f"Unexpected Content-Disposition: {cd_header!r}"
 

--- a/refiner/tests/integration/test_export.py
+++ b/refiner/tests/integration/test_export.py
@@ -1,7 +1,13 @@
+import csv
 import re
+from io import StringIO
 
 import pytest
 from fastapi import status
+
+from app.db.code_systems.db import get_all_code_systems_db
+from app.db.conditions.db import get_condition_codes_by_condition_id_db
+from app.db.configurations.model import DbConfigurationCustomCode
 
 
 @pytest.mark.integration
@@ -33,6 +39,82 @@ class TestConfigurationExport:
             r'filename=".+_Code_Export_\d{6}_\d{2}:\d{2}:\d{2}\.csv"',
             cd_header,
         ), f"Unexpected Content-Disposition: {cd_header!r}"
+
+    async def test_export_with_multiple_codesets(
+        self,
+        setup,
+        authed_client,
+        get_condition_id,
+        create_config,
+        associate_codeset,
+        db_pool,
+        add_custom_code,
+    ):
+        """
+        CSV export should include all codes from primary and associated code sets.
+        """
+
+        amebiasis_id = await get_condition_id("Amebiasis")
+        config = await create_config(amebiasis_id)
+        config_id = config["id"]
+
+        byssinosis_id = await get_condition_id("Byssinosis")
+        await associate_codeset(config_id, byssinosis_id)
+
+        # Get codes for both conditions
+        amebiasis_codes = await get_condition_codes_by_condition_id_db(
+            id=amebiasis_id, db=db_pool
+        )
+
+        byssinosis_codes = await get_condition_codes_by_condition_id_db(
+            id=byssinosis_id, db=db_pool
+        )
+
+        await add_custom_code(
+            config_id,
+            DbConfigurationCustomCode(
+                code="mock code",
+                system_key="loinc",
+                name="mock code name",
+            ),
+        )
+
+        # add 1 for custom code
+        expected_code_rows = len(amebiasis_codes) + len(byssinosis_codes) + 1
+
+        response = await authed_client.get(f"/api/v1/configurations/{config_id}/export")
+        assert response.status_code == status.HTTP_200_OK
+
+        content = response.text
+        lines = [line for line in content.splitlines() if line.strip()]
+
+        # Header + data rows (should have header + all codes)
+        assert len(lines) == expected_code_rows + 1, (
+            f"Expected {expected_code_rows + 1} rows (header + codes), got {len(lines)}"
+        )
+
+        reader = csv.DictReader(StringIO(content))
+        conditions_in_csv = set()
+        code_systems_in_csv = set()
+
+        for row in reader:
+            if row["Condition"]:
+                conditions_in_csv.add(row["Condition"])
+            if row["Code System"]:
+                code_systems_in_csv.add(row["Code System"])
+
+        assert len(code_systems_in_csv) > 0
+
+        code_systems = await get_all_code_systems_db(db=db_pool)
+        expected_code_systems = {cs.display_name for cs in code_systems.values()}
+
+        assert code_systems_in_csv.issubset(expected_code_systems), (
+            f"Found invalid code systems in CSV: {code_systems_in_csv - expected_code_systems}"
+        )
+
+        assert conditions_in_csv == {"Amebiasis", "Byssinosis"}, (
+            f"Expected only Amebiasis and Byssinosis, got {conditions_in_csv}"
+        )
 
     async def test_export_csv_body_is_non_empty(
         self, setup, authed_client, get_condition_id, create_config


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR:

- Updates the code set table's header from `Condition` to `Display name`
- Updates the configuration CSV export
  - Removes the restriction that prevents users from downloading a configuration export when config is locked by another user
  - Adds a `Condition` column that includes the condition grouper's name (unless it's a custom code, then it's blank)
  - Fixed an issue where the `system_key` value for custom codes was being added to the document instead of system name
  - Refactoring / cleanup (add functions, remove unneeded comments, etc.)
- Additions / improvements to tests 

## 🔗 Related Issue

Fixes #1278 
- #1278 

## 🧪 How to test

- Check that you now see `Display name` instead of `Condition` when looking at the code set table
- Verify that the configuration export CSV downloads and appears as expected