### PR TITLE
feat(ci): Make server recipes more ergonomic

### DIFF
--- a/.justscripts/just/server.just
+++ b/.justscripts/just/server.just
@@ -16,10 +16,30 @@ set dotenv-load
 _venv:
     [ -d .venv ] || python3 -m venv .venv
 
-[doc('Run pytest suite')]
+[doc('Run pytest on a given path')]
 [group('test')]
-test: _venv
-    {{ if env("CI", "") != "" { ".venv/bin/pytest tests" } else { ".venv/bin/pytest -vvv tests" } }}
+test *ARGS: _venv
+    .venv/bin/pytest {{ ARGS }}
+
+[doc('Run unit tests')]
+[group('test')]
+test-unit: _venv
+    {{ if env("CI", "") != "" { ".venv/bin/pytest tests/unit" } else { ".venv/bin/pytest -vvv tests/unit" } }}
+
+[doc('Run Integration tests')]
+[group('test')]
+test-integration: _venv
+    {{ if env("CI", "") != "" { ".venv/bin/pytest tests/integration --ignore=tests/integration/scenarios" } else { ".venv/bin/pytest -vvv tests/integration --ignore=tests/integration/scenarios" } }}
+
+[doc('Run Scenarios tests')]
+[group('test')]
+test-scenarios: _venv
+    {{ if env("CI", "") != "" { ".venv/bin/pytest tests/integration/scenarios" } else { ".venv/bin/pytest -vvv tests/integration/scenarios" } }}
+
+[doc('Run Lambda tests')]
+[group('test')]
+test-lambda: _venv
+    {{ if env("CI", "") != "" { ".venv/bin/pytest app/lambda" } else { ".venv/bin/pytest -vvv app/lambda" } }}
 
 [doc('Run Ruff checker, fix things, and formatter')]
 fix: _venv
@@ -35,15 +55,31 @@ lint: _venv
 check: _venv
     .venv/bin/mypy
 
+[doc('Install all depenencies e.g Refiner and Lambda')]
+[group('dependencies')]
+install-all: _venv
+    just server install-dev
+    just server install-lambda-dev
+
 [doc('Install dependencies locally')]
 [group('dependencies')]
 install: _venv
-    .venv/bin/pip install -r requirements.txt
+    .venv/bin/pip install -r ./requirements.txt
 
 [doc('Install all dependencies locally')]
 [group('dependencies')]
 install-dev: _venv
-    .venv/bin/pip install -r dev-requirements.txt -r requirements.txt
+    .venv/bin/pip install -r ./dev-requirements.txt -r ./requirements.txt
+
+[doc('Install Lambda dependencies locally')]
+[group('dependencies')]
+install-lambda: _venv
+    .venv/bin/pip install -r ./requirements.txt -r ./app/lambda/requirements.txt
+
+[doc('Install all Lambda dependencies locally')]
+[group('dependencies')]
+install-lambda-dev: _venv
+    .venv/bin/pip install -r ./dev-requirements.txt -r ./app/lambda/dev-requirements.txt -r ./app/lambda/requirements.txt
 
 [doc('Seed Localstack with the infra needed for manual tests')]
 [group('localstack')]


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

They know follow our CI workflow as well. The best new recipe to try out is
running individual tests using `just server test {$@}` where you can pass any
arguments to `pytest`. I've also made things easier for installing dependencies
as well.

> [!TIP]
> These recipes have been coming in handy for me locally when running some
> tests. I've also felt inspired by the recent changes @jakewheeler made to our
> CI workflow for tests so I wanted to bring that here.

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

1. Run `just server` to see the new recipes
1. Try out the new `just server test ...` with any arguments you'd like
1. Try out the new `just server install-all` to install/update all dependencies
   across Lambda and Refiner.
