### PR TITLE
fix(dx): run the correct server tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -87,7 +87,7 @@ lint:
 [doc('Run tests on all code')]
 [group('test')]
 test:
-    just server::test
+    just server::test-all
     just client::run test:coverage
     just client::run e2e
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

Since #1438, this recipe would fail because it would just call `just server::test`. Since this is a capture-all test recipe, I've updated it to be `just server::test-all` instead.

## 🔗 Related Issue

- n/a

## ✅ Acceptance Criteria

- n/a

## 🧪 How to test

1. Run `just test`
1. All server tests should run sequentially
1. Tests should all pass.
