### PR TITLE
test: fix manage codes e2e test reliability

### DIFF
--- a/client/e2e/manage-codes-dev.spec.ts
+++ b/client/e2e/manage-codes-dev.spec.ts
@@ -66,9 +66,9 @@ test.describe('Codes management - search', () => {
     });
 
     const table = page.getByRole('table');
+    const tableRows = table.getByRole('row');
     await expect(table).toBeVisible();
-    const tableRowCount = await table.getByRole('row').count();
-    expect(tableRowCount).toBe(4); // include header
+    await expect(tableRows).toHaveCount(4); // include header
 
     await test.step('Enter search query', async () => {
       const searchBox = page.getByRole('searchbox', {
@@ -90,8 +90,7 @@ test.describe('Codes management - search', () => {
 
     await test.step('Check search results', async () => {
       await expect(table).toBeVisible();
-      const newRowCount = await table.getByRole('row').count();
-      expect(newRowCount).toBe(2); // custom code and header only
+      await expect(table.getByRole('row')).toHaveCount(2); // custom code and header only
     });
   });
 
@@ -164,6 +163,8 @@ test.describe('Codes management - search', () => {
     await test.step('Check table results', async () => {
       const table = page.getByRole('table');
       const tableRows = table.getByRole('row');
+
+      await expect(tableRows.first()).toBeVisible(); // make sure table is ready
       const rowCount = await tableRows.count();
 
       // start at 1 to skip header

--- a/client/e2e/manage-codes-dev.spec.ts
+++ b/client/e2e/manage-codes-dev.spec.ts
@@ -434,8 +434,7 @@ test.describe('Codes management - filters', () => {
       await page.keyboard.press('Escape');
       await expect(sourceFilterButton).toContainText('1 selected');
 
-      const newCount = await tableRows.count();
-      expect(newCount).toBe(2);
+      await expect(tableRows).toHaveCount(2);
     });
   });
 

--- a/client/e2e/manage-codes-dev.spec.ts
+++ b/client/e2e/manage-codes-dev.spec.ts
@@ -164,7 +164,7 @@ test.describe('Codes management - search', () => {
       const table = page.getByRole('table');
       const tableRows = table.getByRole('row');
 
-      await expect(tableRows.first()).toBeVisible(); // make sure table is ready
+      await expect(tableRows.nth(1)).toBeVisible(); // make sure table is ready
       const rowCount = await tableRows.count();
 
       // start at 1 to skip header
@@ -252,6 +252,7 @@ test.describe('Codes management - filters', () => {
     page,
     configurationsPage,
     configurationPage,
+    api,
   }) => {
     const condition = 'Anotia';
     await configurationsPage.createConfiguration(condition);
@@ -271,6 +272,9 @@ test.describe('Codes management - filters', () => {
         .hover();
       await page.getByLabel('Add Alpha-gal Syndrome').click();
       await page.getByRole('button', { name: 'Close drawer' }).click();
+      await expect(
+        page.getByRole('button', { name: '2 Condition code sets' })
+      ).toBeVisible();
     });
 
     const codeSystemFilterButton = page.getByTestId('code-system-button');
@@ -289,20 +293,40 @@ test.describe('Codes management - filters', () => {
     });
 
     await test.step('Select code system filter options', async () => {
+      const systems = await api.getSystems();
+      const cvxId = systems.find((s) => s.display_name === 'CVX')!.id;
+      const loincID = systems.find((s) => s.display_name === 'LOINC')!.id;
+
       await loincOption.click();
       await page.keyboard.press('Escape');
       await expect(codeSystemFilterButton).toContainText('1 selected');
+
+      await page.waitForResponse(
+        (res) =>
+          res.url().includes('/codes') &&
+          res.request().url().includes(`code_systems=${loincID}`) &&
+          res.status() === 200
+      );
 
       await codeSystemFilterButton.click();
       await expect(cvxOption).toBeVisible();
       await cvxOption.click();
       await page.keyboard.press('Escape');
       await expect(codeSystemFilterButton).toContainText('2 selected');
+
+      await page.waitForResponse(
+        (res) =>
+          res.url().includes('/codes') &&
+          res.request().url().includes(`code_systems=${loincID}`) &&
+          res.request().url().includes(`code_systems=${cvxId}`) &&
+          res.status() === 200
+      );
     });
 
     await test.step('Check that table results only has LOINC codes', async () => {
       // This condition has no CVX codes which is why only LOINC appear
       const tableRows = page.getByRole('table').getByRole('row');
+      await expect(tableRows.nth(1)).toBeVisible(); // make sure table is ready
       const rowCount = await tableRows.count();
       for (let i = 1; i < rowCount; i++) {
         const codeSystemCell = tableRows.nth(i).getByRole('cell').nth(2);

--- a/client/e2e/manage-codes-dev.spec.ts
+++ b/client/e2e/manage-codes-dev.spec.ts
@@ -101,14 +101,16 @@ test.describe('Codes management - search', () => {
     configurationPage,
   }) => {
     const condition = 'Amebiasis';
+    const systems = await api.getSystems();
+    const icd10Id = systems.find((s) => s.display_name === 'ICD-10')!.id;
     await test.step('Set up configuration', async () => {
       const config = await api.createConfiguration(condition);
-      const systems = await api.getSystems();
+
       await api.uploadCustomCodeCsv(config.id, [
         {
           code: 'A06.22',
           display: 'Amebic',
-          system_id: systems.find((s) => s.display_name === 'ICD-10')!.id,
+          system_id: icd10Id,
         },
       ]);
     });
@@ -137,7 +139,16 @@ test.describe('Codes management - search', () => {
         exact: false,
       });
 
+      const codeSystemResp = page.waitForResponse(
+        (res) =>
+          res.url().includes('/codes') &&
+          res.request().url().includes(`code_systems=${icd10Id}`) &&
+          res.status() === 200
+      );
+
       await icd10Option.click();
+      await codeSystemResp;
+
       await page.keyboard.press('Escape');
       await expect(codeSystemFilterButton).toContainText('1 selected');
     });
@@ -376,6 +387,9 @@ test.describe('Codes management - filters', () => {
         .hover();
       await page.getByLabel('Add Acanthamoeba').click();
       await page.getByRole('button', { name: 'Close drawer' }).click();
+      await expect(
+        page.getByRole('button', { name: '2 Condition code sets' })
+      ).toBeVisible();
     });
 
     await test.step('Check source filter', async () => {
@@ -406,6 +420,7 @@ test.describe('Codes management - filters', () => {
 
     await test.step('Check that table results only has Acanthamoeba codes', async () => {
       const tableRows = page.getByRole('table').getByRole('row');
+      await expect(tableRows.nth(1)).toBeVisible(); // make sure table is loaded
       const rowCount = await tableRows.count();
       for (let i = 1; i < rowCount; i++) {
         const sourceCell = tableRows.nth(i).getByRole('cell').nth(4);
@@ -513,6 +528,9 @@ test.describe('Codes management - filters', () => {
         .hover();
       await page.getByLabel(`Add ${associatedCondition}`).click();
       await page.getByRole('button', { name: 'Close drawer' }).click();
+      await expect(
+        page.getByRole('button', { name: '2 Condition code sets' })
+      ).toBeVisible();
     });
 
     await test.step('Configure code system filter', async () => {
@@ -549,15 +567,15 @@ test.describe('Codes management - filters', () => {
       await sourceFilterButton.click();
 
       await expect(sourceOptions).toBeVisible();
-      const sourceOptionCount = await sourceOptions.getByRole('option').count();
-      expect(sourceOptionCount).toBe(4); // both CGs + custom code + clear selection
+      await expect(sourceOptions.getByRole('option')).toHaveCount(4); // both CGs + custom code + clear selection
 
       // use all 3 options
-      const optionCountExcludingClearSelectionButton = sourceOptionCount - 1;
+      const optionCountExcludingClearSelectionButton = 3;
       for (let i = 0; i < optionCountExcludingClearSelectionButton; i++) {
         const option = sourceOptions.getByRole('option').nth(i);
         await expect(option).toBeVisible();
         await option.click();
+        await expect(option).toHaveAttribute('aria-selected', 'true');
       }
       await page.keyboard.press('Escape');
       await expect(sourceFilterButton).toHaveText('3 selected');
@@ -576,6 +594,7 @@ test.describe('Codes management - filters', () => {
       await expect(statusOptions).toBeVisible();
       await expect(includedOption).toBeVisible();
       await includedOption.click();
+      await expect(includedOption).toHaveAttribute('aria-selected', 'true');
 
       await page.keyboard.press('Escape');
       await expect(statusFilterButton).toHaveText('1 selected');

--- a/client/e2e/manage-codes-dev.spec.ts
+++ b/client/e2e/manage-codes-dev.spec.ts
@@ -77,15 +77,16 @@ test.describe('Codes management - search', () => {
       });
 
       await expect(searchBox).toBeVisible();
-      await searchBox.fill('mock custom');
 
       // wait for response so test doesn't fail waiting for debounce
-      await page.waitForResponse(
+      const searchResp = page.waitForResponse(
         (res) =>
           res.url().includes('/codes') &&
           res.request().url().includes('search=mock+custom') &&
           res.status() === 200
       );
+      await searchBox.fill('mock custom');
+      await searchResp;
     });
 
     await test.step('Check search results', async () => {
@@ -149,15 +150,16 @@ test.describe('Codes management - search', () => {
       });
 
       await expect(searchBox).toBeVisible();
-      await searchBox.fill(searchText);
 
       // wait for response so test doesn't fail waiting for debounce
-      await page.waitForResponse(
+      const searchResp = page.waitForResponse(
         (res) =>
           res.url().includes('/codes') &&
           res.request().url().includes(`search=${searchText}`) &&
           res.status() === 200
       );
+      await searchBox.fill(searchText);
+      await searchResp;
     });
 
     await test.step('Check table results', async () => {
@@ -297,30 +299,35 @@ test.describe('Codes management - filters', () => {
       const cvxId = systems.find((s) => s.display_name === 'CVX')!.id;
       const loincID = systems.find((s) => s.display_name === 'LOINC')!.id;
 
-      await loincOption.click();
-      await page.keyboard.press('Escape');
-      await expect(codeSystemFilterButton).toContainText('1 selected');
-
-      await page.waitForResponse(
+      const loincFilterResponse = page.waitForResponse(
         (res) =>
           res.url().includes('/codes') &&
           res.request().url().includes(`code_systems=${loincID}`) &&
           res.status() === 200
       );
 
-      await codeSystemFilterButton.click();
-      await expect(cvxOption).toBeVisible();
-      await cvxOption.click();
-      await page.keyboard.press('Escape');
-      await expect(codeSystemFilterButton).toContainText('2 selected');
+      await loincOption.click();
+      await loincFilterResponse;
 
-      await page.waitForResponse(
+      await page.keyboard.press('Escape');
+      await expect(codeSystemFilterButton).toContainText('1 selected');
+
+      const cvxFilterResponse = page.waitForResponse(
         (res) =>
           res.url().includes('/codes') &&
           res.request().url().includes(`code_systems=${loincID}`) &&
           res.request().url().includes(`code_systems=${cvxId}`) &&
           res.status() === 200
       );
+
+      await codeSystemFilterButton.click();
+      await expect(cvxOption).toBeVisible();
+
+      await cvxOption.click();
+      await cvxFilterResponse;
+
+      await page.keyboard.press('Escape');
+      await expect(codeSystemFilterButton).toContainText('2 selected');
     });
 
     await test.step('Check that table results only has LOINC codes', async () => {

--- a/client/e2e/manage-codes-dev.spec.ts
+++ b/client/e2e/manage-codes-dev.spec.ts
@@ -554,6 +554,7 @@ test.describe('Codes management - filters', () => {
       const table = page.getByRole('table');
       const tableRows = table.getByRole('row');
 
+      // this includes the header row
       await expect(tableRows).toHaveCount(5);
 
       const sourceCellNumber = 4;

--- a/client/e2e/manage-codes-dev.spec.ts
+++ b/client/e2e/manage-codes-dev.spec.ts
@@ -408,6 +408,7 @@ test.describe('Codes management - filters', () => {
       const statusCell = tableRows.nth(1).getByRole('cell').last();
       const statusSwitch = statusCell.getByRole('switch');
       await statusSwitch.click();
+      await expect(statusCell).toContainText('Excluded');
     });
 
     const includedOption = sourceOptions.getByRole('option', {

--- a/client/e2e/manage-codes-dev.spec.ts
+++ b/client/e2e/manage-codes-dev.spec.ts
@@ -401,8 +401,7 @@ test.describe('Codes management - filters', () => {
 
     await test.step('Check the page on load', async () => {
       await expect(table).toBeVisible();
-      const initialCount = await tableRows.count(); // this includes the header row
-      expect(initialCount).toBe(3);
+      await expect(tableRows).toHaveCount(3);
     });
 
     await test.step('Exclude a code', async () => {

--- a/client/e2e/manage-codes-dev.spec.ts
+++ b/client/e2e/manage-codes-dev.spec.ts
@@ -554,28 +554,23 @@ test.describe('Codes management - filters', () => {
       const table = page.getByRole('table');
       const tableRows = table.getByRole('row');
 
-      // this includes the header row
       await expect(tableRows).toHaveCount(5);
 
-      // skip header row
-      const rowOne = tableRows.nth(1);
-      const rowTwo = tableRows.nth(2);
-      const rowThree = tableRows.nth(3);
-      const rowFour = tableRows.nth(4);
-
       const sourceCellNumber = 4;
-      await expect(
-        rowOne.getByRole('cell').nth(sourceCellNumber)
-      ).toContainText('Custom code');
-      await expect(
-        rowTwo.getByRole('cell').nth(sourceCellNumber)
-      ).toContainText(`${associatedCondition} CG`);
-      await expect(
-        rowThree.getByRole('cell').nth(sourceCellNumber)
-      ).toContainText(`${associatedCondition} CG`);
-      await expect(
-        rowFour.getByRole('cell').nth(sourceCellNumber)
-      ).toContainText('Anotia CG');
+      const sourceCells = tableRows
+        .filter({ hasNot: page.getByRole('columnheader') })
+        .locator(`td:nth-child(${sourceCellNumber + 1})`);
+
+      const texts = await sourceCells.allTextContents();
+
+      expect(texts.some((t) => t.includes('Custom code'))).toBe(true);
+      expect(texts.some((t) => t.includes(`${associatedCondition} CG`))).toBe(
+        true
+      );
+      expect(texts.some((t) => t.includes('Anotia CG'))).toBe(true);
+      expect(
+        texts.filter((t) => t.includes(`${associatedCondition} CG`))
+      ).toHaveLength(2);
     });
   });
 


### PR DESCRIPTION
# 🔀 PULL REQUEST

## 💡 Summary

This PR updates the manage codes e2e tests to improve their reliability in the pipeline. We were noticing some issues related to timing and network requests.

- Use `toHaveCount` instead of `count()` and `toBe`
- Fix the way we wait for network requests
- Improve test by not checking specific row order

## 🧪 How to test

- Tests should be passing locally and in the pipeline