### PR TITLE
WIP feat(server): apply code exclusions when projecting active.json

### DIFF
--- a/refiner/app/db/configurations/exclusions/db.py
+++ b/refiner/app/db/configurations/exclusions/db.py
@@ -1,0 +1,54 @@
+from collections import defaultdict
+from uuid import UUID
+
+from psycopg.rows import dict_row
+
+from app.db.pool import AsyncDatabaseConnection
+
+type CodeSystemKey = str
+type ExcludedCodesByCondition = dict[UUID, set[tuple[CodeSystemKey, str]]]
+
+
+async def get_code_exclusions_db(
+    configuration_id: UUID, db: AsyncDatabaseConnection
+) -> ExcludedCodesByCondition:
+    """
+    Fetches the codes a configuration has excluded, grouped by condition.
+
+    Exclusions are stored as `code_id` references, but the projection that
+    consumes them (`convert_config_to_storage_payload`) reads condition codes
+    from the `conditions` JSONB columns, which carry no code ID. Resolving to
+    `(system key, code)` here is what bridges the two representations; the
+    `codes` table's UNIQUE (system_id, code) makes that resolution lossless.
+
+    Args:
+        configuration_id (UUID): The configuration whose exclusions to fetch
+        db (AsyncDatabaseConnection): The async database connection
+
+    Returns:
+        ExcludedCodesByCondition: Excluded (system key, code) pairs keyed by
+            condition ID. Conditions with no exclusions are absent.
+    """
+
+    query = """
+    SELECT
+        e.condition_id,
+        s.key AS system_key,
+        c.code
+    FROM configurations_conditions_code_exclusions e
+    JOIN codes c ON c.id = e.code_id
+    JOIN systems s ON s.id = c.system_id
+    WHERE e.configuration_id = %s
+    """
+    params = (configuration_id,)
+
+    async with db.get_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(query, params)
+            rows = await cur.fetchall()
+
+    excluded: ExcludedCodesByCondition = defaultdict(set)
+    for row in rows:
+        excluded[row["condition_id"]].add((row["system_key"], row["code"]))
+
+    return dict(excluded)

--- a/refiner/app/services/configurations.py
+++ b/refiner/app/services/configurations.py
@@ -10,6 +10,7 @@ from app.db.code_systems.db import (
 )
 from app.db.conditions.db import get_condition_by_id_db, get_included_conditions_db
 from app.db.conditions.model import DbConditionCoding
+from app.db.configurations.exclusions.db import get_code_exclusions_db
 from app.db.configurations.model import (
     CURRENT_ACTIVE_CONFIG_SCHEMA_VERSION,
     ConfigurationStorageMetadata,
@@ -245,8 +246,18 @@ async def convert_config_to_storage_payload(
         included_conditions=configuration.included_conditions, db=db
     )
     systems_keys_to_index_by = await get_allowed_code_system_keys(db=db)
+    excluded_codes = await get_code_exclusions_db(
+        configuration_id=configuration.id, db=db
+    )
     # condition codes -> build both the flat set and per-system dicts
     for condition in conditions:
+        # exclusions are scoped to (configuration, condition), so they are applied
+        # here rather than to the merged dict below: this loop is the last point
+        # where a code's originating condition is still known, and it is the only
+        # loop custom codes never pass through -- so an exclusion can never strip a
+        # hand-added custom code that happens to share a (system, code) pair.
+        excluded_for_condition = excluded_codes.get(condition.id, set())
+
         # map each db code list to its target dict + OID
         code_system_map: dict[CodeSystemKey, list[DbConditionCoding]] = (
             index_condition_code_list_by_system(
@@ -270,6 +281,7 @@ async def convert_config_to_storage_payload(
                         )
                     )
                     for c in code_list
+                    if (key, c.code) not in excluded_for_condition
                 ]
             )
 

--- a/refiner/migrations/20260803202038_add_code_exclusions.sql
+++ b/refiner/migrations/20260803202038_add_code_exclusions.sql
@@ -1,0 +1,24 @@
+-- migrate:up
+
+CREATE TABLE configurations_conditions_code_exclusions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    configuration_id UUID NOT NULL,
+    condition_id UUID NOT NULL,
+    code_id UUID NOT NULL REFERENCES codes(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- ON DELETE CASCADE is required: removing a condition from a configuration
+    -- deletes the configurations_conditions row, and deleting a configuration
+    -- cascades to it. Without this, either path raises a ForeignKeyViolation
+    -- once the user has excluded any code from that condition.
+    FOREIGN KEY (configuration_id, condition_id)
+        REFERENCES configurations_conditions(configuration_id, condition_id)
+        ON DELETE CASCADE,
+
+    UNIQUE (configuration_id, condition_id, code_id)
+);
+
+
+-- migrate:down
+
+DROP TABLE configurations_conditions_code_exclusions;

