### PR TITLE
refactor(refiner): Update RefinerComplete schema documentation & split RefinerCompleteFile class

### DIFF
--- a/refiner/app/lambda/RefinerComplete.md
+++ b/refiner/app/lambda/RefinerComplete.md
@@ -20,9 +20,20 @@ Combinations marked `false` in `RefinerMetadata` will have no corresponding entr
 
 ## `RefinerSkip`
 
-A boolean indicating whether the refiner skipped processing entirely. When `false`, the refiner ran its normal processing loop (though individual jurisdiction/condition pairs may still have been skipped, as indicated by `RefinerMetadata`).
+A boolean indicating whether the refiner skipped processing entirely. When
+`true`, it signals that the refiner either skipped the eCR due to configuration
+OR encountered a fatal execution error. In either case, `RefinerMetadata` and
+`RefinerOutputFiles` are omitted.
 
-## Example
+## `Error`
+
+An optional string containing the diagnostic error message if the refiner
+encountered a fatal error. This field is only present when `RefinerSkip` is
+`true`.
+
+## Examples
+
+A successful refinement output.
 
 ```json
 {
@@ -43,5 +54,14 @@ A boolean indicating whether the refiner skipped processing entirely. When `fals
     "RefinerOutput/<persistence_id>/NY/COVID19/refined_eICR.xml",
     "RefinerOutput/<persistence_id>/NY/COVID19/refined_RR.xml"
   ]
