### PR TITLE
fix: increase version menu z-index

### DIFF
--- a/client/src/pages/Configurations/ManageCodes/VersionMenu.tsx
+++ b/client/src/pages/Configurations/ManageCodes/VersionMenu.tsx
@@ -24,7 +24,7 @@ export function VersionMenu({
 
   return (
     <>
-      <Menu as="div" className="z-10">
+      <Menu as="div" className="z-50">
         <MenuButton>
           <div className="cursor-pointer">
             <span className="font-bold">


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR ups the z-index on the version menu. The main reason for this being that the version menu now has the possibility of overlapping the sticky header on the sections table. Increasing the z-index value of the menu ensures it will be rendered on top.

## 📺 Demo

Before:

<img width="960" height="664" alt="image" src="https://github.com/user-attachments/assets/b7656fa3-52dd-43ec-8c49-1f2ffbad7c84" />

After:

<img width="961" height="615" alt="image" src="https://github.com/user-attachments/assets/603f6bb0-8771-48d0-a244-b184d3e86b5c" />

## 🧪 How to test

1. Navigate to the sections tab in the configuration view
2. Create enough versions of a config to make the version menu its maximum height
3. Ensure that the menu is rendered on top of the table header