### PR TITLE
chore: add `react/function-component-definition` ESLint rule

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -39,7 +39,13 @@ export default defineConfig(
     rules: {
       ...reactHooks.configs.recommended.rules,
       ...tanstackQuery.configs.recommended.rules,
-
+      'react/function-component-definition': [
+        'error',
+        {
+          namedComponents: 'function-declaration',
+          unnamedComponents: 'arrow-function',
+        },
+      ],
       'react/jsx-curly-brace-presence': [
         'error',
         {

--- a/client/src/test-utils.tsx
+++ b/client/src/test-utils.tsx
@@ -12,13 +12,9 @@ const createTestQueryClient = () =>
     },
   });
 
-export const TestQueryClientProvider = ({
-  children,
-}: {
-  children: ReactNode;
-}) => {
+export function TestQueryClientProvider({ children }: { children: ReactNode }) {
   const queryClient = createTestQueryClient();
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
-};
+}


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds the [react/function-component-definition](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md) rule to the ESLint config. This rule will enable us to automatically enforce our typical component definition approach (`function` keyword for named components, arrow functions for unnamed components).

This PR cleans up any existing violations as well.

## 🧪 How to test

- App works as it did previously
- Automated tests continue to pass
