### PR TITLE
refactor: `configurations.s3_urls` should no longer be an array

### DIFF
--- a/refiner/app/api/v1/configurations/activation.py
+++ b/refiner/app/api/v1/configurations/activation.py
@@ -140,8 +140,8 @@ async def activate_configuration(
             detail="Could not find primary condition associated with configuration.",
         )
 
-    # Write the config data to S3 and get the URLs back
-    s3_urls = await run_in_threadpool(
+    # Write the config data to S3 and get the URL back
+    s3_url = await run_in_threadpool(
         upload_configuration_payload, config_payload, config_metadata, logger
     )
 
@@ -151,7 +151,7 @@ async def activate_configuration(
         activated_by_user_id=user.id,
         canonical_url=primary_condition.canonical_url,
         jurisdiction_id=user.jurisdiction_id,
-        s3_urls=s3_urls,
+        s3_url=s3_url,
         db=db,
     )
 
@@ -174,10 +174,10 @@ async def activate_configuration(
         upload_condition_mapping_payload, condition_mapping_payload, jd, logger
     )
 
-    # Activation files have been written to S3 and the database record has been updated.
+    # Activation file has been written to S3 and the database record has been updated.
     # We can now make a new current.json file for the newly activated version.
     await run_in_threadpool(
-        upload_current_version_file, s3_urls, active_config.version, logger
+        upload_current_version_file, s3_url, active_config.version, logger
     )
 
     return ConfigurationStatusUpdateResponse(
@@ -242,8 +242,8 @@ async def deactivate_configuration(
         )
 
     # Try updating `current.json` first
-    s3_urls = config_to_deactivate.s3_urls
-    await run_in_threadpool(upload_current_version_file, s3_urls, None, logger)
+    s3_url = config_to_deactivate.s3_url
+    await run_in_threadpool(upload_current_version_file, s3_url, None, logger)
 
     deactivated_config = await deactivate_configuration_db(
         configuration_id=config_to_deactivate.id,

--- a/refiner/app/db/configurations/activations/db.py
+++ b/refiner/app/db/configurations/activations/db.py
@@ -20,7 +20,7 @@ async def _activate_configuration_db(
     configuration_id: UUID,
     activated_by_user_id: UUID,
     jurisdiction_id: str,
-    s3_urls: list[str],
+    s3_url: str,
     *,
     cur: AsyncCursor[CursorType],
 ) -> UUID | None:
@@ -28,7 +28,7 @@ async def _activate_configuration_db(
             UPDATE configurations
             SET
                 status = 'active',
-                s3_urls = %s,
+                s3_url = %s,
                 last_activated_by = %s
             WHERE id = %s
                 RETURNING
@@ -36,7 +36,7 @@ async def _activate_configuration_db(
         """
 
     params = (
-        s3_urls,
+        s3_url,
         activated_by_user_id,
         configuration_id,
     )
@@ -72,7 +72,7 @@ async def _deactivate_configuration_db(
             UPDATE configurations
             SET
                 status = 'inactive',
-                s3_urls = NULL
+                s3_url = NULL
             WHERE id = %s
             AND status = 'active'
             RETURNING
@@ -116,7 +116,7 @@ async def activate_configuration_db(
     activated_by_user_id: UUID,
     canonical_url: str,
     jurisdiction_id: str,
-    s3_urls: list[str],
+    s3_url: str,
     db: AsyncDatabaseConnection,
 ) -> DbConfiguration | None:
     """
@@ -143,7 +143,7 @@ async def activate_configuration_db(
                     configuration_id=configuration_id,
                     activated_by_user_id=activated_by_user_id,
                     jurisdiction_id=jurisdiction_id,
-                    s3_urls=s3_urls,
+                    s3_url=s3_url,
                     cur=cur,
                 )
             else:
@@ -163,7 +163,7 @@ async def activate_configuration_db(
                     configuration_id=configuration_id,
                     activated_by_user_id=activated_by_user_id,
                     jurisdiction_id=jurisdiction_id,
-                    s3_urls=s3_urls,
+                    s3_url=s3_url,
                     cur=cur,
                 )
     if not activated_config_id:

--- a/refiner/app/db/configurations/db.py
+++ b/refiner/app/db/configurations/db.py
@@ -1265,7 +1265,7 @@ def _get_configurations_core_query() -> str:
         c.last_activated_at,
         c.last_activated_by,
         c.created_by,
-        c.s3_urls
+        c.s3_url
     FROM configurations c
     JOIN configurations_conditions cc_primary ON cc_primary.configuration_id = c.id AND cc_primary.is_primary = true
     LEFT JOIN LATERAL (

--- a/refiner/app/db/configurations/model.py
+++ b/refiner/app/db/configurations/model.py
@@ -143,7 +143,7 @@ class DbConfiguration:
     last_activated_at: datetime | None
     last_activated_by: UUID | None
     created_by: UUID
-    s3_urls: list[str]
+    s3_url: str
 
     @classmethod
     def from_db_row(cls, row: dict[str, Any]) -> "DbConfiguration":
@@ -178,7 +178,7 @@ class DbConfiguration:
             last_activated_at=row["last_activated_at"],
             last_activated_by=row["last_activated_by"],
             created_by=row["created_by"],
-            s3_urls=row["s3_urls"],
+            s3_url=row["s3_url"],
         )
 
 

--- a/refiner/app/services/aws/s3.py
+++ b/refiner/app/services/aws/s3.py
@@ -47,13 +47,13 @@ s3_client = boto3.client("s3", **_build_s3_client_kwargs())
 
 
 def upload_current_version_file(
-    directory_keys: list[str], active_version: int | None, logger: Logger
+    directory_key: str, active_version: int | None, logger: Logger
 ) -> None:
     """
     Writes a new `current.json` file for all directories with new activation files.
 
     Args:
-        directory_keys (list[str]): A list of child RSG code directories in the form: s3://bucket/SDDH/12345
+        directory_key (str): Directory key to condition within a JD, ex: `configurations/SDDH/07221093-b8a1-4b1d-8678-259277bfba64`
         active_version (int): The newly activated configuration version
         logger (Logger): The standard application logger
     """
@@ -62,23 +62,23 @@ def upload_current_version_file(
         if active_version is not None and active_version > 0
         else None
     }
-    for key in directory_keys:
-        s3_client.put_object(
-            Bucket=S3_CONFIGURATION_BUCKET_NAME,
-            Key=f"{key}/current.json",
-            Body=json.dumps(data, indent=2).encode("utf-8"),
-            ContentType="application/json",
-        )
-        logger.info(
-            f"Updating current.json to version {active_version}: {key}/current.json"
-        )
+
+    s3_client.put_object(
+        Bucket=S3_CONFIGURATION_BUCKET_NAME,
+        Key=f"{directory_key}/current.json",
+        Body=json.dumps(data, indent=2).encode("utf-8"),
+        ContentType="application/json",
+    )
+    logger.info(
+        f"Updating current.json to version {active_version}: {directory_key}/current.json"
+    )
 
 
 def upload_configuration_payload(
     payload: ConfigurationStoragePayload,
     metadata: ConfigurationStorageMetadata,
     logger: Logger,
-) -> list[str]:
+) -> str:
     """
     Given a payload and metadata, writes this information to JSON files in S3.
 
@@ -88,19 +88,14 @@ def upload_configuration_payload(
         logger (Logger): The standard application logger.
 
     Returns:
-        list[str]: List of keys pointing to the child RSG SNOMED code directories
+        str: Key to the parent directory where the activation file lives
     """
-    s3_condition_code_paths = []
 
     payload_data = payload.to_dict()
     metadata_data = metadata.to_dict()
 
     canonical_url = metadata.canonical_url
     jurisdiction_id = metadata.jurisdiction_id
-
-    parent_directory = get_parent_directory_key(
-        jurisdiction_id=jurisdiction_id, canonical_url=canonical_url
-    )
 
     # Write active.json
     active_key = get_active_file_key(
@@ -128,11 +123,12 @@ def upload_configuration_payload(
         ContentType="application/json",
     )
 
-    s3_condition_code_paths.append(parent_directory)
     logger.info(f"Writing file to: {active_key}")
     logger.info(f"Writing file to: {metadata_key}")
 
-    return s3_condition_code_paths
+    return get_parent_directory_key(
+        jurisdiction_id=jurisdiction_id, canonical_url=canonical_url
+    )
 
 
 def upload_condition_mapping_payload(

--- a/refiner/migrations/20260615170607_single_s3_url.sql
+++ b/refiner/migrations/20260615170607_single_s3_url.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+ALTER TABLE configurations
+  RENAME COLUMN s3_urls TO s3_url;
+
+ALTER TABLE configurations
+  ALTER COLUMN s3_url TYPE TEXT USING s3_url[1];
+
+-- migrate:down
+ALTER TABLE configurations
+  ALTER COLUMN s3_url TYPE TEXT[] USING NULLIF(ARRAY[s3_url], ARRAY[NULL::TEXT]);
+
+ALTER TABLE configurations
+  RENAME COLUMN s3_url TO s3_urls;

--- a/refiner/schema.sql
+++ b/refiner/schema.sql
@@ -211,7 +211,7 @@ CREATE TABLE public.configurations (
     last_activated_at timestamp with time zone,
     last_activated_by uuid,
     created_by uuid NOT NULL,
-    s3_urls text[]
+    s3_url text
 );
 
 
@@ -253,20 +253,6 @@ CREATE TABLE public.configurations_sections (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     section_type public.configurations_sections_type NOT NULL,
     narrative public.section_narrative CONSTRAINT configurations_sections_narrative_new_not_null NOT NULL
-);
-
-
---
--- Name: custom_codes; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.custom_codes (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    name text NOT NULL,
-    value text NOT NULL,
-    system_id uuid NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
@@ -866,4 +852,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260602161536'),
     ('20260603120000'),
     ('20260604134336'),
-    ('20260608203714');
+    ('20260608203714'),
+    ('20260615170607');

--- a/refiner/tests/integration/test_configurations.py
+++ b/refiner/tests/integration/test_configurations.py
@@ -816,7 +816,7 @@ class TestConfigurations:
                 activated_by_user_id=uuid4(),
                 canonical_url="https://mock.com",
                 jurisdiction_id="SDDH",
-                s3_urls=["s3://bucket/key"],
+                s3_url="s3://bucket/key",
                 db=db_pool,
             )
 

--- a/refiner/tests/unit/conftest.py
+++ b/refiner/tests/unit/conftest.py
@@ -144,7 +144,7 @@ def mock_configuration(mock_user):
         last_activated_at=None,
         last_activated_by=None,
         created_by=mock_user.id,
-        s3_urls=[],
+        s3_url="",
     )
 
 

--- a/refiner/tests/unit/test_configuration_locks.py
+++ b/refiner/tests/unit/test_configuration_locks.py
@@ -131,7 +131,7 @@ def mock_db_functions(monkeypatch, mock_user, mock_configuration):
         last_activated_at=None,
         last_activated_by=None,
         created_by=mock_user.id,
-        s3_urls=[],
+        s3_url=[],
     )
 
     monkeypatch.setattr(

--- a/refiner/tests/unit/test_configuration_locks.py
+++ b/refiner/tests/unit/test_configuration_locks.py
@@ -131,7 +131,7 @@ def mock_db_functions(monkeypatch, mock_user, mock_configuration):
         last_activated_at=None,
         last_activated_by=None,
         created_by=mock_user.id,
-        s3_url=[],
+        s3_url="",
     )
 
     monkeypatch.setattr(

--- a/refiner/tests/unit/test_configurations.py
+++ b/refiner/tests/unit/test_configurations.py
@@ -135,7 +135,7 @@ def mock_db_functions(
         last_activated_at=None,
         last_activated_by=None,
         created_by=mock_user.id,
-        s3_url=[],
+        s3_url="",
     )
 
     monkeypatch.setattr(
@@ -357,7 +357,7 @@ async def test_edit_custom_code_from_configuration(
         last_activated_at=None,
         last_activated_by=None,
         created_by=mock_user.id,
-        s3_url=[],
+        s3_url="",
     )
     monkeypatch.setattr(
         "app.api.v1.configurations.custom_codes.get_configuration_by_id_db",

--- a/refiner/tests/unit/test_configurations.py
+++ b/refiner/tests/unit/test_configurations.py
@@ -135,7 +135,7 @@ def mock_db_functions(
         last_activated_at=None,
         last_activated_by=None,
         created_by=mock_user.id,
-        s3_urls=[],
+        s3_url=[],
     )
 
     monkeypatch.setattr(
@@ -357,7 +357,7 @@ async def test_edit_custom_code_from_configuration(
         last_activated_at=None,
         last_activated_by=None,
         created_by=mock_user.id,
-        s3_urls=[],
+        s3_url=[],
     )
     monkeypatch.setattr(
         "app.api.v1.configurations.custom_codes.get_configuration_by_id_db",

--- a/refiner/tests/unit/test_service_refine.py
+++ b/refiner/tests/unit/test_service_refine.py
@@ -83,7 +83,7 @@ def _make_db_configuration_v1_1(**kwargs) -> DbConfiguration:
         "last_activated_at": None,
         "last_activated_by": None,
         "created_by": "fake-config-id-v1-1",
-        "s3_urls": [],
+        "s3_url": [],
     }
     defaults.update(kwargs)
     return DbConfiguration(**defaults)
@@ -133,7 +133,7 @@ def _make_db_configuration_v3_1_1(**kwargs) -> DbConfiguration:
         "last_activated_at": None,
         "last_activated_by": None,
         "created_by": "fake-config-id-v1-1",
-        "s3_urls": [],
+        "s3_url": [],
     }
     defaults.update(kwargs)
     return DbConfiguration(**defaults)

--- a/refiner/tests/unit/test_service_refine.py
+++ b/refiner/tests/unit/test_service_refine.py
@@ -133,7 +133,7 @@ def _make_db_configuration_v3_1_1(**kwargs) -> DbConfiguration:
         "last_activated_at": None,
         "last_activated_by": None,
         "created_by": "fake-config-id-v1-1",
-        "s3_url": [],
+        "s3_url": "",
     }
     defaults.update(kwargs)
     return DbConfiguration(**defaults)

--- a/refiner/tests/unit/test_service_terminology.py
+++ b/refiner/tests/unit/test_service_terminology.py
@@ -46,7 +46,7 @@ def make_dbconfiguration(**kwargs) -> DbConfiguration:
         "last_activated_at": None,
         "last_activated_by": None,
         "created_by": uuid4(),
-        "s3_url": [],
+        "s3_url": "",
     }
     defaults.update(kwargs)
     return DbConfiguration(**defaults)

--- a/refiner/tests/unit/test_service_terminology.py
+++ b/refiner/tests/unit/test_service_terminology.py
@@ -46,7 +46,7 @@ def make_dbconfiguration(**kwargs) -> DbConfiguration:
         "last_activated_at": None,
         "last_activated_by": None,
         "created_by": uuid4(),
-        "s3_urls": [],
+        "s3_url": [],
     }
     defaults.update(kwargs)
     return DbConfiguration(**defaults)
@@ -75,7 +75,6 @@ class TestTerminologyService:
     async def test_processed_configuration_from_payload_and_xpath(
         self,
     ):
-
         cond1: DbCondition = make_condition(
             snomed_codes=[make_db_condition_coding("A", "SNOMED")]
         )
@@ -94,7 +93,6 @@ class TestTerminologyService:
     async def test_processed_configuration_duplicate_codes(
         self,
     ):
-
         cond1: DbCondition = make_condition(
             snomed_codes=[make_db_condition_coding("DUP", "SNOMED")]
         )


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR does two main things:
1. Adds a migrations that renames `configurations.s3_urls` to `configurations.s3_url`, changes the type of the column from `TEXT[]` to `TEXT`, and inserts the first value from the previous array, if applicable
2. Updates the application to handle the new data type and naming


## 🔗 Related Issue

Fixes #961
- #961

## 🧪 How to test

👉  There should be no noticeable change to the application itself.

1. Checkout `main`, create one or more configurations, activate them
2. Checkout this branch
3. Run the `up` migration - you should see the column's name change and rows will have a single URL value
4. Try running the `down` migration - you should see the column's name change back and an array with a single value
5. Run the `up` migration again and check that the app is working as you expect
6. All automated tests should continue to work as before