### PR TITLE
chore: drop version column from codes

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1216,9 +1216,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1297,9 +1297,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1649,9 +1649,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
-      "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.1.tgz",
+      "integrity": "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1665,8 +1665,8 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^2.0.0-alpha.3",
-        "@emnapi/runtime": "^2.0.0-alpha.3"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@orval/angular": {
@@ -2996,12 +2996,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.14.8",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.8.tgz",
-      "integrity": "sha512-O39GJQpAYEJcIu3uN1//YtmhjSEOyw75vg9CKCatBDPiD5hKtZQoJHfferyrB/LdOD3UWaoMLWtdEjarwIwdDw==",
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.17.6"
+        "@tanstack/virtual-core": "3.17.7"
       },
       "funding": {
         "type": "github",
@@ -3013,9 +3013,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.6",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.6.tgz",
-      "integrity": "sha512-h0/Ebo18CkOrChlQIhNtQkM5ySUnh/GumQ/D1st3hG2HWUPEF+ILUc2k29UtivCi/9G7w7G3/f7Xyd5cCFbKBw==",
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4991,9 +4991,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.6.tgz",
-      "integrity": "sha512-69D/imtToCsIcAl8WBS2YaRwA4jO/j0HhU+hELqMEu9f54MoUtI6+XH5mrKU8rEFNEk/Ui1I2MK4/JkWacclGw==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.8.tgz",
+      "integrity": "sha512-zAgkquC2WYF0PIc6XbNYkA2uuxxFavzgmX61R+dHDUa558V8Ejf8ozTZFR6QzM24RWu4kBcRkhJ5kpz77j9fnQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5034,9 +5034,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5738,9 +5738,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.397",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.397.tgz",
-      "integrity": "sha512-khGTy9U9x02KEtsKM8vx5A62BsRmcOsIgDpWr1ImE32Ax8GxHGPHZf+Eu9H8zOOyHJnB0jTbseyTHbq2XCT8yw==",
+      "version": "1.5.398",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
+      "integrity": "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -6290,9 +6290,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6381,9 +6381,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6506,9 +6506,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6610,9 +6610,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6941,9 +6941,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
-      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -10586,9 +10586,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
-      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",

--- a/refiner/app/db/codes/db.py
+++ b/refiner/app/db/codes/db.py
@@ -14,14 +14,15 @@ async def get_rsg_codes_by_condition_id_db(
     """
 
     query = """
-        SELECT c.display, c.code, c.version, c.system_id
+        SELECT c.display, c.code, tes.version, c.system_id
         FROM conditions_codes as cc
         LEFT JOIN codes c on c.id = cc.code_id
-        WHERE cc.condition_id = %s AND cc.is_child_rsg;
+        LEFT JOIN conditions cond on cond.id = %(condition_id)s
+        LEFT JOIN tes on cond.tes_id = tes.id
+        WHERE cc.condition_id = %(condition_id)s AND cc.is_child_rsg;
     """
-    params = (condition_id,)
     async with db.get_connection() as conn:
         async with conn.cursor(row_factory=class_row(DbCode)) as cur:
-            await cur.execute(query, params)
+            await cur.execute(query, {"condition_id": condition_id})
 
             return await cur.fetchall()

--- a/refiner/migrations/20260729154745_drop_codes_version_col.sql
+++ b/refiner/migrations/20260729154745_drop_codes_version_col.sql
@@ -1,4 +1,12 @@
 -- migrate:up
+
+-- migrate:up
+CREATE INDEX IF NOT EXISTS idx_conditions_codes_code_id
+    ON conditions_codes (code_id);
+
+CREATE INDEX IF NOT EXISTS idx_conditions_codes_condition_id
+    ON conditions_codes (condition_id);
+
 -- Replace the unique constraint to scope to the existing codes
 ALTER TABLE codes
     DROP CONSTRAINT IF EXISTS codes_system_id_version_value_key;
@@ -28,6 +36,9 @@ ALTER TABLE codes
         UNIQUE (system_id, code);
 
 -- migrate:down
+
+DROP INDEX IF EXISTS idx_conditions_codes_code_id;
+DROP INDEX IF EXISTS idx_conditions_codes_condition_id;
 
 -- Re-add version column
 ALTER TABLE codes

--- a/refiner/migrations/20260729154745_drop_codes_version_col.sql
+++ b/refiner/migrations/20260729154745_drop_codes_version_col.sql
@@ -1,6 +1,5 @@
 -- migrate:up
 
--- migrate:up
 CREATE INDEX IF NOT EXISTS idx_conditions_codes_code_id
     ON conditions_codes (code_id);
 

--- a/refiner/migrations/20260729154745_drop_codes_version_col.sql
+++ b/refiner/migrations/20260729154745_drop_codes_version_col.sql
@@ -77,9 +77,9 @@ SELECT
     c.display,
     c.created_at
 FROM conditions_codes cc
-LEFT JOIN codes c ON c.id = cc.code_id
-LEFT JOIN conditions cond ON cc.condition_id = cond.id
-LEFT JOIN tes t ON cond.tes_id = t.id
+JOIN codes c ON c.id = cc.code_id
+JOIN conditions cond ON cc.condition_id = cond.id
+JOIN tes t ON cond.tes_id = t.id
 ON CONFLICT (system_id, version, code) DO NOTHING;
 
 -- update the join table with all the re-inserted codes by checking the linked

--- a/refiner/migrations/20260729154745_drop_codes_version_col.sql
+++ b/refiner/migrations/20260729154745_drop_codes_version_col.sql
@@ -13,12 +13,12 @@ WITH duplicates_to_delete AS (
     WHERE c1.version > c2.version
       AND c1.system_id = c2.system_id
       AND c1.code = c2.code
-    RETURNING c1.id AS old_id, c2.id AS new_id
+    RETURNING c1.id AS new_id, c2.id AS old_id
 )
 UPDATE conditions_codes
-SET code_id = d.new_id
+SET code_id = d.old_id
 FROM duplicates_to_delete d
-WHERE code_id = d.old_id;
+WHERE code_id = d.new_id;
 
 ALTER TABLE codes
     DROP COLUMN version;

--- a/refiner/migrations/20260729154745_drop_codes_version_col.sql
+++ b/refiner/migrations/20260729154745_drop_codes_version_col.sql
@@ -1,0 +1,90 @@
+-- migrate:up
+-- Replace the unique constraint to scope to the existing codes
+ALTER TABLE codes
+    DROP CONSTRAINT IF EXISTS codes_system_id_version_value_key;
+
+-- replace rows in the join table with the deconflicted ID's and then
+-- delete rows made duplicate with the dropped version so we can apply the
+-- followup unique index. Tiebreak self join by version so the replacement
+-- ids line up.
+WITH duplicates_to_delete AS (
+    DELETE FROM codes c1
+    USING codes c2
+    WHERE c1.version > c2.version
+      AND c1.system_id = c2.system_id
+      AND c1.code = c2.code
+    RETURNING c1.id AS old_id, c2.id AS new_id
+)
+UPDATE conditions_codes
+SET code_id = d.new_id
+FROM duplicates_to_delete d
+WHERE code_id = d.old_id;
+
+ALTER TABLE codes
+    DROP COLUMN version;
+
+ALTER TABLE codes
+    ADD CONSTRAINT codes_system_id_code_value_key
+        UNIQUE (system_id, code);
+
+-- migrate:down
+
+-- Re-add version column
+ALTER TABLE codes
+    ADD COLUMN version text;
+
+-- Rebuild the version column on the codes table
+
+-- set the existing code version columns to the highest RV code
+WITH ranked_codes AS (
+    SELECT
+      c.id as code_id,
+      tes.version,
+      ROW_NUMBER() OVER (PARTITION BY cc.code_id ORDER BY tes.version ASC) as rn
+    FROM conditions_codes cc
+    JOIN codes c ON cc.code_id = c.id
+    JOIN conditions cond ON cc.condition_id = cond.id
+    JOIN tes ON cond.tes_id = tes.id
+)
+UPDATE codes c
+SET version = rv.version
+FROM ranked_codes rv
+WHERE c.id = rv.code_id AND rv.rn = 1;
+
+-- Rebuild the old constraint
+ALTER TABLE codes
+    DROP CONSTRAINT IF EXISTS codes_system_id_code_value_key,
+    ALTER COLUMN version SET NOT NULL,
+    ADD CONSTRAINT codes_system_id_version_value_key
+        UNIQUE (system_id, version, code);
+
+-- -- -- insert all the other ones
+INSERT INTO codes (system_id, code, version, display, created_at)
+SELECT
+    c.system_id,
+    c.code,
+    t.version,
+    c.display,
+    c.created_at
+FROM conditions_codes cc
+LEFT JOIN codes c ON c.id = cc.code_id
+LEFT JOIN conditions cond ON cc.condition_id = cond.id
+LEFT JOIN tes t ON cond.tes_id = t.id
+ON CONFLICT (system_id, version, code) DO NOTHING;
+
+-- update the join table with all the re-inserted codes by checking the linked
+-- TES version
+UPDATE conditions_codes cc
+SET code_id = new_codes.id
+FROM
+    conditions cond,
+    tes t,
+    codes new_codes,
+    codes old_codes
+WHERE cc.condition_id = cond.id
+    AND cond.tes_id = t.id
+    AND cc.code_id = old_codes.id
+    AND old_codes.code = new_codes.code
+    AND old_codes.system_id = new_codes.system_id
+    AND new_codes.version = t.version
+    AND cc.code_id != new_codes.id;

--- a/refiner/schema.sql
+++ b/refiner/schema.sql
@@ -138,7 +138,6 @@ CREATE TABLE public.codes (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     display text CONSTRAINT codes_name_not_null NOT NULL,
     code text CONSTRAINT codes_value_not_null NOT NULL,
-    version text NOT NULL,
     system_id uuid NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
@@ -381,11 +380,11 @@ ALTER TABLE ONLY public.codes
 
 
 --
--- Name: codes codes_system_id_version_value_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: codes codes_system_id_code_value_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.codes
-    ADD CONSTRAINT codes_system_id_version_value_key UNIQUE (system_id, version, code);
+    ADD CONSTRAINT codes_system_id_code_value_key UNIQUE (system_id, code);
 
 
 --
@@ -602,13 +601,6 @@ ALTER TABLE ONLY public.users
 
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_username_key UNIQUE (username);
-
-
---
--- Name: codes_upsert_constraint_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX codes_upsert_constraint_idx ON public.codes USING btree (system_id, version, code);
 
 
 --
@@ -912,4 +904,6 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260630173611'),
     ('20260701151910'),
     ('20260709201220'),
-    ('20260716184236');
+    ('20260716184236'),
+    ('20260728212408'),
+    ('20260729154745');

--- a/refiner/schema.sql
+++ b/refiner/schema.sql
@@ -131,6 +131,25 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: active_payload_schema_reactivations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.active_payload_schema_reactivations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    target_schema_version integer CONSTRAINT active_payload_schema_reactivati_target_schema_version_not_null NOT NULL,
+    status text NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone,
+    success_count integer DEFAULT 0 NOT NULL,
+    failure_count integer DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT active_payload_schema_reactivations_counts_check CHECK (((success_count >= 0) AND (failure_count >= 0))),
+    CONSTRAINT active_payload_schema_reactivations_status_check CHECK ((status = ANY (ARRAY['IN_PROGRESS'::text, 'COMPLETE'::text, 'PARTIAL_FAILURE'::text, 'FAILED'::text])))
+);
+
+
+--
 -- Name: codes; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -372,6 +391,14 @@ CREATE TABLE public.users (
 
 
 --
+-- Name: active_payload_schema_reactivations active_payload_schema_reactivations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.active_payload_schema_reactivations
+    ADD CONSTRAINT active_payload_schema_reactivations_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: codes codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -601,6 +628,27 @@ ALTER TABLE ONLY public.users
 
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_username_key UNIQUE (username);
+
+
+--
+-- Name: active_payload_schema_reactivations_one_complete_per_version_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX active_payload_schema_reactivations_one_complete_per_version_id ON public.active_payload_schema_reactivations USING btree (target_schema_version) WHERE (status = 'COMPLETE'::text);
+
+
+--
+-- Name: active_payload_schema_reactivations_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX active_payload_schema_reactivations_status_idx ON public.active_payload_schema_reactivations USING btree (status);
+
+
+--
+-- Name: active_payload_schema_reactivations_target_schema_version_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX active_payload_schema_reactivations_target_schema_version_idx ON public.active_payload_schema_reactivations USING btree (target_schema_version);
 
 
 --
@@ -905,5 +953,6 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260701151910'),
     ('20260709201220'),
     ('20260716184236'),
+    ('20260722140510'),
     ('20260728212408'),
     ('20260729154745');

--- a/refiner/schema.sql
+++ b/refiner/schema.sql
@@ -680,6 +680,20 @@ CREATE INDEX configurations_sections_configuration_id_idx ON public.configuratio
 
 
 --
+-- Name: idx_conditions_codes_code_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_conditions_codes_code_id ON public.conditions_codes USING btree (code_id);
+
+
+--
+-- Name: idx_conditions_codes_condition_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_conditions_codes_condition_id ON public.conditions_codes USING btree (condition_id);
+
+
+--
 -- Name: one_primary_per_configuration; Type: INDEX; Schema: public; Owner: -
 --
 

--- a/refiner/scripts/seeding/lib.py
+++ b/refiner/scripts/seeding/lib.py
@@ -291,7 +291,6 @@ class CodeRow(TypedDict):
     id: UUID
     display: str
     code: str
-    version: str
     system_id: str
 
 

--- a/refiner/scripts/seeding/load_static_data.py
+++ b/refiner/scripts/seeding/load_static_data.py
@@ -80,9 +80,11 @@ class ProcessedCondition(TypedDict):
 
 type SystemDbId = str
 type SystemOid = str
-
 type CodeValue = str
-type SystemCodeTuple = tuple[SystemDbId, CodeValue]
+type DbCodedConcept = tuple[SystemDbId, CodeValue]
+
+type CodeVersion = str
+type SystemCodeTuple = tuple[SystemDbId, CodeVersion, CodeValue]
 
 
 class ConditionToCodeRelationshipTrace(TypedDict):
@@ -93,13 +95,15 @@ class ConditionToCodeRelationshipTrace(TypedDict):
     condition_id: UUID
     condition_url: str
     condition_display_name: str
-    child_rsg_codes: set[SystemCodeTuple]
-    non_child_rsg_codes: set[SystemCodeTuple]
+    child_rsg_codes: set[DbCodedConcept]
+    non_child_rsg_codes: set[DbCodedConcept]
 
 
 type ConditionUniqueIndex = tuple[VsCanonicalUrl, VsVersion]
 
-type ConditionToCodeRelationshipIndex = dict[str, ConditionToCodeRelationshipTrace]
+type ConditionToCodeRelationshipIndex = dict[
+    ConditionUniqueIndex, ConditionToCodeRelationshipTrace
+]
 
 
 class ProcessedCodePayload(TypedDict):
@@ -162,14 +166,15 @@ def _build_codes(
     condition_to_code_relationships: ConditionToCodeRelationshipIndex,
 ) -> ProcessedCodePayload:
     snomed_db_id = oid_indexed_system_db_ids[SNOMED_OID]
-    codes_seen_so_far: set[tuple[str, str]] = set()
+    codes_seen_so_far: set[DbCodedConcept] = set()
     codes_for_codes_table: list[CodeRow] = []
 
     for condition in condition_groupers:
         cond_canonical_url = condition.get("url", "")
+        cond_version = condition.get("version", "")
 
-        condition_child_rsg_snomed_codes: set[SystemCodeTuple] = set()
-        condition_non_child_rsg_snomed_codes: set[SystemCodeTuple] = set()
+        condition_child_rsg_snomed_codes: set[DbCodedConcept] = set()
+        condition_non_child_rsg_snomed_codes: set[DbCodedConcept] = set()
 
         child_tuples: set[FhirCodeTuple] = set()
 
@@ -198,9 +203,9 @@ def _build_codes(
                     )
                 )
 
-        condition_to_code_relationships[cond_canonical_url]["child_rsg_codes"] = (
-            condition_child_rsg_snomed_codes
-        )
+        condition_to_code_relationships[(cond_canonical_url, cond_version)][
+            "child_rsg_codes"
+        ] = condition_child_rsg_snomed_codes
         sibling_code_tuple_sets = [
             extract_codes_from_compose(sibling_vs)
             for sibling_vs in get_sibling_context_valuesets(condition, valuesets_map)
@@ -242,9 +247,9 @@ def _build_codes(
                 ):
                     condition_non_child_rsg_snomed_codes.add(code_tuple)
 
-        condition_to_code_relationships[cond_canonical_url]["non_child_rsg_codes"] = (
-            condition_non_child_rsg_snomed_codes
-        )
+        condition_to_code_relationships[(cond_canonical_url, cond_version)][
+            "non_child_rsg_codes"
+        ] = condition_non_child_rsg_snomed_codes
 
     return ProcessedCodePayload(
         codes_to_insert=codes_for_codes_table,
@@ -381,9 +386,9 @@ def _upsert_conditions_and_groupers(
             OR conditions_context_groupers.code_count IS DISTINCT FROM EXCLUDED.code_count
             OR conditions_context_groupers.completeness IS DISTINCT FROM EXCLUDED.completeness
     """
-    condition_to_code_relationships: dict[str, ConditionToCodeRelationshipTrace] = (
-        defaultdict()
-    )
+    condition_to_code_relationships: dict[
+        ConditionUniqueIndex, ConditionToCodeRelationshipTrace
+    ] = defaultdict()
 
     for item in processed:
         cond = item["condition"]
@@ -397,6 +402,8 @@ def _upsert_conditions_and_groupers(
 
         cond_id = condition_response[0]
         condition_canonical_url = cond.get("canonical_url")
+        condition_version = cond.get("version")
+
         condition_name = cond.get("display_name")
         condition_payload = ConditionToCodeRelationshipTrace(
             condition_id=cond_id,
@@ -406,7 +413,9 @@ def _upsert_conditions_and_groupers(
             condition_url=condition_canonical_url,
         )
 
-        condition_to_code_relationships[condition_canonical_url] = condition_payload
+        condition_to_code_relationships[
+            (condition_canonical_url, condition_version)
+        ] = condition_payload
 
         groupers = item.get("context_groupers", [])
         if not groupers:

--- a/refiner/scripts/seeding/load_static_data.py
+++ b/refiner/scripts/seeding/load_static_data.py
@@ -101,9 +101,7 @@ class ConditionToCodeRelationshipTrace(TypedDict):
 
 type ConditionUniqueIndex = tuple[VsCanonicalUrl, VsVersion]
 
-type ConditionToCodeRelationshipIndex = dict[
-    ConditionUniqueIndex, ConditionToCodeRelationshipTrace
-]
+type ConditionToCodeRelationshipIndex = dict[str, ConditionToCodeRelationshipTrace]
 
 
 class ProcessedCodePayload(TypedDict):
@@ -386,9 +384,9 @@ def _upsert_conditions_and_groupers(
             OR conditions_context_groupers.code_count IS DISTINCT FROM EXCLUDED.code_count
             OR conditions_context_groupers.completeness IS DISTINCT FROM EXCLUDED.completeness
     """
-    condition_to_code_relationships: dict[
-        ConditionUniqueIndex, ConditionToCodeRelationshipTrace
-    ] = defaultdict()
+    condition_to_code_relationships: dict[str, ConditionToCodeRelationshipTrace] = (
+        defaultdict()
+    )
 
     for item in processed:
         cond = item["condition"]

--- a/refiner/scripts/seeding/load_static_data.py
+++ b/refiner/scripts/seeding/load_static_data.py
@@ -101,7 +101,9 @@ class ConditionToCodeRelationshipTrace(TypedDict):
 
 type ConditionUniqueIndex = tuple[VsCanonicalUrl, VsVersion]
 
-type ConditionToCodeRelationshipIndex = dict[str, ConditionToCodeRelationshipTrace]
+type ConditionToCodeRelationshipIndex = dict[
+    ConditionUniqueIndex, ConditionToCodeRelationshipTrace
+]
 
 
 class ProcessedCodePayload(TypedDict):
@@ -384,9 +386,9 @@ def _upsert_conditions_and_groupers(
             OR conditions_context_groupers.code_count IS DISTINCT FROM EXCLUDED.code_count
             OR conditions_context_groupers.completeness IS DISTINCT FROM EXCLUDED.completeness
     """
-    condition_to_code_relationships: dict[str, ConditionToCodeRelationshipTrace] = (
-        defaultdict()
-    )
+    condition_to_code_relationships: dict[
+        ConditionUniqueIndex, ConditionToCodeRelationshipTrace
+    ] = defaultdict()
 
     for item in processed:
         cond = item["condition"]

--- a/refiner/scripts/seeding/load_static_data.py
+++ b/refiner/scripts/seeding/load_static_data.py
@@ -80,10 +80,9 @@ class ProcessedCondition(TypedDict):
 
 type SystemDbId = str
 type SystemOid = str
-type CodeVersion = str
 
 type CodeValue = str
-type SystemCodeTuple = tuple[SystemDbId, CodeVersion, CodeValue]
+type SystemCodeTuple = tuple[SystemDbId, CodeValue]
 
 
 class ConditionToCodeRelationshipTrace(TypedDict):
@@ -92,17 +91,15 @@ class ConditionToCodeRelationshipTrace(TypedDict):
     """
 
     condition_id: UUID
+    condition_url: str
     condition_display_name: str
     child_rsg_codes: set[SystemCodeTuple]
     non_child_rsg_codes: set[SystemCodeTuple]
-    version: str
 
 
 type ConditionUniqueIndex = tuple[VsCanonicalUrl, VsVersion]
 
-type ConditionToCodeRelationshipIndex = dict[
-    ConditionUniqueIndex, ConditionToCodeRelationshipTrace
-]
+type ConditionToCodeRelationshipIndex = dict[str, ConditionToCodeRelationshipTrace]
 
 
 class ProcessedCodePayload(TypedDict):
@@ -164,15 +161,12 @@ def _build_codes(
     oid_indexed_system_db_ids: dict[SystemOid, SystemDbId],
     condition_to_code_relationships: ConditionToCodeRelationshipIndex,
 ) -> ProcessedCodePayload:
-
     snomed_db_id = oid_indexed_system_db_ids[SNOMED_OID]
-    codes_seen_so_far: set[tuple[str, str, str]] = set()
+    codes_seen_so_far: set[tuple[str, str]] = set()
     codes_for_codes_table: list[CodeRow] = []
 
     for condition in condition_groupers:
         cond_canonical_url = condition.get("url", "")
-        cond_version = condition.get("version", "")
-        cond_index = (cond_canonical_url, cond_version)
 
         condition_child_rsg_snomed_codes: set[SystemCodeTuple] = set()
         condition_non_child_rsg_snomed_codes: set[SystemCodeTuple] = set()
@@ -190,7 +184,7 @@ def _build_codes(
             display = parse_child_rsg_details_from_use_context(
                 child_vs.get("useContext", "")
             )
-            code_tuple = (snomed_db_id, cond_version, child_rsg_code)
+            code_tuple = (snomed_db_id, child_rsg_code)
             condition_child_rsg_snomed_codes.add(code_tuple)
 
             if code_tuple not in codes_seen_so_far:
@@ -199,13 +193,12 @@ def _build_codes(
                     CodeRow(
                         id=uuid4(),
                         code=child_rsg_code,
-                        version=cond_version,
                         display=display,
                         system_id=snomed_db_id,
                     )
                 )
 
-        condition_to_code_relationships[cond_index]["child_rsg_codes"] = (
+        condition_to_code_relationships[cond_canonical_url]["child_rsg_codes"] = (
             condition_child_rsg_snomed_codes
         )
         sibling_code_tuple_sets = [
@@ -231,13 +224,12 @@ def _build_codes(
                 if not code:
                     continue
 
-                code_tuple = (system_id, cond_version, code)
+                code_tuple = (system_id, code)
                 if code_tuple not in codes_seen_so_far:
                     codes_seen_so_far.add(code_tuple)
                     code_row = CodeRow(
                         id=uuid4(),
                         code=code,
-                        version=cond_version,
                         display=c.get("display") or "",
                         system_id=system_id,
                     )
@@ -250,7 +242,7 @@ def _build_codes(
                 ):
                     condition_non_child_rsg_snomed_codes.add(code_tuple)
 
-        condition_to_code_relationships[cond_index]["non_child_rsg_codes"] = (
+        condition_to_code_relationships[cond_canonical_url]["non_child_rsg_codes"] = (
             condition_non_child_rsg_snomed_codes
         )
 
@@ -389,9 +381,9 @@ def _upsert_conditions_and_groupers(
             OR conditions_context_groupers.code_count IS DISTINCT FROM EXCLUDED.code_count
             OR conditions_context_groupers.completeness IS DISTINCT FROM EXCLUDED.completeness
     """
-    condition_to_code_relationships: dict[
-        ConditionUniqueIndex, ConditionToCodeRelationshipTrace
-    ] = defaultdict()
+    condition_to_code_relationships: dict[str, ConditionToCodeRelationshipTrace] = (
+        defaultdict()
+    )
 
     for item in processed:
         cond = item["condition"]
@@ -405,18 +397,16 @@ def _upsert_conditions_and_groupers(
 
         cond_id = condition_response[0]
         condition_canonical_url = cond.get("canonical_url")
-        condition_version = cond.get("version")
         condition_name = cond.get("display_name")
-        condition_index = (condition_canonical_url, condition_version)
         condition_payload = ConditionToCodeRelationshipTrace(
             condition_id=cond_id,
             condition_display_name=condition_name,
             child_rsg_codes=set(),
             non_child_rsg_codes=set(),
-            version=condition_version,
+            condition_url=condition_canonical_url,
         )
 
-        condition_to_code_relationships[condition_index] = condition_payload
+        condition_to_code_relationships[condition_canonical_url] = condition_payload
 
         groupers = item.get("context_groupers", [])
         if not groupers:
@@ -449,7 +439,6 @@ def _upsert_relationships(
         CREATE TEMP TABLE IF NOT EXISTS stage_relationships (
             condition_id UUID NOT NULL,
             system_id UUID NOT NULL,
-            version TEXT NOT NULL,
             code TEXT NOT NULL,
             is_child_rsg BOOLEAN NOT NULL
         ) ON COMMIT DROP
@@ -466,17 +455,17 @@ def _upsert_relationships(
             if not cond_id:
                 continue
 
-            for system_id, version, code in cond["child_rsg_codes"]:
+            for system_id, code in cond["child_rsg_codes"]:
                 staged_counts[child_rsg_key] += 1
-                yield (cond_id, system_id, version, code, True)
+                yield (cond_id, system_id, code, True)
 
-            for system_id, version, code in cond["non_child_rsg_codes"]:
+            for system_id, code in cond["non_child_rsg_codes"]:
                 staged_counts[non_child_rsg_key] += 1
-                yield (cond_id, system_id, version, code, False)
+                yield (cond_id, system_id, code, False)
 
     logger.info("🚀 Streaming relationships into stage table...")
     with cursor.copy(
-        """COPY stage_relationships (condition_id, system_id, version, code, is_child_rsg) FROM STDIN"""
+        """COPY stage_relationships (condition_id, system_id, code, is_child_rsg) FROM STDIN"""
     ) as copy:
         for row in relationship_generator():
             copy.write_row(row)
@@ -495,7 +484,6 @@ def _upsert_relationships(
         FROM stage_relationships sr
         JOIN codes c
             ON  c.system_id = sr.system_id
-            AND c.version = sr.version
             AND c.code = sr.code;
     """)
 
@@ -518,7 +506,6 @@ def _upsert_codes(
         CREATE TEMP TABLE IF NOT EXISTS stage_codes (
             id UUID NOT NULL,
             system_id UUID NOT NULL,
-            version TEXT NOT NULL,
             code TEXT NOT NULL,
             display TEXT
         ) ON COMMIT DROP
@@ -530,14 +517,13 @@ def _upsert_codes(
             yield (
                 code["id"],
                 code["system_id"],
-                code["version"],
                 code["code"],
                 code["display"],
             )
 
     logger.info("🚀 Streaming codes into stage table...")
     with cursor.copy(
-        "COPY stage_codes (id, system_id, version, code, display) FROM STDIN"
+        "COPY stage_codes (id, system_id, code, display) FROM STDIN"
     ) as copy:
         for record in code_generator():
             copy.write_row(record)
@@ -546,16 +532,15 @@ def _upsert_codes(
     cursor.execute("ANALYZE stage_codes;")
 
     cursor.execute("""
-        INSERT INTO codes (id, system_id, version, code, display)
-        SELECT s.id, s.system_id, s.version, s.code, s.display
+        INSERT INTO codes (id, system_id, code, display)
+        SELECT s.id, s.system_id, s.code, s.display
         FROM stage_codes s
         LEFT JOIN codes c
             ON  s.system_id = c.system_id
             AND s.code = c.code
-            AND s.version = c.version
         WHERE c.id IS NULL
-        ORDER BY s.system_id, s.version, s.code
-        ON CONFLICT (system_id, version, code) DO NOTHING;
+        ORDER BY s.system_id, s.code
+        ON CONFLICT (system_id, code) DO NOTHING;
     """)
 
     logger.info(f"✨ {cursor.rowcount:,} total new rows inserted in codes table.")


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

Changes to the codes table / seed script to support version-agnostic codes. Part of the TES diff work to help with performance of DB queries 

## 🔗 Related Issue
Task within #1430 
- #1430

## ✅ Acceptance Criteria

- [ ] Codes table doesn't have version information
- [ ] All codes <> conditions information remains the same
- [ ] App doesn't have degraded functionality

## 🧪 How to test
- Run a refresh on main with `just db refresh` 
- Switch to this branch and run migrate. Note the codes should be shrinking (150912 -- > 89146 unique codes), but the relationships should stay the same (583,955 total relationships (558 child_rsg, 583,397 non_child_rsg)). Check the child_rsg codes numbers and the relationship join numbers are the same
- Verify app functionality is the same
- Run a down migration to check the db gets reset correctly

