### PR TITLE
fix: change copy for diff rendering limit value

### DIFF
--- a/client/src/components/Diff/index.test.tsx
+++ b/client/src/components/Diff/index.test.tsx
@@ -22,7 +22,7 @@ describe('Diff view', () => {
     );
     expect(
       screen.getByText(
-        `Maximum uncompressed file size is ${FileInfoResponseValue.max_for_diff_rendering_mb}`
+        `Maximum uncompressed file size is ${FileInfoResponseValue.max_for_diff_rendering_mb}MB`
       )
     ).toBeInTheDocument();
   });

--- a/client/src/components/Diff/index.test.tsx
+++ b/client/src/components/Diff/index.test.tsx
@@ -10,7 +10,7 @@ const mockMatchedCondition: Condition = {
   render_diff: true,
 };
 
-describe('ExternalLink', () => {
+describe('Diff view', () => {
   it('should display a warning if the file size is too big', () => {
     render(
       <Diff
@@ -22,10 +22,7 @@ describe('ExternalLink', () => {
     );
     expect(
       screen.getByText(
-        `Maximum uncompressed file size is ${FileInfoResponseValue.max_for_diff_rendering_mb}`,
-        {
-          exact: false,
-        }
+        `Maximum uncompressed file size is ${FileInfoResponseValue.max_for_diff_rendering_mb}`
       )
     ).toBeInTheDocument();
   });

--- a/client/src/components/Diff/index.test.tsx
+++ b/client/src/components/Diff/index.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { Diff } from '.';
-import { Condition } from '../../api/schemas';
+import { Condition, FileInfoResponseValue } from '../../api/schemas';
 
 const mockMatchedCondition: Condition = {
   code: '840539006',
@@ -21,9 +21,12 @@ describe('ExternalLink', () => {
       ></Diff>
     );
     expect(
-      screen.getByText('Maximum uncompressed file size is', {
-        exact: false,
-      })
+      screen.getByText(
+        `Maximum uncompressed file size is ${FileInfoResponseValue.max_for_diff_rendering_mb}`,
+        {
+          exact: false,
+        }
+      )
     ).toBeInTheDocument();
   });
 });

--- a/client/src/components/Diff/index.tsx
+++ b/client/src/components/Diff/index.tsx
@@ -149,7 +149,7 @@ export function Diff({
 function DiffViewWarning() {
   return (
     <Warning
-      heading={`Maximum uncompressed file size is ${FileInfoResponseValue.max_for_uncompressed_mb}MB`}
+      heading={`Maximum uncompressed file size is ${FileInfoResponseValue.max_for_diff_rendering_mb}MB`}
       message="This file is too large to view in-browser. Please download the results to compare them."
     />
   );


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary
We were using the wrong constant for the error we render for the diff view as discovered during an office hour. Getting this out to fix it
<img width="1075" height="377" alt="Screenshot 2026-06-11 at 3 29 47 PM" src="https://github.com/user-attachments/assets/249b5d23-5873-4c0a-a5f5-eb84f04573f0" />

## 🧪 How to test
Can use this file through the upload flow to get to this screen

[sddh-covid-3.5-mb.zip](https://github.com/user-attachments/files/28853229/sddh-covid-3.5-mb.zip)

## ℹ️ Additional Information

Any suggestions on a better test / way of catching something like this are welcome