### PR TITLE
chore(test): Remove warnings around `HTTP_422_UNPROCESSABLE_ENTITY` deprecation

### DIFF
--- a/refiner/app/api/validation/file_validation.py
+++ b/refiner/app/api/validation/file_validation.py
@@ -38,7 +38,7 @@ def format_xml_document_for_display_or_raise(text: str) -> str:
         return format_xml_document_for_display(text)
     except etree.XMLSyntaxError as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Invalid XML: {e.msg} (line {e.lineno}, column {e.offset})",
         )
 

--- a/refiner/tests/unit/test_service_format.py
+++ b/refiner/tests/unit/test_service_format.py
@@ -147,7 +147,7 @@ class TestFormatXmlDocumentForDisplayOrRaise:
     def test_raises_422_for_invalid_xml(self):
         with pytest.raises(HTTPException) as exc_info:
             format_xml_document_for_display_or_raise("<unclosed>")
-        assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         assert "Invalid XML" in exc_info.value.detail
 
     def test_preserves_comments_through_wrapper(self):


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

Removes the warnings coming from `just server::test-unit` around
`HTTP_422_UNPROCESSABLE_ENTITY` being deprecated. Below is an example of the
warning.

```
DeprecationWarning: 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead.
```

## 🔗 Related Issue

- Discovered in #1436

## ✅ Acceptance Criteria

- [ ] Running tests should produce no deprecation warnings

## 🧪 How to test

1. Run `just server::test-unit` and there will be zero warnings.
