### PR TITLE
fix: remove original and augmented doc_id from lambda logs

### DIFF
--- a/refiner/app/lambda/lambda_function.py
+++ b/refiner/app/lambda/lambda_function.py
@@ -926,7 +926,5 @@ def write_remainder_rrs(
             output_key=rr_output_key,
             jurisdiction_code=jurisdiction_code,
             condition_codes=list(remainder.skipped_codes),
-            original_rr_doc_id=remainder.augmented_result.original_doc_id,
-            augmented_rr_doc_id=remainder.augmented_result.augmented_doc_id,
             operation=LogOperation.REMAINDER_RR_WRITTEN,
         )


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

In order to remove any potential PII or PHI risks from lambda logs, removing original and augmented doc id from being written (was only happening when remainder RR was being written). Change will be mentioned to APHL in Tech Sync on 7/23

<!--
What changes are being proposed?
-->

## 🔗 Related Issue

<!--
add the issue number in both places:
Fixes #3
- #3
-->

Fixes #1549 

- #1549 

## ✅ Acceptance Criteria

 - [ ] rr_doc_id is removed from the logs in the augmentation module
- [ ]  Change is communicated to APHL


<!--
Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
-->

## 🧪 How to test

<!--
Unit tests

1. Ensure dependencies are all installed with `just server install-dev`
1. Test specific paths within the `refiner/` directory with just server test -vv tests/`
1. Additionally you can check coverage with `just server test --cov=app tests`

or

Testing the application:

1. Run `just dev up`
1. Check that all services are up and running with `docker ps`
1. In your browser, navigate to [http://localhost:8081](http://localhost:8081)
   to test the application
1. You should be able to [insert goal you want to accomplish!]
-->

## ℹ️ Additional Information

<!--
Anything else the review team should know?
-->
