### PR TITLE
fix(pre-commit): Ignore Scenario snapshots for trimming trailing whitespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,19 @@ repos:
         -   --unsafe
     # - ensure files end with newline
     -   id: end-of-file-fixer
-        exclude: ^(refiner/openapi\.json|client/src/api/)
+        exclude: |
+          (?x)^(
+            refiner/openapi\.json|
+            client/src/api/
+          )$
     # - remove trailing whitespace
     -   id: trailing-whitespace
-        exclude: ^(refiner/openapi\.json|client/src/api/)
+        exclude: |
+          (?x)^(
+            refiner/openapi\.json|
+            client/src/api/|
+            refiner/tests/integration/scenarios/snapshots/.+/.+\.xml
+          )$
 
 # ruff linting and formatting
 -   repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

I'm removing the generated snapshots from getting formatted by trimming
whitespace to avoid issues with updating these test files. This patch also adds
some more legibility to the `exclude` stanza by having each pattern on it's own
line using the multi-line regex format. See this link for a more thorough
explanation of what these changes are doing.

link => https://regex101.com/r/YnNs0R/1

## 🔗 Related Issue

- Discovered in #1436

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

1. Make changes to any file matching this glob
   `refiner/tests/integration/scenarios/snapshots/**/*.xml` by adding some
   arbitrary whitespace at the end of a line
1. Run the `pre-commit` hook to validate whether this file gets trimmed for
   whitespace. It should remain the same formatting as when you saved it..
