### PR TITLE
chore: image scanning accounts for vulnerabilities that don't have fixes available

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -59,7 +59,7 @@ jobs:
           format: "sarif"
           output: "trivy-${{ matrix.image.name }}-results.sarif"
           severity: ${{ env.TRIVY_SEVERITY }}
-          ignore-unfixed: true
+          ignore-unfixed: false
           timeout: "10m"
 
       - name: Run Trivy vulnerability scanner (JSON for PR comment)
@@ -69,7 +69,7 @@ jobs:
           format: "json"
           output: "trivy-${{ matrix.image.name }}-results.json"
           severity: ${{ env.TRIVY_SEVERITY }}
-          ignore-unfixed: true
+          ignore-unfixed: false
           timeout: "10m"
 
       - name: Display Trivy results as table

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -95,7 +95,7 @@ jobs:
           format: "sarif"
           output: "trivy-${{ matrix.image.name }}-results.sarif"
           severity: ${{ steps.params.outputs.severity }}
-          ignore-unfixed: true
+          ignore-unfixed: false
           timeout: "10m"
 
       - name: Run Trivy vulnerability scanner (JSON)
@@ -106,7 +106,7 @@ jobs:
           format: "json"
           output: "trivy-${{ matrix.image.name }}-results.json"
           severity: ${{ steps.params.outputs.severity }}
-          ignore-unfixed: true
+          ignore-unfixed: false
           timeout: "10m"
 
       - name: Display Trivy results as table


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR modifies the scanning job to include CVEs that do not have an available fix. This brings the scanning job closer to what we'll see coming from the AWS Inspector scans.

## 🧪 How to test

- Take a look at the comment on this PR. You will see we are now receiving many more vulnerabilities coming from the base image that do not have fixes available yet