### PR TITLE
fix(dx): Really remove Structurizr;

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,12 +4,12 @@ alias help := _default
 @_default:
     just --list --list-submodules
 
-[group('alias')]
-[doc('Alias for `docker`')]
+# Alias for `docker`
+[group: 'alias']
 mod dk './.justscripts/just/docker.just'
 
-[group('alias')]
-[doc('Alias for `client`')]
+# Alias for `client`
+[group: 'alias']
 mod c './.justscripts/just/client.just'
 
 # Alias for `database`
@@ -40,16 +40,12 @@ mod cd './.justscripts/just/cloud.just'
 [group: 'alias']
 mod d './.justscripts/just/dev.just'
 
-[group('alias')]
-[doc('Alias for `structurizr`')]
-mod s9r './.justscripts/just/structurizr.just'
-
-[group('sub-command')]
-[doc('Run docker build commands')]
+# Run docker build commands
+[group: 'sub-command']
 mod docker './.justscripts/just/docker.just'
 
-[group('sub-command')]
-[doc('Run commands against `client/` code')]
+# Run commands against `client/` code
+[group: 'sub-command']
 mod client './.justscripts/just/client.just'
 
 # Run dev-related docker compose commands


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This patch also ran the formatter on the `justfile` as well. The Structurizr
work was removed in #1288 but made it's way back into when resolving conflicts
in #1384. This patch removes it permanently.

## 🔗 Related Issue

- #1288, #1384

## ✅ Acceptance Criteria

- [ ] Structurizr is removed from the project

## 🧪 How to test

Test using `rg -i 'structurizr|s9r'` and note that there are no references to
either in our repository.
