### PR TITLE
chore: show which `ops/entrypoint.sh` vars are missing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,12 +41,11 @@ services:
       - ./refiner/app/db:/var/task/app/db
       - ./refiner/assets:/var/task/assets
 
+# Run with `docker compose --profile ops run --rm ops prepare-db`
   ops:
     build:
       context: .
       dockerfile: Dockerfile.ops
-      args:
-        VERSION: ${VERSION:-0.0.0}
     working_dir: /app
     entrypoint: ["./entrypoint.sh"]
     depends_on:

--- a/ops/README.md
+++ b/ops/README.md
@@ -4,16 +4,15 @@
 
 | Name                    | Description                                      | Required | Default value |
 | ----------------------- | ------------------------------------------------ | -------- | ------------- |
-| `ENV`                   | Runtime environment, such as `local` or `demo`   | Yes      | N/A           |
-| `VERSION`               | Application/version identifier                   | Yes      | N/A           |
+| `ENV`                   | Runtime environment, such as `development` or `production`   | Yes      | N/A           |
 | `DB_URL`                | The PostgreSQL database URL                      | Yes      | N/A           |
 | `DB_PASSWORD`           | The PostgreSQL password                          | Yes      | N/A           |
-| `SSL_MODE`              | PostgreSQL `sslmode` value                       | No       | `require`     |
-| `AWS_REGION`            | AWS region used when creating the S3 client      | Yes      | N/A           |
-| `AWS_ACCESS_KEY_ID`     | AWS access key for local/demo S3 access          | Local/demo only | N/A     |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret key for local/demo S3 access          | Local/demo only | N/A     |
-| `S3_ENDPOINT_URL`       | Custom S3 endpoint, used for LocalStack/demo S3  | Local/demo only | N/A     |
 | `S3_BUCKET_CONFIG`      | S3 bucket containing configuration artifacts     | Yes      | N/A           |
+| `AWS_REGION`            | AWS region used when creating the S3 client      | Yes      | N/A           |
+| `SSL_MODE`              | PostgreSQL `sslmode` value                       | No       | `require`     |
+| `AWS_ACCESS_KEY_ID`     | AWS access key for local/demo S3 access          | Local/demo only | N/A    |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key for local/demo S3 access          | Local/demo only | N/A    |
+| `S3_ENDPOINT_URL`       | Custom S3 endpoint, used for LocalStack/demo S3  | Local/demo only | N/A    |
 
 ## entrypoint.sh
 

--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -5,22 +5,33 @@ set -euo pipefail # exit on failure
 SSL_MODE="${SSL_MODE:-require}"
 
 # Ensure required variables are present
-if [[ -z "${ENV:-}" || \
-      -z "${VERSION:-}" || \
-      -z "${DB_URL:-}" || \
-      -z "${DB_PASSWORD:-}" || \
-      -z "${AWS_REGION:-}" || \
-      -z "${S3_BUCKET_CONFIG:-}" ]]; then
-  echo "ERROR: ENV, VERSION, DB_URL, DB_PASSWORD, AWS_REGION, and S3_BUCKET_CONFIG must be set"
+REQUIRED_VARS=(ENV DB_URL DB_PASSWORD AWS_REGION S3_BUCKET_CONFIG)
+MISSING=()
+
+for var in "${REQUIRED_VARS[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    MISSING+=("$var")
+  fi
+done
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "ERROR: The following required variables are not set: ${MISSING[*]}"
   exit 1
 fi
 
 # Ensure local/demo S3 variables are present
 if [[ "${ENV}" == "local" || "${ENV}" == "demo" ]]; then
-  if [[ -z "${AWS_ACCESS_KEY_ID:-}" || \
-        -z "${AWS_SECRET_ACCESS_KEY:-}" || \
-        -z "${S3_ENDPOINT_URL:-}" ]]; then
-    echo "ERROR: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and S3_ENDPOINT_URL must be set for local/demo"
+  LOCAL_VARS=(AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY S3_ENDPOINT_URL)
+  MISSING=()
+
+  for var in "${LOCAL_VARS[@]}"; do
+    if [[ -z "${!var:-}" ]]; then
+      MISSING+=("$var")
+    fi
+  done
+
+  if [[ ${#MISSING[@]} -gt 0 ]]; then
+    echo "ERROR: The following variables are required for local/demo: ${MISSING[*]}"
     exit 1
   fi
 fi


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

I've made a small update to this script to tell you exactly which variables are missing. This should make debugging a little easier, especially when we see failures in dev.

I also realized that `VERSION` is not required, so I've removed it.

Instead of an error like this if `ENV` and `DB_URL` were missing, for example:
```sh
ERROR: ENV, VERSION, DB_URL, DB_PASSWORD, AWS_REGION, and S3_BUCKET_CONFIG must be set
```

You'll now see something like this:
```sh
ERROR: The following required variables are not set: ENV DB_URL
```

## 🧪 How to test

1. Run `docker compose build ops --no-cache`
2. Delete a variable or two from the `ops` service in `docker-compose.yml`
3. Run `docker compose --profile ops run --rm ops prepare-db`
4. Check that the error message reflects the variables you deleted