### PR TITLE
chore: add `react/self-closing-comp` ESLint rule

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -39,6 +39,13 @@ export default defineConfig(
     rules: {
       ...reactHooks.configs.recommended.rules,
       ...tanstackQuery.configs.recommended.rules,
+      'react/self-closing-comp': [
+        'error',
+        {
+          component: true,
+          html: true,
+        },
+      ],
 
       'react/jsx-curly-brace-presence': [
         'error',

--- a/client/src/components/Diff/index.test.tsx
+++ b/client/src/components/Diff/index.test.tsx
@@ -18,7 +18,7 @@ describe('ExternalLink', () => {
         unrefined_eicr=""
         condition={mockMatchedCondition}
         renderDiff={false}
-      ></Diff>
+       />
     );
     expect(
       screen.getByText('Maximum uncompressed file size is', {

--- a/client/src/components/Diff/index.test.tsx
+++ b/client/src/components/Diff/index.test.tsx
@@ -18,7 +18,7 @@ describe('ExternalLink', () => {
         unrefined_eicr=""
         condition={mockMatchedCondition}
         renderDiff={false}
-       />
+      />
     );
     expect(
       screen.getByText('Maximum uncompressed file size is', {

--- a/client/src/components/Pagination/index.tsx
+++ b/client/src/components/Pagination/index.tsx
@@ -194,7 +194,7 @@ function SvgContainer({ children }: SvgContainerProps) {
 function ChevronLeft() {
   return (
     <SvgContainer>
-      <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"></path>
+      <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" />
     </SvgContainer>
   );
 }
@@ -202,7 +202,7 @@ function ChevronLeft() {
 function ChevronRight() {
   return (
     <SvgContainer>
-      <path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"></path>
+      <path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" />
     </SvgContainer>
   );
 }

--- a/client/src/components/Search/index.tsx
+++ b/client/src/components/Search/index.tsx
@@ -37,7 +37,7 @@ function SearchIcon() {
       focusable="false"
       className="usa-icon"
     >
-      <use href={`${SearchSvg}#search`}></use>
+      <use href={`${SearchSvg}#search`} />
     </svg>
   );
 }

--- a/client/src/components/Spinner/SpinnerWithMinimalRender.tsx
+++ b/client/src/components/Spinner/SpinnerWithMinimalRender.tsx
@@ -23,7 +23,7 @@ export function SpinnerWithMinimalRender({
   );
 
   return shouldShowSpinner ? (
-    <SpinnerWithMessage loadingMessage={loadingMessage}></SpinnerWithMessage>
+    <SpinnerWithMessage loadingMessage={loadingMessage} />
   ) : (
     renderWhenDone
   );

--- a/client/src/pages/AppUpdates/index.tsx
+++ b/client/src/pages/AppUpdates/index.tsx
@@ -42,7 +42,7 @@ export function AppUpdates() {
                 );
               })}
               {i !== releaseContentToRender.length - 1 && (
-                <hr className="bg-base-lighter h-0.5! border-none"></hr>
+                <hr className="bg-base-lighter h-0.5! border-none" />
               )}
             </div>
           );

--- a/client/src/pages/Configurations/ConfigBuild/VersionMenu.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/VersionMenu.tsx
@@ -62,7 +62,7 @@ export function VersionMenu({
                   aria-hidden
                   key={`${config.id}-divider`}
                   className="bg-gray-cool-10 my-1 h-px"
-                ></div>
+                 />
               )}
             </Fragment>
           ))}
@@ -71,7 +71,7 @@ export function VersionMenu({
       <div
         aria-hidden
         className="border-gray-cool-20 mx-1 hidden h-10 border-l md:block"
-      ></div>
+       />
     </>
   );
 }

--- a/client/src/pages/Configurations/ConfigBuild/VersionMenu.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/VersionMenu.tsx
@@ -62,7 +62,7 @@ export function VersionMenu({
                   aria-hidden
                   key={`${config.id}-divider`}
                   className="bg-gray-cool-10 my-1 h-px"
-                 />
+                />
               )}
             </Fragment>
           ))}
@@ -71,7 +71,7 @@ export function VersionMenu({
       <div
         aria-hidden
         className="border-gray-cool-20 mx-1 hidden h-10 border-l md:block"
-       />
+      />
     </>
   );
 }

--- a/client/src/pages/SessionRedirect/index.tsx
+++ b/client/src/pages/SessionRedirect/index.tsx
@@ -18,7 +18,7 @@ export function SessionRedirect({
             <Icon.Home
               aria-label="Home icon indicating a need to return to homepage to login again"
               className="text-gray-cool-50 h-30! w-30!"
-             />
+            />
             <h1 className="text-center">
               Your session has ended. <br />
               Please log back in to access the app.

--- a/client/src/pages/SessionRedirect/index.tsx
+++ b/client/src/pages/SessionRedirect/index.tsx
@@ -18,7 +18,7 @@ export function SessionRedirect({
             <Icon.Home
               aria-label="Home icon indicating a need to return to homepage to login again"
               className="text-gray-cool-50 h-30! w-30!"
-            ></Icon.Home>
+             />
             <h1 className="text-center">
               Your session has ended. <br />
               Please log back in to access the app.


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds the [react/self-closing-comp](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md) rule to the ESLint config. This rule disallows extra closing tags for components without children. 

This PR cleans up any existing violations as well.

## 🧪 How to test

- App works as it did previously
- Automated tests continue to pass
