### PR TITLE
chore: add `@typescript-eslint/consistent-type-definitions` ESLint rule

### DIFF
--- a/client/e2e/fixtures/api.ts
+++ b/client/e2e/fixtures/api.ts
@@ -1,27 +1,27 @@
 import { APIRequestContext, expect } from '@playwright/test';
 
-type Configuration = {
+interface Configuration {
   id: string;
   name: string;
-};
+}
 
-type CodedConcept = {
+interface CodedConcept {
   code: string;
   display: string;
-};
+}
 
-type Condition = {
+interface Condition {
   id: string;
   display_name: string;
   rsg_codes: CodedConcept[];
-};
+}
 
-type CustomCode = {
+interface CustomCode {
   code: string;
   system_key: string;
   system_display_name: string;
   name: string;
-};
+}
 
 export class Api {
   constructor(private request: APIRequestContext) {}

--- a/client/e2e/fixtures/index.ts
+++ b/client/e2e/fixtures/index.ts
@@ -11,14 +11,14 @@ import { SimulatorPage } from '../pages/SimulatorPage';
 import { Api } from './api';
 import { ActivityLogPage } from '../pages/ActivityLogPage';
 
-type Fixtures = {
+interface Fixtures {
   configurationPage: ConfigurationPage;
   configurationsPage: ConfigurationsPage;
   simulatorPage: SimulatorPage;
   activityLogPage: ActivityLogPage;
   makeAxeBuilder: () => AxeBuilder;
   api: Api;
-};
+}
 
 const extendedTest = baseTest.extend<Fixtures>({
   makeAxeBuilder: async ({ page }, use) => {

--- a/client/e2e/pages/ActivityLogPage.ts
+++ b/client/e2e/pages/ActivityLogPage.ts
@@ -1,11 +1,11 @@
 import { Page, expect } from '@playwright/test';
 
-type ActivityLogRow = {
+interface ActivityLogRow {
   name: string;
   condition: string;
   action: string;
   date: string;
-};
+}
 
 export class ActivityLogPage {
   constructor(private page: Page) {}

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -76,6 +76,7 @@ export default defineConfig(
       '@typescript-eslint/no-misused-promises': 'off',
       '@typescript-eslint/no-redundant-type-constituents': 'off',
       '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
       '@typescript-eslint/no-restricted-types': [
         'error',
         {

--- a/client/src/components/Diff/DiffToggleOptions.tsx
+++ b/client/src/components/Diff/DiffToggleOptions.tsx
@@ -45,12 +45,12 @@ function DashboardIcon({ isActive }: IconProps) {
   );
 }
 
-type DiffToggleProps = {
+interface DiffToggleProps {
   setShowDiffOnly: React.Dispatch<React.SetStateAction<boolean>>;
   showDiffOnly: boolean;
   splitView: boolean;
   setSplitView: React.Dispatch<React.SetStateAction<boolean>>;
-};
+}
 export function DiffToggleOptions({
   setShowDiffOnly,
   showDiffOnly,

--- a/client/src/components/Diff/Warning.tsx
+++ b/client/src/components/Diff/Warning.tsx
@@ -1,7 +1,7 @@
-type WarningProps = {
+interface WarningProps {
   heading: string;
   message: string;
-};
+}
 
 export function Warning({ heading, message }: WarningProps) {
   return (

--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -8,9 +8,9 @@ import { createContext, useContext } from 'react';
 import classNames from 'classnames';
 import { CloseIcon } from '@components/Icons/CloseIcon';
 
-type ModalContextValue = {
+interface ModalContextValue {
   onClose: () => void;
-};
+}
 
 const ModalContext = createContext<ModalContextValue | null>(null);
 

--- a/client/src/components/Spinner/SpinnerWithMinimalRender.tsx
+++ b/client/src/components/Spinner/SpinnerWithMinimalRender.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { sleep } from '../../utils';
 
-type SpinnerWithMinimalRenderProps = {
+interface SpinnerWithMinimalRenderProps {
   isLoading: boolean;
   renderWhenDone: React.ReactNode;
   loadingMessage?: string;
   minimalRenderDuration?: number;
-};
+}
 
 const TWO_SECONDS_IN_MILLISECONDS = 2000;
 
@@ -28,9 +28,9 @@ export function SpinnerWithMinimalRender({
   );
 }
 
-type SpinnerWithMessageProps = {
+interface SpinnerWithMessageProps {
   loadingMessage: string;
-};
+}
 function SpinnerWithMessage({ loadingMessage }: SpinnerWithMessageProps) {
   return (
     <div className="flex items-center">

--- a/client/src/components/Tooltip/index.tsx
+++ b/client/src/components/Tooltip/index.tsx
@@ -22,11 +22,11 @@ const arrowClasses: Record<TooltipPosition, string> = {
 
 const BOUNDING_GAP = 8;
 
-type PositionConfig = {
+interface PositionConfig {
   top: (r: DOMRect) => number;
   left: (r: DOMRect) => number;
   transform: string;
-};
+}
 
 const POSITION_MAPPING: Record<TooltipPosition, PositionConfig> = {
   top: {

--- a/client/src/pages/Configurations/ConfigBuild/CodeSets/AddConditionCodeSetsDrawer.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CodeSets/AddConditionCodeSetsDrawer.tsx
@@ -6,14 +6,14 @@ import { IncludedCondition } from '../../../../api/schemas';
 import { TesLink } from '../../TesLink';
 import { ConditionCodeSetListItem } from './ConditionCodeSetListItem';
 
-type AddConditionCodeSetsDrawerProps = {
+interface AddConditionCodeSetsDrawerProps {
   isOpen: boolean;
   onClose: () => void;
   conditions: IncludedCondition[];
   configurationId: string;
   reportable_condition_display_name: string;
   disabled: boolean;
-};
+}
 
 export function AddConditionCodeSetsDrawer({
   isOpen,

--- a/client/src/pages/Configurations/ConfigBuild/CodeSets/CodeSetsTable.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CodeSets/CodeSetsTable.tsx
@@ -256,13 +256,13 @@ function Header({ children }: { children: React.ReactNode }) {
   );
 }
 
-type CodeSystemSelectionProps = {
+interface CodeSystemSelectionProps {
   selectedCodeSystem: string;
   handleCodeSystemSelect: (
     event: React.ChangeEvent<HTMLSelectElement, Element>
   ) => void;
   codeSystems: CodeSystemsReponse[];
-};
+}
 
 function CodeSystemSelection({
   selectedCodeSystem,

--- a/client/src/pages/Configurations/ConfigBuild/CodeSets/Drawer.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CodeSets/Drawer.tsx
@@ -13,7 +13,7 @@ import { Search } from '@components/Search';
 import { Button } from '@components/Button';
 import { CloseIcon } from '@components/Icons/CloseIcon';
 
-type DrawerProps = {
+interface DrawerProps {
   title: string | React.ReactNode;
   subtitle?: string | React.ReactNode;
   searchPlaceholder: string;
@@ -22,7 +22,7 @@ type DrawerProps = {
   onClose: () => void;
   onSearch?: (filter: string) => void;
   drawerWidth?: '35%' | '60%';
-};
+}
 
 /**
  * Drawer component used as a sidebar overlay for displaying grouped content.

--- a/client/src/pages/Configurations/ConfigBuild/CustomCodes/CsvImport/ImportCustomCodes.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CustomCodes/CsvImport/ImportCustomCodes.tsx
@@ -27,10 +27,10 @@ const EMPTY_PREVIEW_FORM: UploadCustomCodesPreviewItem = {
   name: '',
 };
 
-type PreviewRow = {
+interface PreviewRow {
   item: SearchPreviewItem;
   matches?: readonly FuseResultMatch[];
-};
+}
 
 interface ImportCustomCodesProps {
   configurationId: string;
@@ -39,7 +39,7 @@ interface ImportCustomCodesProps {
   onStepChange?: (step: CsvImportStep) => void;
 }
 
-type PreviewError = { row: number; error: string };
+interface PreviewError { row: number; error: string }
 
 type SearchPreviewItem = UploadCustomCodesPreviewItem & {
   previewIndex: number;
@@ -149,7 +149,7 @@ export function ImportCustomCodes({
     }
   };
 
-  type UploadCsvError = {
+  interface UploadCsvError {
     response?: {
       data?: {
         detail?: {
@@ -160,7 +160,7 @@ export function ImportCustomCodes({
         };
       };
     };
-  };
+  }
 
   const handleFileChange = async (
     event: React.ChangeEvent<HTMLInputElement>

--- a/client/src/pages/Configurations/ConfigBuild/CustomCodes/CsvImport/ImportCustomCodes.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/CustomCodes/CsvImport/ImportCustomCodes.tsx
@@ -39,7 +39,10 @@ interface ImportCustomCodesProps {
   onStepChange?: (step: CsvImportStep) => void;
 }
 
-interface PreviewError { row: number; error: string }
+interface PreviewError {
+  row: number;
+  error: string;
+}
 
 type SearchPreviewItem = UploadCustomCodesPreviewItem & {
   previewIndex: number;

--- a/client/src/pages/Configurations/ConfigBuild/index.tsx
+++ b/client/src/pages/Configurations/ConfigBuild/index.tsx
@@ -142,9 +142,9 @@ export function ConfigBuild() {
   );
 }
 
-type ExportBuilderProps = {
+interface ExportBuilderProps {
   id: string;
-};
+}
 
 export function Export({ id }: ExportBuilderProps) {
   return (
@@ -535,10 +535,10 @@ function DeleteCodeSetButton({
   );
 }
 
-type OptionsLabelsProps = {
+interface OptionsLabelsProps {
   children: React.ReactNode;
   htmlFor?: string;
-};
+}
 
 function OptionsLabel({ children, htmlFor }: OptionsLabelsProps) {
   const styles = '!text-gray-600 text-base font-bold';

--- a/client/src/pages/Configurations/ConfigurationTitleBar.tsx
+++ b/client/src/pages/Configurations/ConfigurationTitleBar.tsx
@@ -3,15 +3,15 @@ import { useIsMutating } from '@tanstack/react-query';
 
 type ConfigurationSteps = 'build' | 'test' | 'activate';
 
-type ConfigurationTitleBarProps = {
+interface ConfigurationTitleBarProps {
   step: ConfigurationSteps;
   condition: string;
-};
+}
 
-type ConfigurationTitleContent = {
+interface ConfigurationTitleContent {
   title: string;
   subtitle: React.ReactNode;
-};
+}
 
 export function ConfigurationTitleBar({
   step,

--- a/client/src/pages/Configurations/index.tsx
+++ b/client/src/pages/Configurations/index.tsx
@@ -326,10 +326,10 @@ function NewConfigModal({ open, onClose }: NewConfigModalProps) {
   );
 }
 
-type ConditionOptionProps = {
+interface ConditionOptionProps {
   matchResult: FuseResult<GetConditionsResponse> | undefined;
   condition: GetConditionsResponse;
-};
+}
 
 function ConditionOption({ matchResult, condition }: ConditionOptionProps) {
   if (!matchResult) return condition.display_name;
@@ -356,10 +356,10 @@ function ConditionOption({ matchResult, condition }: ConditionOptionProps) {
   );
 }
 
-type RsgMatchRowProps = {
+interface RsgMatchRowProps {
   matchResult: FuseResultMatch;
   rsgCodes: CodedConcept[];
-};
+}
 function RsgMatchRow({ rsgCodes, matchResult }: RsgMatchRowProps) {
   const matchedCode = rsgCodes[matchResult?.refIndex as number];
   const isRsgDisplayMatch = matchResult.key === 'rsg_codes.display';
@@ -384,9 +384,9 @@ function RsgMatchRow({ rsgCodes, matchResult }: RsgMatchRowProps) {
   );
 }
 
-type SelectedConditionPanelProps = {
+interface SelectedConditionPanelProps {
   selectedCondition: GetConditionsResponse;
-};
+}
 function SelectedConditionPanel({
   selectedCondition,
 }: SelectedConditionPanelProps) {

--- a/client/src/pages/Simulator/index.test.tsx
+++ b/client/src/pages/Simulator/index.test.tsx
@@ -58,9 +58,9 @@ const renderView = () =>
     </MemoryRouter>
   );
 
-type MutationParam = {
+interface MutationParam {
   onError?: (error: Error) => void;
-};
+}
 
 describe('Simulate testing', () => {
   describe('Simulate testing - errors during config discovery', () => {


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR adds the `@typescript-eslint/consistent-type-definitions` to enforce consistent type definitions throughout the React client code. It also updates all files that required changes to meet compliance.

## 🧪 How to test

- Automated tests continue to pass
- App works as it did before