--- a/refiner/tests/integration/test_code_exclusions.py
+++ b/refiner/tests/integration/test_code_exclusions.py
@@ -1,0 +1,115 @@
+import pytest
+from psycopg.rows import dict_row
+
+from app.db.configurations.db import get_configuration_by_id_db
+from app.db.configurations.exclusions.db import get_code_exclusions_db
+from app.services.configurations import convert_config_to_storage_payload
+
+
+async def _pick_condition_code(db_pool, condition_id, system_key: str):
+    """
+    Return one (code_id, code) the condition contributes in `system_key`.
+
+    Reads the normalized `codes` tables, while the projection under test reads
+    the `conditions` JSONB columns. Asserting the picked code shows up in the
+    projected payload is therefore also a check that the two representations
+    still agree.
+    """
+
+    async with db_pool.get_connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT c.id, c.code
+                FROM conditions_codes cc
+                JOIN codes c ON c.id = cc.code_id
+                JOIN systems s ON s.id = c.system_id
+                WHERE cc.condition_id = %s AND s.key = %s
+                ORDER BY c.code
+                LIMIT 1
+                """,
+                (condition_id, system_key),
+            )
+            row = await cur.fetchone()
+            assert row, f"condition {condition_id} contributes no {system_key} codes"
+            return row["id"], row["code"]
+
+
+async def _exclude(db_pool, configuration_id, condition_id, code_id):
+    async with db_pool.get_connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                INSERT INTO configurations_conditions_code_exclusions
+                    (configuration_id, condition_id, code_id)
+                VALUES (%s, %s, %s)
+                """,
+                (configuration_id, condition_id, code_id),
+            )
+
+
+def _codes_for_system(payload, system_key: str) -> set[str]:
+    return {c["code"] for c in payload.code_system_sets.get(system_key, [])}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestCodeExclusions:
+    async def test_excluded_code_is_dropped_from_the_projected_payload(
+        self,
+        create_config,
+        get_condition_id,
+        test_user_jurisdiction_id,
+        db_pool,
+    ):
+        condition_id = await get_condition_id("Ophthalmia Neonatorum")
+        config_id = (await create_config(condition_id))["id"]
+
+        configuration = await get_configuration_by_id_db(
+            id=config_id, jurisdiction_id=test_user_jurisdiction_id, db=db_pool
+        )
+        assert configuration
+
+        code_id, code = await _pick_condition_code(db_pool, condition_id, "snomed")
+
+        before = await convert_config_to_storage_payload(
+            configuration=configuration, db=db_pool
+        )
+        assert before
+        assert code in _codes_for_system(before, "snomed")
+
+        await _exclude(db_pool, config_id, condition_id, code_id)
+
+        after = await convert_config_to_storage_payload(
+            configuration=configuration, db=db_pool
+        )
+        assert after
+        assert code not in _codes_for_system(after, "snomed")
+
+        # nothing else moved: the exclusion is surgical, not a wholesale drop
+        assert _codes_for_system(before, "snomed") - {code} == _codes_for_system(
+            after, "snomed"
+        )
+        assert _codes_for_system(before, "loinc") == _codes_for_system(after, "loinc")
+
+    async def test_get_code_exclusions_groups_by_condition(
+        self,
+        create_config,
+        get_condition_id,
+        db_pool,
+    ):
+        # a distinct condition from the test above: a configuration is unique
+        # per condition, so reusing one returns 409
+        condition_id = await get_condition_id("Chlamydia trachomatis infection")
+        config_id = (await create_config(condition_id))["id"]
+
+        assert (
+            await get_code_exclusions_db(configuration_id=config_id, db=db_pool) == {}
+        )
+
+        code_id, code = await _pick_condition_code(db_pool, condition_id, "snomed")
+        await _exclude(db_pool, config_id, condition_id, code_id)
+
+        excluded = await get_code_exclusions_db(configuration_id=config_id, db=db_pool)
+
+        assert excluded == {condition_id: {("snomed", code)}}

--- a/refiner/tests/unit/helpers/configuration.py
+++ b/refiner/tests/unit/helpers/configuration.py
@@ -1,4 +1,5 @@
 import unittest
+from uuid import UUID
 
 from app.db.conditions.model import DbCondition
 from app.db.configurations.model import DbConfiguration
