### PR TITLE
test: use `eslint-plugin-jsx-a11y` for improved a11y checking during development

### DIFF
--- a/client/e2e/pages/ConfigurationPage.ts
+++ b/client/e2e/pages/ConfigurationPage.ts
@@ -50,7 +50,8 @@ export class ConfigurationPage {
     await this.page
       .getByRole('listitem')
       .filter({ hasText: conditionName })
-      .click();
+      .hover();
+    await this.page.getByLabel(`Add ${conditionName}`).click();
     await this.page.getByRole('button', { name: 'Close drawer' }).click();
   }
 

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -4,12 +4,12 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 import eslintConfigPrettier from 'eslint-config-prettier/flat';
-import prettier from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import';
 import { defineConfig } from 'eslint/config';
 import reactPlugin from 'eslint-plugin-react';
 import testingLibraryPlugin from 'eslint-plugin-testing-library';
 import tanstackQuery from '@tanstack/eslint-plugin-query';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 
 export default defineConfig(
   { ignores: ['dist', 'tests/setup.ts', 'src/api'] },
@@ -18,6 +18,7 @@ export default defineConfig(
       js.configs.recommended,
       eslintConfigPrettier,
       importPlugin.flatConfigs.recommended,
+      jsxA11y.flatConfigs.recommended,
       ...tseslint.configs.recommendedTypeChecked,
     ],
     files: ['**/*.{ts,tsx}'],
@@ -122,7 +123,5 @@ export default defineConfig(
       'react-hooks/rules-of-hooks': 'off',
       'react-hooks/exhaustive-deps': 'off',
     },
-  },
-
-  prettier
+  }
 );

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -50,6 +50,7 @@
         "eslint-config-prettier": "10.1.8",
         "eslint-import-resolver-typescript": "4.4.4",
         "eslint-plugin-import": "2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-prettier": "5.5.5",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "7.1.1",
@@ -176,7 +177,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -534,7 +534,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -583,7 +582,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -594,7 +592,6 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -606,7 +603,6 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1641,13 +1637,15 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
       "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
       "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
@@ -2566,7 +2564,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3163,7 +3160,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3278,7 +3276,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3288,7 +3285,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3297,7 +3293,8 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -3374,7 +3371,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -4095,7 +4091,6 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -4240,7 +4235,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4355,6 +4349,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4574,6 +4569,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ast-v8-to-istanbul": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
@@ -4645,6 +4647,16 @@
         "form-data": "^4.0.5",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -4792,7 +4804,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5111,7 +5122,6 @@
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -5248,6 +5258,13 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -5464,7 +5481,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5492,6 +5510,7 @@
       "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz",
       "integrity": "sha512-QCqAWP3kwj8Gz9UXncVXQGdrhnWxD8SQBSeZp5pOsyCcQ6RpL738L1/tfuwBiMi6F1fYkxqPnBrFBR4L+f49Cg==",
       "license": "CC0-1.0",
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5802,7 +5821,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5863,7 +5881,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5990,7 +6007,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6068,6 +6084,84 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -6667,7 +6761,6 @@
       "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-11.0.6.tgz",
       "integrity": "sha512-8YbWR8kDf2pQ8G9LT11p39VY4T7eWVrj00Fhp1HUSdv5uW9q6+WK8OMAdy9Ui7vGb1zNouFDzwBIqJwt82rIYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "focus-trap": "^7.8.0",
         "tabbable": "^6.4.0"
@@ -8151,7 +8244,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.1.0.tgz",
       "integrity": "sha512-NTDqo7XhzL1fqmUzYroiyK2qGua7sOMzLav35BfNA/mPUSCtw8pZghHFMTYR9JdnJ23IQz695FcaM6EE6bpbFQ==",
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -8161,6 +8255,26 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/leven": {
@@ -8470,6 +8584,7 @@
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
       "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -8481,6 +8596,7 @@
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
       "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
