### PR TITLE
fix(ui,ux): Have search text for selecting configurations to conform to its stated minimum

### DIFF
--- a/client/src/pages/Configurations/index.tsx
+++ b/client/src/pages/Configurations/index.tsx
@@ -220,7 +220,7 @@ function NewConfigModal({ open, onClose }: NewConfigModalProps) {
     useExtendedSearch: true,
   });
   const searchTextLongEnough =
-    searchText.length > MIN_CONFIG_SEARCH_TEXT_LENGTH;
+    searchText.length >= MIN_CONFIG_SEARCH_TEXT_LENGTH;
   const isSearching = searchTextLongEnough && results.length > 0;
 
   function reset() {


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

I noticed this weird behavior where when searching for text such as HIV, it
wouldn't find a hit until I typed `HIV ` with a space at the end. This to me
felt like the 3 character minimum was actually more like 4. So this updates it
to be an inclusive comparison.

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

1. `just dev::up`
1. Setup a new configuration
1. Type only three characters into the search to get results