+}
+```
+
+A failed refinement output.
+
+```json
+{
+  "RefinerSkip": true,
+  "Error": "Fatal error: setId missing from document"
 }
 ```

--- a/refiner/app/lambda/RefinerComplete.md
+++ b/refiner/app/lambda/RefinerComplete.md
@@ -1,39 +1,26 @@
 # RefinerComplete JSON Schema
 
-The `RefinerComplete` file is written to S3 after the refiner finishes processing an eCR. It contains three fields:
+The `RefinerComplete` file is written to S3 after the refiner finishes
+processing an eCR. It can take one of two mutually exclusive shapes: a
+**Success** signal or an **Error** signal.
 
-## `RefinerMetadata`
+## Success Signal
 
-A nested object that records which jurisdiction/condition combinations from the Reportability Response (RR) were processed. The outer keys are **jurisdiction codes** (e.g. `"CA"`, `"NY"`), and each maps to an object whose keys are **condition codes** (SNOMED codes like `"27836007"`). The boolean value indicates whether refinement was performed:
+A success signal is sent when the refiner completes processing (even if some
+conditions were skipped due to missing configurations).
 
-- **`true`** — an active configuration was found and the eICR/RR were refined for this combination.
-- **`false`** — no active configuration existed, so refinement was skipped.
+### Fields
 
-## `RefinerOutputFiles`
+- **`RefinerMetadata`**: A nested object that records which jurisdiction/condition combinations from the Reportability Response (RR) were processed. The outer keys are **jurisdiction codes** (e.g. `"CA"`, `"NY"`), and each maps to an object whose keys are **condition codes** (SNOMED codes like `"27836007"`). The boolean value indicates whether refinement was performed:
+  - **`true`** — an active configuration was found and the eICR/RR were
+    refined for this combination.
+  - **`false`** — no active configuration existed, so refinement was skipped.
+- **`RefinerOutputFiles`**: An array of S3 keys pointing to the refined output files. Each successfully refined jurisdiction/condition combination produces two entries:
+  - `RefinerOutput/<persistence_id>/<jurisdiction_code>/<condition_grouper_names_no_spaces>/refined_eICR.xml`
+  - `RefinerOutput/<persistence_id>/<jurisdiction_code>/<condition_grouper_names_no_spaces>/refined_RR.xml`
+- **`RefinerSkip`**: Set to `false`.
 
-An array of S3 keys pointing to the refined output files. Each successfully refined jurisdiction/condition combination produces two entries:
-
-- `RefinerOutput/<persistence_id>/<jurisdiction_code>/<condition_grouper_names_no_spaces>/refined_eICR.xml`
-- `RefinerOutput/<persistence_id>/<jurisdiction_code>/<condition_grouper_names_no_spaces>/refined_RR.xml`
-
-Combinations marked `false` in `RefinerMetadata` will have no corresponding entries here.
-
-## `RefinerSkip`
-
-A boolean indicating whether the refiner skipped processing entirely. When
-`true`, it signals that the refiner either skipped the eCR due to configuration
-OR encountered a fatal execution error. In either case, `RefinerMetadata` and
-`RefinerOutputFiles` are omitted.
-
-## `Error`
-
-An optional string containing the diagnostic error message if the refiner
-encountered a fatal error. This field is only present when `RefinerSkip` is
-`true`.
-
-## Examples
-
-A successful refinement output.
+### Example
 
 ```json
 {
@@ -57,7 +44,20 @@ A successful refinement output.
 }
 ```
 
-A failed refinement output.
+## Error Signal
+
+An error signal is sent when the refiner encounters a fatal execution error that
+prevents the refinement process from completing.
+
+### Fields
+
+- **`RefinerSkip`**: Set to `true`.
+- **`Error`**: A string containing the diagnostic error message.
+
+**Note:** When an Error signal is sent, `RefinerMetadata` and
+`RefinerOutputFiles` are omitted.
+
+### Example
 
 ```json
 {

--- a/refiner/app/lambda/lambda_function.py
+++ b/refiner/app/lambda/lambda_function.py
@@ -51,7 +51,7 @@ ConditionCode = str
 RefinerMetadata = dict[JurisdictionCode, dict[ConditionCode, bool]]
 
 
-class RefinerCompleteFile(TypedDict):
+class RefinerCompleteFile(TypedDict, total=False):
     """
     Represents the completion file written after all refinement is done.
 
@@ -61,6 +61,7 @@ class RefinerCompleteFile(TypedDict):
     RefinerMetadata: RefinerMetadata
     RefinerSkip: bool
     RefinerOutputFiles: list[str]
+    Error: str
 
 
 @dataclass

--- a/refiner/app/lambda/lambda_function.py
+++ b/refiner/app/lambda/lambda_function.py
@@ -51,9 +51,9 @@ ConditionCode = str
 RefinerMetadata = dict[JurisdictionCode, dict[ConditionCode, bool]]
 
 
-class RefinerCompleteFile(TypedDict, total=False):
+class RefinerCompleteSuccess(TypedDict):
     """
-    Represents the completion file written after all refinement is done.
+    Represents a successful completion file written after all refinement is done.
 
     Required by AIMS infrastructure.
     """
@@ -61,7 +61,20 @@ class RefinerCompleteFile(TypedDict, total=False):
     RefinerMetadata: RefinerMetadata
     RefinerSkip: bool
     RefinerOutputFiles: list[str]
+
+
+class RefinerCompleteError(TypedDict):
+    """
+    Represents a fatal error completion file written despite of failure.
+
+    Required by AIMS infrastructure.
+    """
+
+    RefinerSkip: bool
     Error: str
+
+
+RefinerCompleteFile = RefinerCompleteSuccess | RefinerCompleteError
 
 
 @dataclass


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This establishes the contract for the upcoming error signal. This patch only
updates the documentation and prepares the Class structure.

## 🔗 Related Issue

- Closes #1358

## ✅ Acceptance Criteria

- [x] Update `RefinerComplete` schema documentation to include an optional
      `Error` field.
- [x] Update `RefinerCompleteFile` type definition to support an optional
      `Error` string and partial payloads (`total=False`).
- [ ] ~~Modify `lambda_handler` to ensure a `RefinerComplete` file is written to
      S3 when a fatal error occurs, provided a `persistence_id` could be extracted.~~
- [ ] ~~The error signal must set `RefinerSkip: true` and include the exception
      message in the `Error` field.~~
- [ ] ~~The Lambda must still re-raise the exception after writing the signal to
      maintain failure visibility in AWS.~~
- [ ] ~~Integration tests must verify that no signal is written if
      `persistence_id` extraction fails (e.g. an invalid S3 prefix).~~
- [ ] ~~Integration tests must verify that a signal with `RefinerSkip: true` and
      an `Error` message is written when processing fails (e.g. malformed XML, or
      currently a missing `setID` in the document).~~

## 🧪 How to test

1. Read the updated documentation `refiner/app/lambda/RefinerComplete.md`.
1. Ensure that the `RefinerCompleteFile` type definition supports an optional
   `Error` string and partial payloads (`total=False`).

## ℹ️ Additional Information

> [!NOTE]
> This work is part of three separate PRs related to #1358. This first PR should
> be reviewed first. Subsequent PRs build off this work and will be merged into
> `main` only after the previous PR is merged in.