@@ -8,7 +9,9 @@ from tests.unit.conftest import create_mock_systems
 
 
 async def create_processed_config(
-    config: DbConfiguration, conditions: list[DbCondition]
+    config: DbConfiguration,
+    conditions: list[DbCondition],
+    excluded_codes: dict[UUID, set[tuple[str, str]]] | None = None,
 ):
     mock_systems = create_mock_systems()
     with (
@@ -19,6 +22,10 @@ async def create_processed_config(
         unittest.mock.patch(
             "app.services.configurations.get_id_to_code_system_dict_db",
             new=unittest.mock.AsyncMock(return_value={m.id: m for m in mock_systems}),
+        ),
+        unittest.mock.patch(
+            "app.services.configurations.get_code_exclusions_db",
+            new=unittest.mock.AsyncMock(return_value=excluded_codes or {}),
         ),
     ):
         storage_payload = await convert_config_to_storage_payload(

--- a/refiner/tests/unit/test_service_terminology.py
+++ b/refiner/tests/unit/test_service_terminology.py
@@ -135,3 +135,142 @@ class TestTerminologyService:
             config=config, conditions=[cond1, cond2]
         )
         assert processed.codes == {"DUP"}
+
+
+@pytest.mark.asyncio
+class TestCodeExclusions:
+    """
+    Exclusion ("de-selection") removes a condition-contributed code from the
+    want-set during projection, before `active.json` is built. Because
+    refinement is retention-by-inclusion, a code absent from the want-set
+    retains nothing -- so these tests assert on the projected want-set rather
+    than on refined XML.
+    """
+
+    async def test_excluded_code_is_absent_from_want_set(self):
+        condition = make_condition(
+            snomed_codes=[
+                make_db_condition_coding("KEEP", "Kept"),
+                make_db_condition_coding("DROP", "Excluded"),
+            ]
+        )
+        config = make_dbconfiguration()
+
+        processed = await create_processed_config(
+            config=config,
+            conditions=[condition],
+            excluded_codes={condition.id: {("snomed", "DROP")}},
+        )
+
+        assert processed.codes == {"KEEP"}
+
+    async def test_exclusion_is_scoped_to_its_condition(self):
+        """
+        Exclusions are keyed by (configuration, condition), but `active.json`
+        flattens every included condition into one want-set. So excluding a
+        code from one condition does NOT remove it when a second included
+        condition still contributes it -- the want-set is a union.
+
+        This is load-bearing: roughly half of all seeded codes appear in more
+        than one condition, so this is the common case, not an edge case.
+        """
+
+        cond1 = make_condition(snomed_codes=[make_db_condition_coding("SHARED", "One")])
+        cond2 = make_condition(snomed_codes=[make_db_condition_coding("SHARED", "Two")])
+        config = make_dbconfiguration()
+
+        processed = await create_processed_config(
+            config=config,
+            conditions=[cond1, cond2],
+            excluded_codes={cond1.id: {("snomed", "SHARED")}},
+        )
+
+        assert processed.codes == {"SHARED"}
+
+    async def test_exclusion_is_scoped_to_its_code_system(self):
+        condition = make_condition(
+            snomed_codes=[make_db_condition_coding("1234", "SNOMED 1234")],
+            loinc_codes=[make_db_condition_coding("1234", "LOINC 1234")],
+        )
+        config = make_dbconfiguration()
+
+        processed = await create_processed_config(
+            config=config,
+            conditions=[condition],
+            excluded_codes={condition.id: {("loinc", "1234")}},
+        )
+
+        maps = processed.code_system_sets.system_to_code_maps
+        assert "1234" in maps["snomed"]
+        assert "1234" not in maps["loinc"]
+
+    async def test_exclusion_never_strips_a_matching_custom_code(self, get_mock_system):
+        """
+        The anti-join runs inside the per-condition loop, which custom codes
+        never pass through. So a hand-added custom code survives even when it
+        collides with an excluded condition code on (system, code).
+
+        The code therefore stays in the want-set. That is correct -- the user
+        added it deliberately -- but it will read as a failed exclusion, so the
+        behavior is pinned here rather than left to chance.
+        """
+
+        loinc = get_mock_system("loinc")
+        condition = make_condition(
+            loinc_codes=[make_db_condition_coding("COLLIDE", "From condition")]
+        )
+        config_id = uuid4()
+        config = make_dbconfiguration(
+            id=config_id,
+            custom_codes=[
+                DbCustomCode(
+                    id="custom-1",
+                    code="COLLIDE",
+                    display="Hand added",
+                    system_id=loinc.id,
+                    created_at=datetime.now(),
+                    updated_at=datetime.now(),
+                    configuration_id=config_id,
+                )
+            ],
+        )
+
+        processed = await create_processed_config(
+            config=config,
+            conditions=[condition],
+            excluded_codes={condition.id: {("loinc", "COLLIDE")}},
+        )
+
+        assert processed.codes == {"COLLIDE"}
+        assert (
+            processed.code_system_sets.system_to_code_maps["loinc"]["COLLIDE"].display
+            == "Hand added"
+        )
+
+    async def test_no_exclusions_leaves_want_set_untouched(self):
+        condition = make_condition(
+            snomed_codes=[make_db_condition_coding("A", "A")],
+            loinc_codes=[make_db_condition_coding("B", "B")],
+        )
+        config = make_dbconfiguration()
+
+        with_none = await create_processed_config(
+            config=config, conditions=[condition], excluded_codes={}
+        )
+        baseline = await create_processed_config(config=config, conditions=[condition])
+
+        assert with_none.codes == baseline.codes == {"A", "B"}
+
+    async def test_exclusion_for_an_unrelated_condition_is_ignored(self):
+        condition = make_condition(
+            snomed_codes=[make_db_condition_coding("A", "A")],
+        )
+        config = make_dbconfiguration()
+
+        processed = await create_processed_config(
+            config=config,
+            conditions=[condition],
+            excluded_codes={uuid4(): {("snomed", "A")}},
+        )
+
+        assert processed.codes == {"A"}


### PR DESCRIPTION
# 🔀 PULL REQUEST

<!--
Use semantic commit message for PR title:

Format: <type>(<scope>): <subject>

<scope> is optional

feat: add hat wobble
│     │
│     └── Summary in present tense.
└── Type: chore, docs, feat, fix, refactor, style, or test.
-->

## 💡 Summary

  Server-side half of code exclusion: a code a jurisdiction has excluded from a
  code set no longer participates in refinement.

  Refinement is retention-by-inclusion — the engines keep entries whose codes are
  in the configured want-set. So excluding a code is subtraction from that
  want-set, not removal from XML. The anti-join runs in
  `convert_config_to_storage_payload`, inside the per-condition loop, so excluded
  codes never reach `active.json`.

  Nothing downstream changes: both matching engines, the plan builder, and the
  Lambda read the same `code_system_sets` they always have.

  Placement inside the condition loop is the whole design — it's the last point
  where a code's originating condition is known (so exclusions stay
  condition-scoped), and the only loop custom codes never pass through (so an
  exclusion can't strip a hand-added custom code sharing a `(system, code)` pair).

  Reads from `configurations_conditions_code_exclusions`, the table from #1633.
  **That migration is duplicated here so this branch is testable — drop it when
  #1633 merges.**

  ## 🔗 Related Issue

  Fixes #

  - #1587
  - #1296

  ## ✅ Acceptance Criteria

  From #1587 — this PR covers none of the UI criteria, only the refinement
  behavior they depend on:

  - [x] Excluded codes stop pulling entries into refined output
  - [x] Exclusions scoped to `(configuration, condition)` and to code system
  - [x] Custom codes unaffected by exclusions
  - [ ] Add "Status" column to table — #1633
  - [ ] Exclude & include icon for code set codes — #1633
  - [ ] Excluded code styling — #1633
  - [ ] Code exclusion/inclusion toast — #1633

  ## 🧪 How to test

  There's no write path yet (#1633 has the read only), so exclusions are created
  via SQL.

  1. `just dev up -d` and `just db refresh`
  2. `just server test tests/unit/test_service_terminology.py -v` — projection
     behavior, DB mocked
  3. `just server test tests/integration/test_code_exclusions.py -v` — real SQL
     against the real table
  4. `just server test-scenarios` — golden snapshots unchanged (this change is
     inert with no exclusions)

  To see it by hand: create a config, insert a row into
  `configurations_conditions_code_exclusions`, then activate and diff `active.json`
  — or use the simulator, which re-projects immediately without activating.

  ## ℹ️  Additional Information

  **Exclusions apply at activation.** `active.json` is rewritten on activate, so
  an exclusion doesn't affect refinement until the config is activated again. The
  simulator picks it up immediately.

  **Shared codes are a union.** Exclusions are per `(configuration, condition)`,
  but `active.json` flattens all included conditions into one want-set — so
  excluding a code from one code set leaves it active if another contributes it.
  This is not an edge case: **51.9% of seeded codes appear in more than one
  condition** (78,324 of 150,912; the most shared appear in ~146 conditions each).
  The engine behavior matches the schema and the UI's one-row-per-`(condition,
  code)` listing, but it likely needs a UI affordance. Worth a decision — see
  ADR 0014.

  **Bug found in #1633's migration:** the composite FK to
  `configurations_conditions` needs `ON DELETE CASCADE`. Without it, removing a
  condition from a configuration, or deleting a configuration, raises
  `ForeignKeyViolation` once anything is excluded. Fixed in the copy here; needs
  to land in #1633.

  Design and rationale: ADR 0014 (`docs/decisions/0014_2026-07-29_code-exclusion.md`,
  in #1617).
