### PR TITLE
chore(dx): Ensure `just server::test ...` requires arguments & a new recipe to update snapshots

### DIFF
--- a/.justscripts/just/server.just
+++ b/.justscripts/just/server.just
@@ -6,6 +6,7 @@ alias t := test
 alias ti := test-integration
 alias tl := test-lambda
 alias ts := test-scenarios
+alias us := update-snapshots
 alias tu := test-unit
 alias ta := test-all
 alias f := fix
@@ -26,9 +27,9 @@ set dotenv-load
 _venv:
     [ -d .venv ] || python3 -m venv .venv
 
-[doc('Run pytest on a given path')]
+[doc('Run pytest wrapper. Must include arguments.')]
 [group('test')]
-test *ARGS: _venv
+test +ARGS: _venv
     .venv/bin/pytest {{ ARGS }}
 
 [doc('Run Unit tests')]
@@ -45,6 +46,11 @@ test-integration: _venv
 [group('test')]
 test-scenarios: _venv
     {{ if env("CI", "") != "" { ".venv/bin/pytest tests/integration/scenarios" } else { ".venv/bin/pytest -vvv tests/integration/scenarios" } }}
+
+[doc('Update Scenarios tests snapshots.')]
+[group('test')]
+update-snapshots: _venv
+    .venv/bin/pytest -vvv tests/integration/scenarios --update-snapshots
 
 [doc('Run Lambda tests')]
 [group('test')]


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

The new recipe I found helpful in the development of #1436 to ensure the
snapshots are up-to-date. Also since the `test` recipe doesn't do anything when
it doesn't have any arguments, I've made it mandatory that the user supplies
something to `just server::test ...`.

## 🔗 Related Issue

- Discovered as a need in #1436

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

1. Checkout the new commands with `just server help`
1. Use the new `just server update-snapshots` to update snapshots of Scenarios
1. Try running `just server test` without any arguments, you will see an error.
