### PR TITLE
feat: move 'Export configuration' link to Test & export tab

### DIFF
--- a/client/src/pages/Configurations/ConfigTest/index.test.tsx
+++ b/client/src/pages/Configurations/ConfigTest/index.test.tsx
@@ -100,6 +100,13 @@ describe('Config testing page', () => {
     ).toHaveAttribute('aria-current', 'page');
   });
 
+  it('should display an "Export configuration" button', () => {
+    renderPage();
+    expect(
+      screen.getByText('Export configuration', { selector: 'a' })
+    ).toBeInTheDocument();
+  });
+
   it('should warn the user that the expected condition was not found during inline testing', async () => {
     const user = userEvent.setup();
 

--- a/client/src/pages/Configurations/ConfigTest/index.tsx
+++ b/client/src/pages/Configurations/ConfigTest/index.tsx
@@ -30,10 +30,14 @@ export function ConfigTest() {
     <div>
       <Header configuration={configuration.data} />
       <SectionContainer>
-        <ConfigurationTitleBar
-          title="Test configuration"
-          subtitle="Check the results of your configuration before turning it on."
-        />
+        <div className="flex flex-wrap justify-between">
+          <ConfigurationTitleBar
+            title="Test configuration"
+            subtitle="Check the results of your configuration before turning it on."
+          />
+          <Export id={configuration.data.id} />
+        </div>
+
         <Test config={configuration.data} />
       </SectionContainer>
     </div>
@@ -132,4 +136,20 @@ function useZipUpload() {
     errorMessage,
     resetState,
   };
+}
+
+interface ExportBuilderProps {
+  id: string;
+}
+
+function Export({ id }: ExportBuilderProps) {
+  return (
+    <a
+      className="text-blue-cool-60 mt-8 mb-6 self-end font-bold hover:cursor-pointer hover:underline"
+      href={`/api/v1/configurations/${id}/export`}
+      download
+    >
+      Export configuration
+    </a>
+  );
 }

--- a/client/src/pages/Configurations/ManageCodes/index.test.tsx
+++ b/client/src/pages/Configurations/ManageCodes/index.test.tsx
@@ -602,13 +602,6 @@ describe('Manage codes page', () => {
     await user.click(screen.getByText('Delete', { selector: 'button' }));
   });
 
-  it('should display an "Export configuration" button', () => {
-    renderPage();
-    expect(
-      screen.getByText('Export configuration', { selector: 'a' })
-    ).toBeInTheDocument();
-  });
-
   it('should bulk upload custom codes from a CSV file', async () => {
     const user = userEvent.setup();
     renderPage();

--- a/client/src/pages/Configurations/ManageCodes/index.tsx
+++ b/client/src/pages/Configurations/ManageCodes/index.tsx
@@ -122,13 +122,10 @@ export function ManageCodes() {
         />
       ) : null}
       <SectionContainer>
-        <div className="content flex flex-wrap justify-between">
-          <ConfigurationTitleBar
-            title="Manage codes"
-            subtitle="These codes will be used alongside the condition codesets by the Refiner to search for and retain."
-          />
-          <Export id={configuration.data.id} />
-        </div>
+        <ConfigurationTitleBar
+          title="Manage codes"
+          subtitle="These codes will be used alongside the condition codesets by the Refiner to search for and retain."
+        />
 
         <Builder
           id={configuration.data.id}
@@ -140,22 +137,6 @@ export function ManageCodes() {
         />
       </SectionContainer>
     </>
-  );
-}
-
-interface ExportBuilderProps {
-  id: string;
-}
-
-export function Export({ id }: ExportBuilderProps) {
-  return (
-    <a
-      className="text-blue-cool-60 mt-8 mb-6 self-end font-bold hover:cursor-pointer hover:underline"
-      href={`/api/v1/configurations/${id}/export`}
-      download
-    >
-      Export configuration
-    </a>
   );
 }
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR simply moves the `Export configuration` link to the "Test & export" tab in the config flow from the "Manage codes" tab.

## 📺 Demo

<img width="1595" height="1178" alt="image" src="https://github.com/user-attachments/assets/e5fcab76-7e47-44a3-9d76-fc0230430079" />

## 🧪 How to test

- Check that "Manage codes" does not have a link to download the config and "Test & export" does
- Check that the link downloads the file correctly
- Automated tests should complete successfully