### PR TITLE
chore: switch from `python:3.14-slim` to `python:3.14-alpine` base image

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -17,9 +17,28 @@ ENV VITE_APP_VERSION=$VERSION
 COPY ./client ./
 RUN npm run build
 
+# Install system deps
+FROM python:3.14-alpine AS system-builder
+
+RUN apk add --no-cache \
+    gcc \
+    g++ \
+    musl-dev \
+    libxml2-dev \
+    libxslt-dev
+
+# build the lxml wheel
+WORKDIR /app
+RUN pip wheel --no-cache-dir --wheel-dir=/app/wheels lxml
+
 
 # Runtime image
 FROM python:3.14-alpine
+
+# install runtime C libs
+RUN apk add --no-cache \
+    libxml2 \
+    libxslt
 
 # default VERSION is 0.0.0 if not passed at build time
 ARG VERSION="0.0.0"
@@ -29,15 +48,12 @@ ENV VERSION=$VERSION
 
 WORKDIR /code
 
-# Install build dependencies for C extension packages
-RUN apk add --no-cache \
-    gcc \
-    musl-dev \
-    libxml2-dev \
-    libxslt-dev \
-    libffi-dev
-
 RUN python -m pip install --upgrade pip
+
+# copy & install wheel from builder
+COPY --from=system-builder /app/wheels /wheels
+RUN pip install --no-cache-dir /wheels/*
+
 
 COPY ./refiner/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -19,7 +19,7 @@ RUN npm run build
 
 
 # Runtime image
-FROM python:3.14-slim
+FROM python:3.14-alpine
 
 # default VERSION is 0.0.0 if not passed at build time
 ARG VERSION="0.0.0"
@@ -28,6 +28,14 @@ ARG VERSION="0.0.0"
 ENV VERSION=$VERSION
 
 WORKDIR /code
+
+# Install build dependencies for C extension packages
+RUN apk add --no-cache \
+    gcc \
+    musl-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libffi-dev
 
 RUN python -m pip install --upgrade pip
 

--- a/Dockerfile.ops
+++ b/Dockerfile.ops
@@ -1,5 +1,5 @@
 # Install Python dependencies
-FROM python:3.14-slim
+FROM python:3.14-alpine
 
 # default VERSION is 0.0.0 if not passed at build time
 ARG VERSION="0.0.0"
@@ -15,6 +15,14 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     bash \
     && rm -rf /var/lib/apt/lists/*
+
+# Install build dependencies for C extension packages
+RUN apk add --no-cache \
+    gcc \
+    musl-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libffi-dev
 
 # Copy dbmate binary from dbmate base image
 COPY --from=ghcr.io/amacneil/dbmate:main /usr/local/bin/dbmate /usr/local/bin/dbmate

--- a/Dockerfile.ops
+++ b/Dockerfile.ops
@@ -1,3 +1,17 @@
+# Install system deps
+FROM python:3.14-alpine AS system-builder
+
+RUN apk add --no-cache \
+    gcc \
+    g++ \
+    musl-dev \
+    libxml2-dev \
+    libxslt-dev
+
+# build the lxml wheel
+WORKDIR /app
+RUN pip wheel --no-cache-dir --wheel-dir=/app/wheels lxml
+
 # Install Python dependencies
 FROM python:3.14-alpine
 
@@ -16,18 +30,21 @@ RUN apk update && apk add --no-cache \
     bash \
     && rm -rf /var/lib/apt/lists/*
 
-# Install build dependencies for C extension packages
+# install runtime C libs
 RUN apk add --no-cache \
-    gcc \
-    musl-dev \
-    libxml2-dev \
-    libxslt-dev \
-    libffi-dev
+    libxml2 \
+    libxslt
 
 # Copy dbmate binary from dbmate base image
 COPY --from=ghcr.io/amacneil/dbmate:main /usr/local/bin/dbmate /usr/local/bin/dbmate
 
 WORKDIR /app
+
+RUN python -m pip install --upgrade pip
+
+# copy & install wheel from builder
+COPY --from=system-builder /app/wheels /wheels
+RUN pip install --no-cache-dir /wheels/*
 
 # Python files
 COPY ./refiner/scripts-requirements.txt ./

--- a/Dockerfile.ops
+++ b/Dockerfile.ops
@@ -11,7 +11,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apk update && apk add --no-cache \
     ca-certificates \
     bash \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the base images of the app and ops images to use Alpine instead of the Python slim images, which are based on Debian. We are swapping over to Alpine in an effort to eliminate as much software bloat as possible so that we can limit vulnerabilities and decrease image sizes.

> [!IMPORTANT]
> This change does not impact the Lambda prod image or development images.

## ✅ Acceptance Criteria

- The application and ops containers should continue to function as they did previously

## 🧪 How to test

I'd recommend running the CI setup locally, which will build and use the production ops container and app container. When the setup completes, you can click around the app as normal at http://localhost:8081/.

Shut down your local environment and run this command:

```
docker compose -f docker-compose.yml -f docker-compose.ci.yml up --build
```



