### PR TITLE
fix: fix OID s3 serialization

### DIFF
--- a/refiner/app/services/terminology.py
+++ b/refiner/app/services/terminology.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 
 from pydantic import BaseModel
 
-from app.db.codes.model import CodedConcept
 from app.services.ecr.specification.constants import OID_TO_SYSTEM_KEY_MAP
 
 from ..db.conditions.model import DbCondition, DbConditionCoding
@@ -37,7 +36,7 @@ def index_condition_code_list_by_system(
 
 
 @dataclass(frozen=True)
-class Coding(CodedConcept):
+class Coding:
     """
     A code + display + system triple, representing a single coded concept.
 
@@ -47,7 +46,9 @@ class Coding(CodedConcept):
     and a human label for custom codes with "Other".
     """
 
-    system_oid: str = ""
+    code: str
+    display: str
+    system_oid: str
 
 
 type Code = str
@@ -213,7 +214,7 @@ class CodeSystemSets:
                 item["code"]: Coding(
                     code=item["code"],
                     display=item.get("display", ""),
-                    system_oid=item.get("system", ""),
+                    system_oid=item.get("system_oid", ""),
                 )
                 for item in codings
             }

--- a/refiner/tests/integration/test_serialization.py
+++ b/refiner/tests/integration/test_serialization.py
@@ -1,0 +1,42 @@
+import pytest
+
+from app.db.configurations.db import get_configuration_by_id_db
+from app.services.configurations import convert_config_to_storage_payload
+from app.services.ecr.specification.constants import OID_TO_SYSTEM_KEY_MAP
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestSerialization:
+    async def test_successful_serialization(
+        self,
+        create_config,
+        activate_config,
+        get_condition_id,
+        test_user_jurisdiction_id,
+        db_pool,
+    ):
+        condition_name = "Ophthalmia Neonatorum"
+        condition_id = await get_condition_id(condition_name)
+
+        config_metadata = await create_config(condition_id)
+        config_id = config_metadata["id"]
+        await activate_config(config_id)
+        ophtalmia_config = await get_configuration_by_id_db(
+            id=config_id, jurisdiction_id=test_user_jurisdiction_id, db=db_pool
+        )
+        assert ophtalmia_config
+
+        payload = await convert_config_to_storage_payload(
+            configuration=ophtalmia_config, db=db_pool
+        )
+
+        assert payload
+
+        for k, coding in payload.code_system_sets.items():
+            assert k in OID_TO_SYSTEM_KEY_MAP.values()
+
+            for c in coding:
+                assert c["code"] and c["code"] != ""
+                assert c["display"] and c["display"] != ""
+                assert c["system"] in OID_TO_SYSTEM_KEY_MAP.keys()


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

Fixed an issue with the OID serialization process that got discovered in related work. Adds a regression test too.

Before:
<img width="1696" height="1522" alt="Screenshot 2026-06-26 at 1 54 41 PM" src="https://github.com/user-attachments/assets/644b7d08-9657-49d7-91cb-968e3c769cc0" />
After:
<img width="1682" height="1396" alt="Screenshot 2026-06-26 at 1 55 19 PM" src="https://github.com/user-attachments/assets/912833ed-d24f-4221-bdbc-670c0403c40d" />

## ✅ Acceptance Criteria
System OID's should get put in the serialized configs

## 🧪 How to test
- Start the app locally and activate a config
- Navigate to the localstack URL withe active config
- Notice the system OID's are serialized

## ℹ️ Additional Information

Any other test we want in the short term?