### PR TITLE
style: Select component disabled styling

### DIFF
--- a/client/src/components/Select/index.tsx
+++ b/client/src/components/Select/index.tsx
@@ -19,6 +19,7 @@ export function Select({ children, className, ...props }: SelectProps) {
         className={classNames(
           'border-gray-cool-60 w-full appearance-none border bg-white px-2 py-2.5 text-black',
           'outline-black focus:not-data-focus:outline-none data-focus:outline-2 data-focus:-outline-offset-2',
+          'data-disabled:bg-gray-cool-10! data-disabled:cursor-not-allowed data-disabled:text-gray-600 data-disabled:opacity-60',
           className
         )}
         {...props}


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds disabled styling for the Select component.

## 🧪 How to test

Disabled select components will now look like this:
<img width="1099" height="77" alt="image" src="https://github.com/user-attachments/assets/2befea78-3a46-4daf-b0fc-2e95d8827c6a" />