### PR TITLE
fix: filter code set by system

### DIFF
--- a/client/e2e/configuration.spec.ts
+++ b/client/e2e/configuration.spec.ts
@@ -27,6 +27,33 @@ test.describe('Configuration detail flow', () => {
     ]);
   });
 
+  test('Code set table can be filtered by code system', async ({
+    page,
+    configurationsPage,
+    configurationPage,
+  }) => {
+    const condition = 'Anotia';
+    await configurationsPage.createConfiguration(condition);
+    await configurationPage.goToBuildTab();
+    await page.getByLabel('View TES code set information for Anotia').click();
+    const codeSystemSelect = page.getByRole('combobox', {
+      name: 'Code system',
+    });
+    await expect(codeSystemSelect).toHaveValue('all');
+    const tableRows = page.getByRole('row');
+    await expect(tableRows).toHaveCount(3); // including header
+
+    await codeSystemSelect.selectOption('ICD-10');
+    const rows = page.getByRole('row');
+    const rowCount = await rows.count();
+
+    for (let i = 1; i < rowCount; i++) {
+      // start at 1 to skip header row
+      const cell = rows.nth(i).getByRole('cell').nth(1); // 2nd column
+      await expect(cell).toHaveText('ICD-10');
+    }
+  });
+
   test('Check code set status and individual grouper statuses', async ({
     page,
     configurationsPage,

--- a/client/src/pages/Configurations/ConfigBuild/CustomCodes/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CustomCodes/index.tsx
@@ -429,7 +429,7 @@ function CodeSystemSelection({
             All code systems
           </option>
           {codeSystems.map((s) => (
-            <option key={s.id} value={s.key}>
+            <option key={s.id} value={s.display_name}>
               {s.display_name}
             </option>
           ))}


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR fixes a regression introduced in #1160. Codes in the code set table were not being filtered by the selected code set. Instead it would show the table as empty.

I've added a new test to check that filtering works as expected.

## 📺  Demo
<img width="1023" height="761" alt="Kapture 2026-06-08 at 12 39 50" src="https://github.com/user-attachments/assets/5e97fb23-5973-4858-a5b7-a603fab02efc" />

## 🧪 How to test

- Filtering code sets by system works as expected
- Automated tests are passing

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
