### PR TITLE
fix(dx) Get the `just dev show` command working

### DIFF
--- a/.justscripts/just/dev.just
+++ b/.justscripts/just/dev.just
@@ -7,6 +7,7 @@ docker := require("docker")
 
 alias u := up
 alias d := down
+alias s := show
 
 [doc("Start only the project's core services with docker compose.")]
 [group('docker')]
@@ -28,4 +29,4 @@ show_tbl := 'table {{.Names}}\t{{.Ports}}\t{{.ID}}'
 [doc('Show running `dibbs-ecr-refiner` containers with helpful output')]
 [group('docker')]
 show:
-    {{ docker }} container ls --filter 'name=dibbs-ecr-refiner' --format "{{ show_tbl }}"
+    {{ docker }} container ls --filter 'name=refiner' --format "{{ show_tbl }}"


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

Testing the `just dev show` command locally just now showed that it was not
working as intended. I've updated it to match on `refiner` rather than
`dibbs-ecr-refiner` to have it produce output.

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

1. Run `just dev up --detach` or have containers already running in Docker locally
1. Run `just dev show` and see that there is output for what is currently
   running that matches `refienr`.

## ℹ️ Additional Information

Is there anything else that I should consider here? Am I missing containers? I'd
like to ensure that all local dev Docker commands go through this module.
