### PR TITLE
refactor(ci): Have PR template reference `just`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,7 @@ Fixes #3
 -->
 
 Fixes #
+
 - #
 
 ## ✅ Acceptance Criteria
@@ -41,20 +42,19 @@ Please copy the acceptance criteria from your ticket and paste it here for your 
 <!--
 Unit tests
 
-1. From the project root make sure you're in the `refiner/` directory
-2. Activate a virtual environment using your tool of choice
-3. Make sure that both `requirements.txt` and `dev-requirements.txt` are installed
-4. Run the unit tests with `pytest -vv tests/`
-5. Additionally you can check coverage with `pytest --cov=app tests`
+1. Ensure dependencies are all installed with `just server install-dev`
+1. Test specific paths within the `refiner/` directory with just server test -vv tests/`
+1. Additionally you can check coverage with `just server test --cov=app tests`
 
 or
 
 Testing the application:
 
-1. Run `docker compose up`
-2. Check that both services are up and running with `docker ps`
-3. In your browser, navigate to [http://localhost:8081](http://localhost:8081) to test the application
-4. You should be able to [insert goal you want to accomplish!]
+1. Run `just dev up`
+1. Check that all services are up and running with `docker ps`
+1. In your browser, navigate to [http://localhost:8081](http://localhost:8081)
+   to test the application
+1. You should be able to [insert goal you want to accomplish!]
 -->
 
 ## ℹ️ Additional Information


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This was something that @robertmitchellv mentioned would be helpful to ensure
that we're all using the correct recipes and processes around how to test our
PRs. The main change here is rather than relying on steps and commands to run,
we'll rely on the safety of using Just to run those commands. The added 
benefit is that it also reduces the number of steps a developer needs to run.

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

There's no good way to test this before it gets merged in. The template is only
read from the default branch of the repository. But you can review the Markdown
file directly and see if those new updated steps are good.
