### PR TITLE
feat: move version selection menu into header

### DIFF
--- a/client/src/pages/Configurations/ManageCodes/VersionMenu.tsx
+++ b/client/src/pages/Configurations/ManageCodes/VersionMenu.tsx
@@ -23,56 +23,50 @@ export function VersionMenu({
   const step = useGetStep();
 
   return (
-    <>
-      <Menu as="div" className="z-10">
-        <MenuButton>
-          <div className="cursor-pointer">
-            <span className="font-bold">
-              {status === 'draft' ? 'Editing' : 'Viewing'}: Version{' '}
-              {currentVersion}
-            </span>
-            <ArrowDropDownIcon />
-          </div>
-        </MenuButton>
-        <MenuItems className="absolute mt-1 ml-4 flex max-h-100 flex-col overflow-y-auto rounded-lg bg-white px-4 py-2 shadow-lg">
-          {versions.map((config, i) => (
-            <Fragment key={config.id}>
-              <MenuItem>
-                <Link
-                  className="data-focus:bg-gray-10 block p-2"
-                  to={`/configurations/${config.id}/${step}`}
-                >
-                  <div className="flex flex-col">
-                    <VersionText
-                      versionNumber={config.version}
-                      isActive={config.status === 'active'}
-                    />
-                    <MenuItemDetail
-                      className="text-gray-60"
-                      created_at={config.created_at}
-                      created_by={config.created_by}
-                      last_activated_at={config.last_activated_at}
-                      last_activated_by={config.last_activated_by}
-                    />
-                  </div>
-                </Link>
-              </MenuItem>
-              {versions.length - 1 !== i && (
-                <div
-                  aria-hidden
-                  key={`${config.id}-divider`}
-                  className="bg-gray-cool-10 my-1 h-px"
-                />
-              )}
-            </Fragment>
-          ))}
-        </MenuItems>
-      </Menu>
-      <div
-        aria-hidden
-        className="border-gray-cool-20 mx-1 hidden h-10 border-l md:block"
-      />
-    </>
+    <Menu as="div" className="z-10">
+      <MenuButton>
+        <div className="cursor-pointer">
+          <span>
+            {status === 'draft' ? 'Editing' : 'Viewing'}:{' '}
+            <span className="font-bold">Version {currentVersion}</span>
+          </span>
+          <ArrowDropDownIcon />
+        </div>
+      </MenuButton>
+      <MenuItems className="absolute mt-1 ml-4 flex max-h-100 flex-col overflow-y-auto rounded-lg bg-white px-4 py-2 shadow-lg">
+        {versions.map((config, i) => (
+          <Fragment key={config.id}>
+            <MenuItem>
+              <Link
+                className="data-focus:bg-gray-10 block p-2"
+                to={`/configurations/${config.id}/${step}`}
+              >
+                <div className="flex flex-col">
+                  <VersionText
+                    versionNumber={config.version}
+                    isActive={config.status === 'active'}
+                  />
+                  <MenuItemDetail
+                    className="text-gray-60"
+                    created_at={config.created_at}
+                    created_by={config.created_by}
+                    last_activated_at={config.last_activated_at}
+                    last_activated_by={config.last_activated_by}
+                  />
+                </div>
+              </Link>
+            </MenuItem>
+            {versions.length - 1 !== i && (
+              <div
+                aria-hidden
+                key={`${config.id}-divider`}
+                className="bg-gray-cool-10 my-1 h-px"
+              />
+            )}
+          </Fragment>
+        ))}
+      </MenuItems>
+    </Menu>
   );
 }
 

--- a/client/src/pages/Configurations/ManageCodes/VersionMenu.tsx
+++ b/client/src/pages/Configurations/ManageCodes/VersionMenu.tsx
@@ -25,7 +25,10 @@ export function VersionMenu({
   return (
     <Menu as="div" className="z-50">
       <MenuButton>
-        <div className="cursor-pointer">
+        {/* NOTE: using data-testid in order to make this simple to grab in test code.
+              `findByText` won't work due to the span breaking up the text.
+          */}
+        <div data-testid="selected-version-label" className="cursor-pointer">
           {status === 'draft' ? 'Editing' : 'Viewing'}:{' '}
           <span className="font-bold">Version {currentVersion}</span>
           <ArrowDropDownIcon />

--- a/client/src/pages/Configurations/ManageCodes/index.test.tsx
+++ b/client/src/pages/Configurations/ManageCodes/index.test.tsx
@@ -202,10 +202,12 @@ describe('Manage codes page', () => {
 
   it('should render a version menu with previous versions', async () => {
     const user = userEvent.setup();
-    const expectedMenuText = 'Editing: Version 2';
+    const versionSelectorTestId = 'selected-version-label';
     renderPage();
-    expect(await screen.findByText(expectedMenuText)).toBeInTheDocument();
-    await user.click(await screen.findByText(expectedMenuText));
+    expect(
+      await screen.findByTestId(versionSelectorTestId)
+    ).toBeInTheDocument();
+    await user.click(await screen.findByTestId(versionSelectorTestId));
     expect(await screen.findAllByRole('menuitem')).toHaveLength(2);
   });
 
@@ -284,7 +286,7 @@ describe('Manage codes page', () => {
   });
 
   it('should display user and status information in the version picker menu', async () => {
-    const expectedMenuText = 'Editing: Version 2';
+    const versionSelectorTestId = 'selected-version-label';
     const user = userEvent.setup();
     (useGetConfiguration as unknown as Mock).mockReturnValue({
       data: {
@@ -301,8 +303,13 @@ describe('Manage codes page', () => {
     renderPage();
 
     // check that menu structure looks accurate
-    expect(await screen.findByText(expectedMenuText)).toBeInTheDocument();
-    await user.click(await screen.findByText(expectedMenuText));
+    expect(
+      await screen.findByTestId(versionSelectorTestId)
+    ).toBeInTheDocument();
+    expect(await screen.findByTestId(versionSelectorTestId)).toHaveTextContent(
+      'Editing: Version 2'
+    );
+    await user.click(await screen.findByTestId(versionSelectorTestId));
     const menuItems = await screen.findAllByRole('menuitem');
     expect(menuItems).toHaveLength(2);
 

--- a/client/src/pages/Configurations/layout.tsx
+++ b/client/src/pages/Configurations/layout.tsx
@@ -45,7 +45,7 @@ export function Header({ configuration }: HeaderProps) {
   return (
     <div>
       <TitleContainer>
-        <div className="flex flex-col items-start gap-2 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col items-start gap-4 md:flex-row md:items-center md:justify-between">
           <div className="flex flex-col">
             <div className="flex flex-row items-center gap-2">
               <Title>{configuration.display_name}</Title>
@@ -66,8 +66,16 @@ export function Header({ configuration }: HeaderProps) {
             </div>
             <Status version={configuration.active_version} />
           </div>
-          <div className="flex flex-col gap-2 md:items-end">
-            <ActivationButtons configurationData={configuration} />
+          <div className="flex flex-col items-start gap-4 md:items-end">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center">
+              <VersionMenu
+                id={configuration.id}
+                currentVersion={configuration.version}
+                status={configuration.status}
+                versions={configuration.all_versions}
+              />
+              <ActivationButtons configurationData={configuration} />
+            </div>
             {configuration.active_version === configuration.version && (
               <SerializedContentButton configurationId={configuration.id} />
             )}
@@ -75,12 +83,6 @@ export function Header({ configuration }: HeaderProps) {
         </div>
       </TitleContainer>
       <NavigationContainer>
-        <VersionMenu
-          id={configuration.id}
-          currentVersion={configuration.version}
-          status={configuration.status}
-          versions={configuration.all_versions}
-        />
         <StepsContainer>
           <Steps configurationId={configuration.id} />
         </StepsContainer>


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR moves the configuration version selection menu from the nav bar to the header, left of the activation button. No new functionality has been added.

This PR wraps up the last piece of #1577.

## 🔗 Related Issue

Fixes #1577 

- #1577

## 📺 Demo

Viewing any inactive configuration
<img width="1596" height="1180" alt="image" src="https://github.com/user-attachments/assets/78362415-e86b-4667-8735-2a8c9354304e" />

Viewing the active configuration (link below will only display when running locally)
<img width="1598" height="1179" alt="image" src="https://github.com/user-attachments/assets/de2de4d8-813a-40f4-9ee6-45bf0bdd1cb3" />

## 🧪 How to test

1. Log in and navigate to the configuration detail page
2. You should see the version menu to the left of the activation button
3. The version menu should work as it did previously

- Automated tests have been updated