### PR TITLE
fix: e2e a11y checks are too limited

### DIFF
--- a/client/e2e/activity-log.spec.ts
+++ b/client/e2e/activity-log.spec.ts
@@ -10,7 +10,11 @@ test.describe('Activity log', () => {
     await deleteAllConfigurations();
   });
 
-  test('Check empty state', async ({ activityLogPage, page, makeAxeBuilder }) => {
+  test('Check empty state', async ({
+    activityLogPage,
+    page,
+    makeAxeBuilder,
+  }) => {
     await activityLogPage.goto();
 
     await expect(page.getByLabel('Condition').getByRole('option')).toHaveText([
@@ -29,7 +33,7 @@ test.describe('Activity log', () => {
     activityLogPage,
     api,
     page,
-    makeAxeBuilder
+    makeAxeBuilder,
   }) => {
     const conditionOne = 'Coal Workers’ Pneumoconiosis (CWP)';
     const conditionTwo = 'COVID-19';
@@ -51,7 +55,7 @@ test.describe('Activity log', () => {
   test('Check entries from configuration creation', async ({
     activityLogPage,
     api,
-    makeAxeBuilder
+    makeAxeBuilder,
   }) => {
     const conditionOne = 'COVID-19';
     const conditionTwo = 'Zika Virus Disease';
@@ -81,7 +85,7 @@ test.describe('Activity log', () => {
     page,
     api,
     activityLogPage,
-    makeAxeBuilder
+    makeAxeBuilder,
   }) => {
     const condition = 'Lead in Blood';
     const config = await api.createConfiguration(condition);

--- a/client/e2e/activity-log.spec.ts
+++ b/client/e2e/activity-log.spec.ts
@@ -10,7 +10,7 @@ test.describe('Activity log', () => {
     await deleteAllConfigurations();
   });
 
-  test('Check empty state', async ({ activityLogPage, page }) => {
+  test('Check empty state', async ({ activityLogPage, page, makeAxeBuilder }) => {
     await activityLogPage.goto();
 
     await expect(page.getByLabel('Condition').getByRole('option')).toHaveText([
@@ -22,12 +22,14 @@ test.describe('Activity log', () => {
     await expect(
       page.getByRole('navigation', { name: 'Pagination' }).getByRole('button')
     ).toHaveCount(1);
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 
   test('Check that condition filters are sorted alphabetically by name', async ({
     activityLogPage,
     api,
     page,
+    makeAxeBuilder
   }) => {
     const conditionOne = 'Coal Workers’ Pneumoconiosis (CWP)';
     const conditionTwo = 'COVID-19';
@@ -43,11 +45,13 @@ test.describe('Activity log', () => {
       conditionTwo,
       conditionThree,
     ]);
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 
   test('Check entries from configuration creation', async ({
     activityLogPage,
     api,
+    makeAxeBuilder
   }) => {
     const conditionOne = 'COVID-19';
     const conditionTwo = 'Zika Virus Disease';
@@ -70,12 +74,14 @@ test.describe('Activity log', () => {
     await activityLogPage.selectConditionFromDropdown(conditionOne);
     const conditionOneOnlyRows = await activityLogPage.getTableRows();
     expect(conditionOneOnlyRows).toHaveLength(1);
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 
   test('Check individual custom code entries from CSV upload', async ({
     page,
     api,
     activityLogPage,
+    makeAxeBuilder
   }) => {
     const condition = 'Lead in Blood';
     const config = await api.createConfiguration(condition);
@@ -99,6 +105,7 @@ test.describe('Activity log', () => {
     expect(expectedRow?.action).toContain(expectedAction);
 
     const modalButton = page.getByRole('button', { name: 'View all' });
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
     await expect(modalButton).toBeVisible();
     await expect(modalButton).toBeEnabled();
     await modalButton.click();
@@ -126,5 +133,6 @@ test.describe('Activity log', () => {
     await expect(
       page.getByRole('heading', { name: 'Activity log' })
     ).toBeVisible();
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 });

--- a/client/e2e/configuration.spec.ts
+++ b/client/e2e/configuration.spec.ts
@@ -272,6 +272,9 @@ test.describe('Configuration detail flow', () => {
     await test.step('Configure standard sections', async () => {
       await test.step('Select and check options', async () => {
         await page.getByRole('button', { name: 'Sections' }).click();
+
+        await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
         const admissionDiagnosisCheckboxText = 'Include Admission Diagnosis';
         await page
           .getByRole('checkbox', { name: admissionDiagnosisCheckboxText })

--- a/client/e2e/configuration.spec.ts
+++ b/client/e2e/configuration.spec.ts
@@ -356,6 +356,8 @@ test.describe('Configuration detail flow', () => {
       await configurationPage.goToBuildTab();
       await configurationPage.deleteCodeSet(additionalCodeSetName);
 
+      await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
       await page.getByRole('button', { name: 'Custom codes' }).click();
       await configurationPage.deleteCustomCode(customCodeName);
       await expect(page.getByText('Deleted code')).toBeVisible();
@@ -366,6 +368,9 @@ test.describe('Configuration detail flow', () => {
 
     await test.step('Delete custom section', async () => {
       await page.getByRole('button', { name: 'Sections' }).click();
+
+      await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
       await page
         .getByRole('button', {
           name: `Delete custom section ${customSectionName}`,
@@ -405,7 +410,11 @@ test.describe('Configuration detail flow', () => {
 
     await test.step('Upload custom code CSV', async () => {
       await page.getByRole('button', { name: 'Custom codes' }).click();
+      await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
       await page.getByRole('button', { name: 'Import from CSV' }).click();
+      await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
       await expect(
         page.getByRole('heading', {
           name: 'Import from CSV',
@@ -422,6 +431,9 @@ test.describe('Configuration detail flow', () => {
       const deleteAllButton = page.getByRole('button', {
         name: 'Undo & delete codes',
       });
+
+      await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
       await expect(saveAllButton).toBeVisible();
       await expect(deleteAllButton).toBeVisible();
 
@@ -441,6 +453,8 @@ test.describe('Configuration detail flow', () => {
       await expect(deleteButton).toBeVisible();
 
       await editButton.click();
+      await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
       await expect(
         page.getByRole('heading', { name: 'Edit 12345', level: 2 })
       ).toBeVisible();
@@ -475,6 +489,8 @@ test.describe('Configuration detail flow', () => {
           level: 2,
         })
       ).toBeVisible();
+      await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
       await page.getByRole('button', { name: 'Yes, save codes' }).click();
 
       const savedCodeTableRows = page.locator('table tbody tr');
@@ -486,6 +502,8 @@ test.describe('Configuration detail flow', () => {
 
     await test.step('Activate modified draft', async () => {
       await configurationPage.goToActivateTab();
+      await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
       await expect(page.getByText('Switch to version 2')).toBeVisible();
       await expect(page.getByText('Turn off configuration')).toBeVisible();
 

--- a/client/e2e/configurations.spec.ts
+++ b/client/e2e/configurations.spec.ts
@@ -9,7 +9,7 @@ test.describe('Configurations screen', () => {
 
   test.afterEach(async () => await deleteAllConfigurations());
 
-  test('Check empty page state', async ({ page }) => {
+  test('Check empty page state', async ({ page, makeAxeBuilder }) => {
     await expect(
       page.getByRole('heading', {
         name: 'Configurations',
@@ -25,12 +25,14 @@ test.describe('Configurations screen', () => {
     await expect(page.getByRole('cell')).toHaveText(
       'No configurations available'
     );
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 
   test('Check table with configurations', async ({
     page,
     api,
     configurationsPage,
+    makeAxeBuilder,
   }) => {
     const config = await api.createConfiguration('Anotia');
 
@@ -46,8 +48,12 @@ test.describe('Configurations screen', () => {
     await configurationsPage.search('ano');
     await expect(conditionCell).toHaveText(config.name);
 
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
     await configurationsPage.search('covid');
     await expect(conditionCell).toHaveText('No configurations available');
+
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
 
     await configurationsPage.clearSearch();
 
@@ -55,11 +61,14 @@ test.describe('Configurations screen', () => {
     await expect(
       page.getByRole('heading', { name: config.name, level: 1 })
     ).toBeVisible();
+
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 
   test('Navigates to the active config when one exists', async ({
     api,
     page,
+    makeAxeBuilder,
   }) => {
     // create and activate config
     const condition = 'Anotia';
@@ -75,11 +84,14 @@ test.describe('Configurations screen', () => {
 
     await expect(page.getByText('Viewing: Version 1')).toBeVisible();
     await expect(page.getByRole('link', { name: 'Go to draft' })).toBeVisible();
+
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 
   test('Navigates to the draft config when only a draft and inactive configs exist', async ({
     api,
     page,
+    makeAxeBuilder,
   }) => {
     // create and activate config
     const condition = 'Anotia';
@@ -96,11 +108,14 @@ test.describe('Configurations screen', () => {
     await page.getByText(condition).click();
 
     await expect(page.getByText('Editing: Version 2')).toBeVisible();
+
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 
   test('Navigates to the latest inactive config when only inactive configs exist', async ({
     api,
     page,
+    makeAxeBuilder,
   }) => {
     // create and activate config
     const condition = 'Anotia';
@@ -117,5 +132,7 @@ test.describe('Configurations screen', () => {
     await page.getByText(condition).click();
 
     await expect(page.getByText('Viewing: Version 2')).toBeVisible();
+
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 });

--- a/client/e2e/fixtures/index.ts
+++ b/client/e2e/fixtures/index.ts
@@ -23,7 +23,9 @@ type Fixtures = {
 const extendedTest = baseTest.extend<Fixtures>({
   makeAxeBuilder: async ({ page }, use) => {
     const makeAxeBuilder = () =>
-      new AxeBuilder({ page }).withTags(['wcag2a', 'wcag21aa']);
+      new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag21aa'])
+        .exclude('#refinement-diff'); // react-diff-viewer has known a11y issues we can't fix ourselves
     await use(makeAxeBuilder);
   },
   api: async ({ request }, use) => {

--- a/client/e2e/fixtures/index.ts
+++ b/client/e2e/fixtures/index.ts
@@ -23,7 +23,7 @@ type Fixtures = {
 const extendedTest = baseTest.extend<Fixtures>({
   makeAxeBuilder: async ({ page }, use) => {
     const makeAxeBuilder = () =>
-      new AxeBuilder({ page }).withTags(['wcag21aa']);
+      new AxeBuilder({ page }).withTags(['wcag2a', 'wcag21aa']);
     await use(makeAxeBuilder);
   },
   api: async ({ request }, use) => {
@@ -47,17 +47,16 @@ const extendedExpect = baseExpect.extend({
   async toHaveNoAxeViolations(makeAxeBuilder: () => AxeBuilder) {
     const assertionName = 'toHaveNoAxeViolations';
     const axe = makeAxeBuilder();
-    let pass: boolean;
+    let pass = false;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let results: any;
+    let violations: any[] = [];
     try {
-      results = await axe.analyze();
+      const results = await axe.analyze();
+      violations = results.violations ?? [];
+      pass = violations.length === 0;
     } catch {
       pass = false;
     }
-    const violations = results.violations ?? [];
-
-    pass = violations.length === 0;
 
     const message = pass
       ? () =>

--- a/client/e2e/simulator.spec.ts
+++ b/client/e2e/simulator.spec.ts
@@ -9,8 +9,14 @@ test.describe('Simulate testing', () => {
   });
   test.afterEach(async () => await deleteAllConfigurations());
 
-  test('No available configurations', async ({ page, simulatorPage }) => {
+  test('No available configurations', async ({
+    page,
+    simulatorPage,
+    makeAxeBuilder,
+  }) => {
     await simulatorPage.goto();
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
     await simulatorPage.uploadTestFile();
     await expect(
       page.getByText(
@@ -21,6 +27,8 @@ test.describe('Simulate testing', () => {
     // no configs to select from
     await expect(page.getByRole('checkbox')).toHaveCount(0);
     await expect(page.getByRole('combobox')).toHaveCount(0);
+
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
 
     // only displays a list of conditions that were detected with no matching config
     await expect(
@@ -45,6 +53,7 @@ test.describe('Simulate testing', () => {
   test('Should be able to handle a reasonable amount of configuration options', async ({
     simulatorPage,
     api,
+    makeAxeBuilder,
   }) => {
     for (let i = 0; i < 20; i++) {
       /*
@@ -67,12 +76,15 @@ test.describe('Simulate testing', () => {
     await expect(
       simulatorPage.getConditionSelect('COVID-19').locator('option:checked')
     ).toHaveText('Version 20 (active)');
+
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 
   test('Only COVID-19 has been configured', async ({
     page,
     simulatorPage,
     api,
+    makeAxeBuilder,
   }) => {
     // create config and activate it
     const covid = await api.createConfiguration('COVID-19');
@@ -123,6 +135,8 @@ test.describe('Simulate testing', () => {
       page.getByRole('listitem').getByText('COVID-19')
     ).not.toBeVisible();
 
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
     const refineButton = page.getByRole('button', { name: 'Refine eCR' });
 
     await expect(refineButton).toBeEnabled();
@@ -138,12 +152,15 @@ test.describe('Simulate testing', () => {
     await expect(page.getByLabel('CONDITION:').getByRole('option')).toHaveText([
       'COVID-19',
     ]);
+
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 
   test('Only Influenza is selected for refinement', async ({
     page,
     simulatorPage,
     api,
+    makeAxeBuilder,
   }) => {
     await api.createConfiguration('COVID-19');
     await api.createConfiguration('Influenza');
@@ -159,16 +176,21 @@ test.describe('Simulate testing', () => {
 
     await simulatorPage.getConditionCheckbox('Influenza').click();
 
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
     await simulatorPage.runRefinement();
     await expect(page.getByLabel('CONDITION:').getByRole('option')).toHaveText([
       'COVID-19',
     ]);
+
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 
   test('Refine eCR button is disabled when no selections are made', async ({
     page,
     simulatorPage,
     api,
+    makeAxeBuilder,
   }) => {
     await api.createConfiguration('COVID-19');
     await api.createConfiguration('Influenza');
@@ -195,6 +217,8 @@ test.describe('Simulate testing', () => {
     const refineButton = page.getByRole('button', { name: 'Refine eCR' });
     await expect(refineButton).toBeDisabled();
 
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
     await checkboxes.nth(0).check();
     await expect(refineButton).toBeEnabled();
   });
@@ -203,6 +227,7 @@ test.describe('Simulate testing', () => {
     page,
     simulatorPage,
     api,
+    makeAxeBuilder,
   }) => {
     const covidActive = await api.createConfiguration('COVID-19');
     await api.updateConfigurationStatus(covidActive.id, 'active');
@@ -266,6 +291,8 @@ test.describe('Simulate testing', () => {
       page.getByRole('button', { name: 'Start over' })
     ).toBeEnabled();
 
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
+
     await refineButton.click();
     await expect(
       page.getByRole('heading', { name: 'eCR refinement results' })
@@ -275,5 +302,7 @@ test.describe('Simulate testing', () => {
       'COVID-19',
       'Influenza',
     ]);
+
+    await expect(makeAxeBuilder).toHaveNoAxeViolations();
   });
 });

--- a/client/src/components/Diff/index.tsx
+++ b/client/src/components/Diff/index.tsx
@@ -106,7 +106,7 @@ export function Diff({
       </div>
 
       {renderDiff ? (
-        <div className="relative">
+        <div id="refinement-diff" className="relative">
           <ReactDiffViewer
             oldValue={unrefined_eicr}
             newValue={condition.refined_eicr}

--- a/client/src/pages/Configurations/ConfigBuild/CustomCodes/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CustomCodes/index.tsx
@@ -78,7 +78,7 @@ export function CustomCodesDetail({
 
   return (
     <div role="region">
-      <table id="custom-table" className="mt-6! w-full border-separate">
+      <table className="mt-6! w-full border-separate">
         <thead className="sr-only">
           <tr>
             <th>Custom code</th>
@@ -333,7 +333,6 @@ export function ConditionCodeTable({
         >
           <div
             role="table"
-            id="codeset-table"
             aria-label={`Codes in set with ID ${conditionId}`}
             className="grid grid-cols-[1fr_1fr_4fr]"
           >

--- a/client/src/pages/Configurations/ConfigBuild/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/index.tsx
@@ -258,8 +258,10 @@ function Builder({
                           codeSet.condition_id
                         )
                       }
-                      aria-controls={
-                        selectedCodesetId ? 'codeset-table' : undefined
+                      aria-current={
+                        selectedCodesetId === codeSet.condition_id
+                          ? 'true'
+                          : undefined
                       }
                     />
 
@@ -294,10 +296,7 @@ function Builder({
                       }
                     )}
                     onClick={onCustomCodeClick}
-                    aria-controls={
-                      tableView === 'custom' ? 'custom-table' : undefined
-                    }
-                    aria-pressed={tableView === 'custom'}
+                    aria-current={tableView === 'custom' ? 'true' : undefined}
                   >
                     <span>Custom codes</span>
                     <span>{custom_codes.codes.length.toLocaleString()}</span>
@@ -316,10 +315,7 @@ function Builder({
                       setSelectedCodesetId(null);
                       setTableView('sections');
                     }}
-                    aria-controls={
-                      tableView === 'sections' ? 'sections-table' : undefined
-                    }
-                    aria-pressed={tableView === 'sections'}
+                    aria-current={tableView === 'sections' ? 'true' : undefined}
                   >
                     <span>Sections</span>
                   </Button>


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR:

- Updates the rulesets the Playwright Axe checks use to be closer to the default used by the Axe browser extension
- Excludes the `react-diff-viewer` from a11y checks since it gets flagged and we cannot fix it (noted in a comment)
- Small update to `toHaveNoAxeViolations()`
- Increased a11y checks throughout e2e tests
- Fixed an a11y issue related to the config builder menu

## 🧪 How to test

- Tests and app should work as they did before
- See an [example](https://github.com/CDCgov/dibbs-ecr-refiner/actions/runs/26978095217/job/79610146307) of failing a11y issues in the job report