### PR TITLE
chore: update e2e job to make use of Playwright cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,6 +125,7 @@ jobs:
 
       - name: Cache Playwright Browsers
         uses: actions/cache@v5
+        id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-browsers-${{ hashFiles('client/package-lock.json') }}
@@ -133,8 +134,14 @@ jobs:
             ${{ runner.os }}-playwright-
             ${{ runner.os }}-
 
-      - name: Install Playwright Browsers
+      - name: Install Playwright Browsers (with deps)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
+        working-directory: client
+
+      - name: Install Playwright Browsers (no deps)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install
         working-directory: client
 
       - name: Start Application

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,12 +136,12 @@ jobs:
 
       - name: Install Playwright Browsers (with deps)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
         working-directory: client
 
       - name: Install Playwright Browsers (no deps)
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install
+        run: npx playwright install chromium
         working-directory: client
 
       - name: Start Application


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

I noticed that the e2e job was downloading Playwright dependencies every time during a job run even though we have a cache step. This PR updates the following steps after the cache step to:

1. Download dependencies on no hit
2. Use cached dependencies on a hit

I've also limited the browsers that get installed to only `chromium` since that is all the project currently makes use of.

## 🧪 How to test

- Take a look at the job and see that the cache is working