@@ -8492,6 +8608,7 @@
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
       "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -8565,6 +8682,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8651,7 +8769,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
       "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -10116,7 +10235,6 @@
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10252,7 +10370,6 @@
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -10372,7 +10489,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10481,6 +10597,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10597,7 +10714,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10649,7 +10765,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10662,7 +10777,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -10771,6 +10887,7 @@
       "resolved": "https://registry.npmjs.org/receptor/-/receptor-1.0.0.tgz",
       "integrity": "sha512-yvVEqVQDNzEmGkluCkEdbKSXqZb3WGxotI/VukXIQ+4/BXEeXVjWtmC6jWaR1BIsmEAGYQy3OTaNgDj2Svr01w==",
       "license": "CC0-1.0",
+      "peer": true,
       "dependencies": {
         "element-closest": "^2.0.1",
         "keyboardevent-key-polyfill": "^1.0.2",
@@ -11387,6 +11504,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -11879,6 +11997,21 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -12228,7 +12361,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12487,7 +12619,6 @@
       "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -12538,7 +12669,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12762,7 +12892,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.4"
       },
@@ -12896,7 +13025,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12987,7 +13115,6 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",
@@ -13445,7 +13572,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -63,6 +63,7 @@
     "eslint-config-prettier": "10.1.8",
     "eslint-import-resolver-typescript": "4.4.4",
     "eslint-plugin-import": "2.32.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "5.5.5",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.1.1",

--- a/client/src/components/ConfigurationsTable/index.tsx
+++ b/client/src/components/ConfigurationsTable/index.tsx
@@ -22,7 +22,7 @@ export function ConfigurationsTable({ data }: ConfigurationsTableProps) {
         </thead>
         <tbody>
           <tr>
-            <td data-label={reportableConditionHeader} scope="row">
+            <td data-label={reportableConditionHeader}>
               No configurations available
             </td>
           </tr>
@@ -47,7 +47,6 @@ export function ConfigurationsTable({ data }: ConfigurationsTableProps) {
               <td
                 data-label={reportableConditionHeader}
                 className="p-0! font-bold!"
-                scope="row"
               >
                 <Link
                   aria-label={`Configure ${name}`}

--- a/client/src/components/Drawer/index.test.tsx
+++ b/client/src/components/Drawer/index.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@trussworks/react-uswds', () => ({
   ) => <input {...props} />,
 }));
 vi.mock('focus-trap-react', () => ({
-  default: ({ children }: any) => <div>{children}</div>,
+  FocusTrap: ({ children }: any) => <div>{children}</div>,
 }));
 
 // Initial setup

--- a/client/src/components/Drawer/index.tsx
+++ b/client/src/components/Drawer/index.tsx
@@ -7,7 +7,7 @@
  * filtering for child content.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import FocusTrap from 'focus-trap-react';
+import { FocusTrap } from 'focus-trap-react';
 import { Icon } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 import { Search } from '../Search';

