### PR TITLE
refactor(dx): suppress warning for eslint

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -106,6 +106,7 @@ export default defineConfig(
           alwaysTryTypes: true,
           extensions: ['.js', '.jsx', '.ts', '.tsx'],
           project: ['./tsconfig.app.json', './e2e/tsconfig.json'],
+          noWarnOnMultipleProjects: true,
         },
         node: {
           extensions: ['.js', '.jsx', '.ts', '.tsx'],


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

Adds `noWarnOnMultipleProjects` to suppress the warning about multiple projects.
It's just noise and I didn't want to incorporate the e2e config into the app's
and ignoring the warning is safe.

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

Run `just client::run lint` and there should be no warning like the one below.

```text
Multiple projects found, consider using a single `tsconfig` with `references` to speed up, or use `noWarnOnMultipleProjects` to suppress this warning
```
