### PR TITLE
chore: fix integration test config

### DIFF
--- a/refiner/tests/integration/conftest.py
+++ b/refiner/tests/integration/conftest.py
@@ -55,8 +55,11 @@ from scripts.validation.validate_document_xsd import build_schema, display_xsd_r
 
 get_app_config.cache_clear()
 get_auth_config.cache_clear()
-get_db_config.cache_clear()
 get_aws_config.cache_clear()
+get_db_config.cache_clear()
+
+config = get_db_config()
+
 
 # Session info
 TEST_SESSION_TOKEN = "test-token"
@@ -400,8 +403,8 @@ async def reset_db(db_pool):
 async def db_pool(setup):
     # setup as a dependency guarantees that the pool isn't created until migrations have run
     db = create_db(
-        db_url=get_db_config().DB_URL,
-        db_password=get_db_config().DB_PASSWORD,
+        db_url=config.DB_URL,
+        db_password=config.DB_PASSWORD,
         prepare_threshold=None,
     )
     await db.connect()


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

Fix to the integration test setup that seems to have broken when we refactored the env variables. It seems that calling the DB config via the cache breaks the creation of the DB pool connection. Moving things to the top of the module seems to work.

## 🔗 Related Issue

Fixes local integration test runs

## ✅ Acceptance Criteria

- Local runs of the integration test suite pass 

## 🧪 How to test
- Run the integration tests locally via pytest or just
- Notice all tests pass

## ℹ️ Additional Information
Any concerns with the way we're maintaining the env import?