### PR TITLE
fix(ci): Use the `.venv` for all server recipes;

### DIFF
--- a/.justscripts/just/server.just
+++ b/.justscripts/just/server.just
@@ -11,7 +11,7 @@ alias id := install-dev
 @_default:
     just --list server
 
-set dotenv-load := true
+set dotenv-load
 
 _venv:
     [ -d .venv ] || python3 -m venv .venv
@@ -47,5 +47,5 @@ install-dev: _venv
 
 [doc('Seed Localstack with the infra needed for manual tests')]
 [group('localstack')]
-seed-localstack:
-    python ./tests/localstack/seed.py
+seed-localstack: _venv
+    .venv/bin/python ./tests/localstack/seed.py


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

I was having issues running things deterministically without it referencing the
correct path with our project's .venv like the other commands in this module.

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

You should now be able to run `just server seed-localstack` without any issues
on any system. Test that this command continues to work as intended after this
change.