--- a/client/src/components/Drawer/index.tsx
+++ b/client/src/components/Drawer/index.tsx
@@ -61,12 +61,13 @@ export function Drawer({
       focusTrapOptions={{
         onDeactivate: handleClose,
         escapeDeactivates: true,
+        clickOutsideDeactivates: true,
       }}
     >
       <div>
         <div
           className={classNames(
-            'bg-gray-2 fixed top-0 z-[11049] flex h-full w-full shrink-0 flex-col items-start gap-6 border-l border-solid border-gray-400 p-0 shadow-2xl transition-all duration-300 ease-linear',
+            'bg-gray-2 fixed top-0 z-11049 flex h-full w-full shrink-0 flex-col items-start gap-6 border-l border-solid border-gray-400 p-0 shadow-2xl transition-all duration-300 ease-linear',
             {
               'pointer-events-auto right-0 opacity-100': isOpen,
               'pointer-events-none right-[-60%] opacity-0': !isOpen,
@@ -92,7 +93,7 @@ export function Drawer({
               <section className="p-4">
                 <Title>{title}</Title>
                 {subtitle ? (
-                  <div className="m-0 !py-4 text-gray-600">{subtitle}</div>
+                  <div className="m-0 py-4 text-gray-600">{subtitle}</div>
                 ) : null}
                 {onSearch ? (
                   <>

--- a/client/src/components/Drawer/index.tsx
+++ b/client/src/components/Drawer/index.tsx
@@ -107,17 +107,9 @@ export function Drawer({
                 ) : null}
               </section>
             </div>
-
             <div className="flex flex-col">{children}</div>
           </div>
         </div>
-
-        {isOpen && (
-          <div
-            className="fixed top-0 left-0 z-[11039] h-full w-full"
-            onClick={handleClose}
-          ></div>
-        )}
       </div>
     </FocusTrap>
   );

--- a/client/src/pages/Configurations/ConfigBuild/ConditionCodeSetListItem.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/ConditionCodeSetListItem.tsx
@@ -118,17 +118,8 @@ export function ConditionCodeSetListItem({
   return (
     <li
       className={classNames(
-        'flex h-16 items-center justify-between rounded-md p-4 hover:bg-white',
-        {
-          'cursor-pointer': !isDefault,
-        }
+        'flex h-16 items-center justify-between rounded-md p-4 hover:bg-white'
       )}
-      role="listitem"
-      onClick={(e) => {
-        e.stopPropagation();
-        if (isDefault) return;
-        onClick(condition.associated);
-      }}
       onMouseEnter={() => setShowButton(true)}
       onMouseLeave={() => {
         if (!condition.associated) setShowButton(false);
@@ -136,13 +127,6 @@ export function ConditionCodeSetListItem({
       onFocus={() => setShowButton(true)}
       onBlur={() => {
         if (!condition.associated) setShowButton(false);
-      }}
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter') {
-          e.preventDefault();
-          onClick(condition.associated);
-        }
       }}
     >
       <p>{highlight ? <>{highlight}</> : condition.display_name}</p>

--- a/client/src/pages/Configurations/ConfigBuild/ConditionCodeSetListItem.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/ConditionCodeSetListItem.tsx
@@ -124,30 +124,19 @@ export function ConditionCodeSetListItem({
     >
       <p>{highlight ? <>{highlight}</> : condition.display_name}</p>
       {isDefault ? (
-        <span className="text-bold mr-0! w-20! text-black">Default</span>
-      ) : condition.associated ? (
-        <Button
-          variant="secondary"
-          aria-pressed={true}
-          aria-label={`Remove ${condition.display_name}`}
-          className="mr-0! w-20!"
-          onClick={() => onClick(condition.associated)}
-          disabled={disabled}
-        >
-          Remove
-        </Button>
+        <span className="text-bold mr-3 text-black">Default</span>
       ) : (
         <Button
-          variant="primary"
-          aria-pressed={false}
-          aria-label={`Add ${condition.display_name}`}
+          variant={condition.associated ? 'secondary' : 'primary'}
+          aria-pressed={condition.associated}
+          aria-label={`${condition.associated ? 'Remove' : 'Add'} ${condition.display_name}`}
           className={classNames('mr-0! w-20!', {
-            'sr-only!': !showButton,
+            'sr-only!': !showButton && !condition.associated,
           })}
           onClick={() => onClick(condition.associated)}
           disabled={disabled}
         >
-          Add
+          {condition.associated ? 'Remove' : 'Add'}
         </Button>
       )}
     </li>

--- a/client/src/pages/Configurations/ConfigBuild/ConditionCodeSetListItem.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/ConditionCodeSetListItem.tsx
@@ -26,8 +26,6 @@ export function ConditionCodeSetListItem({
   reportable_condition_display_name,
   disabled,
 }: ConditionCodeSetListItemProps) {
-  const [showButton, setShowButton] = useState(false);
-
   const { mutate: associateMutation } =
     useAssociateConditionWithConfiguration();
   const { mutate: disassociateMutation } =
@@ -37,11 +35,7 @@ export function ConditionCodeSetListItem({
   const queryClient = useQueryClient();
   const formatError = useApiErrorFormatter();
 
-  const [prevAssociation, setPrevAssociation] = useState(condition.associated);
-  if (prevAssociation !== condition.associated) {
-    setPrevAssociation(condition.associated);
-    setShowButton(condition.associated);
-  }
+  const [showButton, setShowButton] = useState(false);
 
   function handleAssociate() {
     associateMutation(
@@ -110,7 +104,6 @@ export function ConditionCodeSetListItem({
     } else {
       handleAssociate();
     }
-    setShowButton(true);
   }
 
   const isDefault =
@@ -121,50 +114,42 @@ export function ConditionCodeSetListItem({
         'flex h-16 items-center justify-between rounded-md p-4 hover:bg-white'
       )}
       onMouseEnter={() => setShowButton(true)}
-      onMouseLeave={() => {
-        if (!condition.associated) setShowButton(false);
-      }}
+      onMouseLeave={() => setShowButton(false)}
       onFocus={() => setShowButton(true)}
-      onBlur={() => {
-        if (!condition.associated) setShowButton(false);
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget)) {
+          setShowButton(false);
+        }
       }}
     >
       <p>{highlight ? <>{highlight}</> : condition.display_name}</p>
-      {showButton ? (
-        isDefault ? (
-          <span className="text-bold mr-0! w-20! text-black">Default</span>
-        ) : condition.associated ? (
-          <Button
-            variant="secondary"
-            aria-pressed={true}
-            aria-label={`Remove ${condition.display_name}`}
-            className="mr-0! w-20!"
-            onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-              e.stopPropagation();
-              onClick(condition.associated);
-            }}
-            tabIndex={-1}
-            disabled={disabled}
-          >
-            Remove
-          </Button>
-        ) : (
-          <Button
-            variant="primary"
-            aria-pressed={false}
-            aria-label={`Add ${condition.display_name}`}
-            className="mr-0! w-20!"
-            onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-              e.stopPropagation();
-              onClick(condition.associated);
-            }}
-            tabIndex={-1}
-            disabled={disabled}
-          >
-            Add
-          </Button>
-        )
-      ) : null}
+      {isDefault ? (
+        <span className="text-bold mr-0! w-20! text-black">Default</span>
+      ) : condition.associated ? (
+        <Button
+          variant="secondary"
+          aria-pressed={true}
+          aria-label={`Remove ${condition.display_name}`}
+          className="mr-0! w-20!"
+          onClick={() => onClick(condition.associated)}
+          disabled={disabled}
+        >
+          Remove
+        </Button>
+      ) : (
+        <Button
+          variant="primary"
+          aria-pressed={false}
+          aria-label={`Add ${condition.display_name}`}
+          className={classNames('mr-0! w-20!', {
+            'sr-only!': !showButton,
+          })}
+          onClick={() => onClick(condition.associated)}
+          disabled={disabled}
+        >
+          Add
+        </Button>
+      )}
     </li>
   );
 }

--- a/client/src/pages/Configurations/ConfigBuild/ConfigLockBanner.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/ConfigLockBanner.tsx
@@ -17,7 +17,6 @@ export function ConfigLockBanner({
     <div
       role="status"
       aria-live="polite"
-      tabIndex={0}
       className={classNames(
         'bg-state-warning-lighter border-b-state-warning! flex w-full flex-col gap-4 px-8 py-4 shadow-lg md:flex-row md:justify-between lg:px-20',
         className

--- a/client/src/pages/Configurations/ConfigBuild/CsvCodeUploadModal.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CsvCodeUploadModal.tsx
@@ -155,7 +155,7 @@ export function PreviewEditModal({
                   setError(null);
                 }
               }}
-              autoFocus
+              autoFocus // eslint-disable-line jsx-a11y/no-autofocus -- focus first input on modal open for keyboard/screen reader users
             />
           </Field>
           {error && <p className="mb-1 text-sm text-red-600">{error}</p>}

--- a/client/src/pages/Configurations/ConfigBuild/CustomCodes/CustomCodeModal.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CustomCodes/CustomCodeModal.tsx
@@ -207,7 +207,7 @@ function CustomCodeForm({
             handleCodeUpdate(e.target.value);
           }}
           onBlur={handleCodeBlur}
-          autoFocus
+          autoFocus // eslint-disable-line jsx-a11y/no-autofocus -- focus first input on modal open for keyboard/screen reader users
         />
       </Field>
       {error && <p className="mb-1 text-sm text-red-600">{error}</p>}

--- a/client/src/pages/Configurations/ConfigBuild/CustomCodes/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CustomCodes/index.tsx
@@ -329,7 +329,9 @@ export function ConditionCodeTable({
         <div
           ref={parentRef}
           className="h-100 overflow-y-auto sm:h-full"
-          tabIndex={0}
+          role="region"
+          aria-label="Code set results"
+          tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex -- scroll container needs focus for keyboard users to scroll virtualized list
         >
           <div
             role="table"

--- a/client/src/pages/Configurations/ConfigBuild/Sections/CustomSectionModal.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/Sections/CustomSectionModal.tsx
@@ -176,7 +176,7 @@ function ModalForm({
               value={name}
               onChange={(e) => setName(e.target.value)}
               type="text"
-              autoFocus
+              autoFocus // eslint-disable-line jsx-a11y/no-autofocus -- focus first input on modal open for keyboard/screen reader users
             />
           </Field>
           <Field className="flex flex-col gap-2">

--- a/client/src/pages/Simulator/RunSimulation.tsx
+++ b/client/src/pages/Simulator/RunSimulation.tsx
@@ -46,7 +46,7 @@ export function RunSimulation({
       <div className="flex flex-col gap-6 xl:flex-row">
         <Container className="flex-1" color="white">
           <Content className="flex items-center gap-6">
-            <img className="px-3 py-1" src={UploadSvg} role="presentation" />
+            <img className="px-3 py-1" src={UploadSvg} alt="" />
             <div className="flex flex-col items-center gap-10">
               <p className="flex flex-col items-center gap-2 text-black">
                 <span className="font-bold">
@@ -131,20 +131,14 @@ function UploadZipFile({
               Refine .zip file
             </Button>
           ) : null}
-          <label
-            htmlFor="zip-upload"
-            aria-label="Open system file browser for simulating"
-            role="button"
+          <Button
+            variant="unstyled"
             className={labelStyling}
-            tabIndex={0}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                inputRef.current?.click();
-              }
-            }}
+            type="button"
+            onClick={() => inputRef.current?.click()}
           >
             {selectedFile ? 'Change file' : 'Upload .zip file'}
-          </label>
+          </Button>
         </div>
         {/* render an autoupload file for QoL in local dev */}
         {env === 'local' ? (


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR aims to improve the dev team's ability to detect potential a11y issues during development. `eslint-plugin-jsx-a11y` has been added to the project and can be run locally with `npm run lint`. It will also run automatically in CI on all PRs/updates.

- Added [`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y)
  - Opted into recommended ruleset 
- Fixed a variety of issues discovered by the plugin
  - Added exceptions for a few non-issues (primarily using `autoFocus` within modals, which is valid)
- Fixed a deprecation notice about not using `focus-trap-react`'s default export
- Improved implementation and usability of condition code set drawer
- Updated tests as needed

## How to test

Main thing to check is the drawer. The `Add` and `Remove` buttons are now the only interactive elements within the list. This should work in a much more polished and expected manner than the previous implementation. It should also eliminate a11y issues related to this component.

Both mouse controls and keyboard controls should work in a very natural way.

Example:
<img width="1023" height="761" alt="Kapture 2026-06-05 at 11 39 17" src="https://github.com/user-attachments/assets/b4cfb171-45aa-4d0f-a877-51bcb91173ef" />

> [!IMPORTANT]
> Tiffany [approves](https://skylight-hq.slack.com/archives/C08QQ1SCDLY/p1780674840295139?thread_ts=1780674305.236949&cid=C08QQ1SCDLY) of the design changes 👍 