### PR TITLE
fix: remove try/except within `get_connection()`

### DIFF
--- a/refiner/app/db/pool.py
+++ b/refiner/app/db/pool.py
@@ -86,14 +86,8 @@ class AsyncDatabaseConnection:
         Raises:
             DatabaseConnectionError: If a connection cannot be retrieved from the pool.
         """
-        try:
-            async with self.pool.connection() as conn:
-                yield conn
-        except Exception as e:
-            raise DatabaseConnectionError(
-                message="Failed to get connection from pool",
-                details={"error": str(e)},
-            )
+        async with self.pool.connection() as conn:
+            yield conn
 
 
 def create_db(


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

Removes the try/except from within the `get_connection()` function. This is not very useful and tends to make it much more difficult to debug issues related to querying.

For example, if something in your query within a DB file is not quite right and you receive an exception it will currently look like this:
```sh
server-1      |     async with db.get_connection() as conn:
server-1      |                ~~~~~~~~~~~~~~~~~^^
server-1      |   File "/usr/local/lib/python3.14/contextlib.py", line 235, in __aexit__
server-1      |     await self.gen.athrow(value)
server-1      |   File "/app/app/db/pool.py", line 94, in get_connection
server-1      |     raise DatabaseConnectionError(
server-1      |     ...<2 lines>...
server-1      |     )
server-1      | app.core.exceptions.DatabaseConnectionError: Failed to get connection from pool
```

Removing the try/except will show you the actual issue directly instead of needing to hunt for it:
```sh
server-1      |   File "/usr/local/lib/python3.14/site-packages/psycopg/rows.py", line 162, in class_row__
server-1      |     return cls(**dict(zip(names, values)))
server-1      | TypeError: DbCodeSystem.__init__() got an unexpected keyword argument 'display'
```

## 🧪 How to test

An easy way to test this is to do something invalid within a query function. In my example above, I replaced a `DbCustomCode` type with a `DbCodeSystem`, which will cause a failure when we try to fetch data.

```python
async with conn.cursor(row_factory=class_row(DbCodeSystem)) as cur: # Should be `DbCustomCode`
    await cur.execute(query, params)
    row = await cur.fetchone()
```