### PR TITLE
fix: Serialized content link is hidden when env is `live`

### DIFF
--- a/client/src/pages/Configurations/SerializedContentButton.tsx
+++ b/client/src/pages/Configurations/SerializedContentButton.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@components/Button';
+import { useGetEnv } from '../../hooks/useGetEnv';
 
 interface SerializedContentButtonProps {
   configurationId: string;
@@ -7,6 +8,9 @@ interface SerializedContentButtonProps {
 export function SerializedContentButton({
   configurationId,
 }: SerializedContentButtonProps) {
+  const env = useGetEnv();
+  if (env === 'live') return;
+
   return (
     <Button
       className="m-0! p-0!"


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR fixes a small issue with #1469 where the proper check was not in place for when the serialized content link will render 🙃  It should only render when `useGetEnv()` returns `local`.